### PR TITLE
test: 100% coverage for t3 + adx + natr + trix + coppock

### DIFF
--- a/crates/wickra-core/src/indicators/adx.rs
+++ b/crates/wickra-core/src/indicators/adx.rs
@@ -269,6 +269,37 @@ mod tests {
         assert!(Adx::new(0).is_err());
     }
 
+    /// Cover the const accessor `period` (lines 89-91) and the Indicator-impl
+    /// `warmup_period` (199-201) + `name` (207-209). None of the trend tests
+    /// inspect these metadata methods.
+    #[test]
+    fn accessors_and_metadata() {
+        let adx = Adx::new(14).unwrap();
+        assert_eq!(adx.period(), 14);
+        assert_eq!(adx.warmup_period(), 28);
+        assert_eq!(adx.name(), "ADX");
+    }
+
+    /// Cover the `tr_v == 0.0` defensive branches in `update` (lines 142,
+    /// 147) — feeding a stream of perfectly flat candles (H == L == close
+    /// every bar) gives true-range 0 each step, so the smoothed `tr_smooth`
+    /// stays at 0.0 and the `plus_di` / `minus_di` divisions would otherwise
+    /// blow up. The indicator must emit zeros (DX denominator is also 0).
+    #[test]
+    fn zero_true_range_yields_zero_di_and_zero_adx() {
+        let candles: Vec<Candle> = (0..30).map(|_| c(10.0, 10.0, 10.0)).collect();
+        let mut adx = Adx::new(5).unwrap();
+        let last = adx
+            .batch(&candles)
+            .into_iter()
+            .flatten()
+            .last()
+            .expect("ADX emits after 2 * period candles");
+        assert_eq!(last.plus_di, 0.0);
+        assert_eq!(last.minus_di, 0.0);
+        assert_eq!(last.adx, 0.0);
+    }
+
     #[test]
     fn batch_equals_streaming() {
         let candles: Vec<Candle> = (0..60)

--- a/crates/wickra-core/src/indicators/coppock.rs
+++ b/crates/wickra-core/src/indicators/coppock.rs
@@ -143,6 +143,23 @@ mod tests {
         assert!(matches!(Coppock::new(14, 11, 0), Err(Error::PeriodZero)));
     }
 
+    /// Cover the const accessors `periods` / `value` (lines 68-75) and the
+    /// Indicator-impl `name` body (128-130). Existing tests inspect numeric
+    /// output and `warmup_period` but never query the configured periods,
+    /// the current cached value, or the indicator name.
+    #[test]
+    fn accessors_and_metadata() {
+        let mut c = Coppock::new(14, 11, 10).unwrap();
+        assert_eq!(c.periods(), (14, 11, 10));
+        assert_eq!(c.name(), "Coppock");
+        assert_eq!(c.value(), None);
+        // Drive past warmup so value() flips to Some.
+        for i in 1..=u32::try_from(c.warmup_period()).unwrap() {
+            c.update(100.0 + f64::from(i));
+        }
+        assert!(c.value().is_some());
+    }
+
     #[test]
     fn first_emission_at_warmup_period() {
         let mut c = Coppock::new(6, 4, 3).unwrap();
@@ -176,8 +193,7 @@ mod tests {
             }
             assert!(
                 out[warmup - 1].is_some(),
-                "Coppock({long}, {short}, {wma}): warmup_period() = {warmup} but index {} is None",
-                warmup - 1,
+                "Coppock({long}, {short}, {wma}): warmup_period() = {warmup} but the warmup index is None",
             );
         }
     }

--- a/crates/wickra-core/src/indicators/natr.rs
+++ b/crates/wickra-core/src/indicators/natr.rs
@@ -121,6 +121,39 @@ mod tests {
         assert_eq!(natr.warmup_period(), 14);
     }
 
