### PR TITLE
test: 100% coverage for pmo + ppo + roc + ulcer_index + williams_r

### DIFF
--- a/crates/wickra-core/src/indicators/pmo.rs
+++ b/crates/wickra-core/src/indicators/pmo.rs
@@ -150,6 +150,37 @@ mod tests {
         assert!(matches!(Pmo::new(35, 1), Err(Error::InvalidPeriod { .. })));
     }
 
+    /// Cover the const accessors `periods` / `value` (lines 76-83) and the
+    /// Indicator-impl `name` body (130-132). `warmup_period` is already
+    /// covered by `first_emission_at_second_update`.
+    #[test]
+    fn accessors_and_metadata() {
+        let mut pmo = Pmo::new(35, 20).unwrap();
+        assert_eq!(pmo.periods(), (35, 20));
+        assert_eq!(pmo.name(), "PMO");
+        assert_eq!(pmo.value(), None);
+        pmo.update(100.0);
+        pmo.update(101.0);
+        assert!(pmo.value().is_some());
+    }
+
+    /// Cover the `prev == 0.0` defensive branch (line 103). The PMO ROC
+    /// divides by the previous price; existing tests use prices ≈ 100, so
+    /// the divide-by-zero guard never fired. Feed a single zero price
+    /// followed by a positive price and assert the first emitted PMO is
+    /// the flat-momentum value (the wrapping `customEMA` of `0.0` is 0.0
+    /// regardless of smoothing factor on its first input).
+    #[test]
+    fn zero_previous_price_treats_roc_as_flat() {
+        let mut pmo = Pmo::new(2, 2).unwrap();
+        // Seed prev_price = 0.
+        assert_eq!(pmo.update(0.0), None);
+        // Next bar: prev == 0 hits the fallback returning roc = 0.0; the
+        // doubly-smoothed PMO seeds at 0.0 (10 * 0 = 0 through both EMAs).
+        let out = pmo.update(50.0).expect("emits");
+        assert_eq!(out, 0.0);
+    }
+
     #[test]
     fn first_emission_at_second_update() {
         let mut pmo = Pmo::new(35, 20).unwrap();

--- a/crates/wickra-core/src/indicators/ppo.rs
+++ b/crates/wickra-core/src/indicators/ppo.rs
@@ -142,6 +142,34 @@ mod tests {
         assert!(matches!(Ppo::new(12, 12), Err(Error::InvalidPeriod { .. })));
     }
 
+    /// Cover the const accessors `periods` / `value` (lines 71-78) and the
+    /// Indicator-impl `name` body (122-124). `warmup_period` is already
+    /// covered by `first_emission_at_warmup_period`.
+    #[test]
+    fn accessors_and_metadata() {
+        let mut ppo = Ppo::new(12, 26).unwrap();
+        assert_eq!(ppo.periods(), (12, 26));
+        assert_eq!(ppo.name(), "PPO");
+        assert_eq!(ppo.value(), None);
+        for i in 1..=26 {
+            ppo.update(f64::from(i));
+        }
+        assert!(ppo.value().is_some());
+    }
+
+    /// Cover the `s == 0.0` defensive branch (line 96). PPO divides by
+    /// the slow EMA; existing tests use prices ≈ 100, so the slow EMA
+    /// is never 0. Feed a stream of zeros — both EMAs converge to 0.0
+    /// and the indicator must emit exactly 0.0 (flat-momentum fallback)
+    /// rather than NaN.
+    #[test]
+    fn zero_slow_ema_yields_zero_ppo() {
+        let mut ppo = Ppo::new(3, 6).unwrap();
+        let out = ppo.batch(&[0.0_f64; 20]);
+        let last = out.into_iter().flatten().last().expect("emits");
+        assert_eq!(last, 0.0);
+    }
+
     #[test]
     fn first_emission_at_warmup_period() {
         let mut ppo = Ppo::new(3, 6).unwrap();

--- a/crates/wickra-core/src/indicators/roc.rs
+++ b/crates/wickra-core/src/indicators/roc.rs
@@ -141,6 +141,30 @@ mod tests {
         assert!(Roc::new(0).is_err());
     }
 
+    /// Cover the const accessor `period` (47-49) and the Indicator-impl
+    /// `warmup_period` (83-85) + `name` (91-93). Existing tests never
+    /// inspect these metadata methods.
+    #[test]
+    fn accessors_and_metadata() {
+        let roc = Roc::new(5).unwrap();
+        assert_eq!(roc.period(), 5);
+        assert_eq!(roc.warmup_period(), 6);
+        assert_eq!(roc.name(), "ROC");
+    }
+
+    /// Cover the `prev == 0.0` defensive branch (line 70). All existing
+    /// tests use prices ≥ 1.0, so the divide-by-zero guard was never
+    /// triggered. Feed a leading zero followed by `period` more values
+    /// so the front of the window is exactly 0.0, then assert the next
+    /// emission is the flat-momentum fallback 0.0 (not NaN).
+    #[test]
+    fn zero_previous_price_yields_zero_roc() {
+        let mut roc = Roc::new(3).unwrap();
+        let out = roc.batch(&[0.0, 5.0, 7.0, 9.0]);
+        let v = out[3].expect("ready after period + 1 inputs");
+        assert_eq!(v, 0.0);
+    }
+
     #[test]
     fn ignores_non_finite_input() {
         let mut roc = Roc::new(3).unwrap();

--- a/crates/wickra-core/src/indicators/ulcer_index.rs
+++ b/crates/wickra-core/src/indicators/ulcer_index.rs
@@ -175,6 +175,35 @@ mod tests {
         assert!(matches!(UlcerIndex::new(0), Err(Error::PeriodZero)));
     }
 
+    /// Cover the const accessors `period` / `value` (lines 77-85) and the
+    /// Indicator-impl `name` body (162-164). `warmup_period` is covered
+    /// already by `reference_values`.
+    #[test]
+    fn accessors_and_metadata() {
+        let mut ui = UlcerIndex::new(14).unwrap();
+        assert_eq!(ui.period(), 14);
+        assert_eq!(ui.name(), "UlcerIndex");
+        assert_eq!(ui.value(), None);
+        // Drive past warmup so value() flips to Some.
+        for i in 0..ui.warmup_period() {
+            ui.update(100.0 + (i as f64).sin() * 5.0);
+        }
+        assert!(ui.value().is_some());
+    }
+
+    /// Cover the `max_price == 0.0` defensive branch (line 123). All
+    /// other tests use prices > 0, so the trailing-max divisor is always
+    /// positive. Feed a stream of zeros — the trailing max is exactly
+    /// 0.0 and the drawdown computation would otherwise hit a 0/0 NaN.
+    /// The indicator must emit exactly 0.0 (drawdown is 0% by convention).
+    #[test]
+    fn zero_max_price_yields_zero_drawdown() {
+        let mut ui = UlcerIndex::new(3).unwrap();
+        let out = ui.batch(&[0.0_f64; 10]);
+        let last = out.into_iter().flatten().last().expect("emits");
+        assert_eq!(last, 0.0);
+    }
+
     #[test]
     fn reference_values() {
         // UlcerIndex(2): warmup = 3.

--- a/crates/wickra-core/src/indicators/williams_r.rs
+++ b/crates/wickra-core/src/indicators/williams_r.rs
@@ -155,6 +155,35 @@ mod tests {
         assert!(WilliamsR::new(0).is_err());
     }
 
+    /// Cover the const accessor `period` (49-51) and the Indicator-impl
+    /// `warmup_period` (87-89) + `name` (95-97). Existing tests never
+    /// inspect these metadata methods.
+    #[test]
+    fn accessors_and_metadata() {
+        let w = WilliamsR::new(14).unwrap();
+        assert_eq!(w.period(), 14);
+        assert_eq!(w.warmup_period(), 14);
+        assert_eq!(w.name(), "WilliamsR");
+    }
+
+    /// Cover the `range == 0.0` defensive branch (line 78). All other
+    /// tests use H != L candles so the lookback range is always positive.
+    /// Feed a stream of perfectly flat candles (H == L == close) — the
+    /// lookback hi/lo coincide and the divide-by-zero guard fires,
+    /// returning the neutral mid-range value -50.0.
+    #[test]
+    fn zero_range_yields_minus_fifty() {
+        let candles: Vec<Candle> = (0..5).map(|_| c(10.0, 10.0, 10.0)).collect();
+        let mut w = WilliamsR::new(3).unwrap();
+        let last = w
+            .batch(&candles)
+            .into_iter()
+            .flatten()
+            .last()
+            .expect("emits");
+        assert_eq!(last, -50.0);
+    }
+
     #[test]
     fn reset_clears_state() {
         let candles: Vec<Candle> = (0..20)


### PR DESCRIPTION
Batch 2 of the per-file 100%-coverage push. Each commit covers one file's Codecov-flagged lines.

| File | Before | Misses |
|---|---|---|
| indicators/pmo.rs | 90.56% | 10 |
| indicators/ppo.rs | 90.29% | 10 |
| indicators/roc.rs | 87.80% | 10 |
| indicators/ulcer_index.rs | 93.86% | 10 |
| indicators/williams_r.rs | 89.79% | 10 |

Per file: accessors/metadata test for the never-queried getters, plus one targeted test that hits the previously-unreachable zero-divisor defensive branch (zero prev price / zero slow EMA / zero trailing max / zero range). No production-code behaviour change.