+    /// Cover the const accessors `period` / `value` (lines 59-66) and the
+    /// Indicator-impl `name` body (98-100). `warmup_period` is covered
+    /// already by `warmup_period_matches_atr`.
+    #[test]
+    fn accessors_and_metadata() {
+        let mut natr = Natr::new(14).unwrap();
+        assert_eq!(natr.period(), 14);
+        assert_eq!(natr.name(), "NATR");
+        assert_eq!(natr.value(), None);
+        let candles: Vec<Candle> = (0..14)
+            .map(|i| candle(100.0, 102.0, 98.0, 101.0, i))
+            .collect();
+        for c in &candles {
+            natr.update(*c);
+        }
+        assert!(natr.value().is_some());
+    }
+
+    /// Cover the `candle.close == 0.0` defensive branch (line 77). All
+    /// other tests feed candles with close ≈ 100, so the zero-close
+    /// fallback never fired. Feed an all-zero candle series — the Candle
+    /// validator accepts open == high == low == close == 0 with positive
+    /// volume, and ATR is 0 each bar, so the indicator must emit exactly
+    /// 0.0 rather than computing 100 * 0 / 0 = NaN.
+    #[test]
+    fn zero_close_yields_zero_natr() {
+        let candles: Vec<Candle> = (0..15).map(|i| candle(0.0, 0.0, 0.0, 0.0, i)).collect();
+        let mut natr = Natr::new(5).unwrap();
+        let out = natr.batch(&candles);
+        let last = out.into_iter().flatten().last().expect("emits");
+        assert_eq!(last, 0.0);
+    }
+
     #[test]
     fn natr_is_atr_over_close_as_percent() {
         // NATR must equal 100 * ATR / close, bar for bar.
@@ -133,13 +166,11 @@ mod tests {
         let natr_out = Natr::new(14).unwrap().batch(&candles);
         let atr_out = Atr::new(14).unwrap().batch(&candles);
         for (i, (n, a)) in natr_out.iter().zip(atr_out.iter()).enumerate() {
-            match (n, a) {
-                (Some(nv), Some(av)) => {
-                    let want = 100.0 * av / candles[i].close;
-                    assert_relative_eq!(*nv, want, epsilon = 1e-9);
-                }
-                (None, None) => {}
-                _ => panic!("warmup mismatch at {i}"),
+            // Same warmup period — emission shape must agree at every index.
+            assert_eq!(n.is_some(), a.is_some(), "warmup mismatch at index {i}");
+            if let (Some(nv), Some(av)) = (n, a) {
+                let want = 100.0 * av / candles[i].close;
+                assert_relative_eq!(*nv, want, epsilon = 1e-9);
             }
         }
     }

--- a/crates/wickra-core/src/indicators/t3.rs
+++ b/crates/wickra-core/src/indicators/t3.rs
@@ -161,6 +161,23 @@ mod tests {
         assert!(matches!(T3::new(0, 0.7), Err(Error::PeriodZero)));
     }
 
+    /// Cover the const accessors `period` / `volume_factor` / `value` and
+    /// the Indicator-impl `name` (lines 95-107, 148-150). Existing tests
+    /// query `warmup_period` (covered by `first_emission_at_warmup_period`)
+    /// but never inspect period, v, value, or name.
+    #[test]
+    fn accessors_and_metadata() {
+        let mut t3 = T3::new(5, 0.7).unwrap();
+        assert_eq!(t3.period(), 5);
+        assert_relative_eq!(t3.volume_factor(), 0.7, epsilon = 1e-12);
+        assert_eq!(t3.name(), "T3");
+        assert_eq!(t3.value(), None);
+        for _ in 0..t3.warmup_period() {
+            t3.update(50.0);
+        }
+        assert!(t3.value().is_some());
+    }
+
     #[test]
     fn new_rejects_out_of_range_volume_factor() {
         assert!(matches!(T3::new(5, -0.1), Err(Error::InvalidPeriod { .. })));

--- a/crates/wickra-core/src/indicators/trix.rs
+++ b/crates/wickra-core/src/indicators/trix.rs
@@ -141,4 +141,30 @@ mod tests {
     fn rejects_zero_period() {
         assert!(Trix::new(0).is_err());
     }
+
+    /// Cover the const accessor `period` (47-49) and the Indicator-impl
+    /// `warmup_period` (84-87) + `name` (93-95). Existing tests never
+    /// inspect these metadata methods.
+    #[test]
+    fn accessors_and_metadata() {
+        let trix = Trix::new(5).unwrap();
+        assert_eq!(trix.period(), 5);
+        // Triple EMA seeds at 3*5-2 = 13; +1 for the rate-of-change pair = 14.
+        assert_eq!(trix.warmup_period(), 14);
+        assert_eq!(trix.name(), "TRIX");
+    }
+
+    /// Cover the `Some(_)` match arm at lines 66-68 — the degenerate path
+    /// where the previous triple-EMA value is exactly 0.0 (which would
+    /// otherwise divide by zero on the percent-rate formula). A series of
+    /// all-zero inputs collapses every EMA stage to 0.0, so once the
+    /// indicator warms up `prev_tr` is `Some(0.0)` and every subsequent
+    /// emission must take the fallback branch and return 0.0.
+    #[test]
+    fn zero_input_series_yields_zero_trix() {
+        let mut trix = Trix::new(3).unwrap();
+        let out = trix.batch(&[0.0_f64; 20]);
+        let last = out.into_iter().flatten().last().expect("emits");
+        assert_eq!(last, 0.0);
+    }
 }


### PR DESCRIPTION
Batch 1 of the per-file 100%-coverage push. Each commit covers one file's Codecov-flagged lines.

| File | Before | Misses |
|---|---|---|
| indicators/t3.rs | 91.48% | 12 |
| indicators/adx.rs | 94.17% | 11 |
| indicators/natr.rs | 87.64% | 11 |
| indicators/trix.rs | 84.05% | 11 |
| indicators/coppock.rs | 91.07% | 10 |

Each commit message explains the missed lines and the test(s) added. No production-code behaviour changes; only new tests + a few test-only refactors (dead panic arms / multi-line asserts with cold-path expression args).