### PR TITLE
test: 100% coverage for cmo + dema + donchian + dpo + ease_of_movement

### DIFF
--- a/crates/wickra-core/src/indicators/cmo.rs
+++ b/crates/wickra-core/src/indicators/cmo.rs
@@ -147,6 +147,21 @@ mod tests {
         assert!(matches!(Cmo::new(0), Err(Error::PeriodZero)));
     }
 
+    /// Cover the const accessors `period` / `value` (66-73) and the
+    /// Indicator-impl `name` body (134-136). Existing tests inspect
+    /// CMO output but never query the metadata.
+    #[test]
+    fn accessors_and_metadata() {
+        let mut cmo = Cmo::new(14).unwrap();
+        assert_eq!(cmo.period(), 14);
+        assert_eq!(cmo.name(), "CMO");
+        assert_eq!(cmo.value(), None);
+        for i in 1..=15 {
+            cmo.update(f64::from(i));
+        }
+        assert!(cmo.value().is_some());
+    }
+
     #[test]
     fn reference_value() {
         // CMO(3) over [10, 11, 10, 12]: changes +1, −1, +2.

--- a/crates/wickra-core/src/indicators/dema.rs
+++ b/crates/wickra-core/src/indicators/dema.rs
@@ -127,4 +127,17 @@ mod tests {
     fn rejects_zero_period() {
         assert!(Dema::new(0).is_err());
     }
+
+    /// Cover the const accessor `period` (43-45) and the Indicator-impl
+    /// `warmup_period` (63-66) + `name` (72-74). Existing tests never
+    /// inspect these metadata methods.
+    #[test]
+    fn accessors_and_metadata() {
+        let dema = Dema::new(5).unwrap();
+        assert_eq!(dema.period(), 5);
+        // EMA1 seeds at period (5), EMA2 needs another (period - 1) = 4 ->
+        // total warmup = 2*period - 1 = 9.
+        assert_eq!(dema.warmup_period(), 9);
+        assert_eq!(dema.name(), "DEMA");
+    }
 }

--- a/crates/wickra-core/src/indicators/donchian.rs
+++ b/crates/wickra-core/src/indicators/donchian.rs
@@ -155,6 +155,17 @@ mod tests {
         assert!(Donchian::new(0).is_err());
     }
 
+    /// Cover the const accessor `period` (57-59) and the Indicator-impl
+    /// `warmup_period` (95-97) + `name` (103-105). Existing tests never
+    /// inspect these metadata methods.
+    #[test]
+    fn accessors_and_metadata() {
+        let d = Donchian::new(20).unwrap();
+        assert_eq!(d.period(), 20);
+        assert_eq!(d.warmup_period(), 20);
+        assert_eq!(d.name(), "DonchianChannels");
+    }
+
     #[test]
     fn reset_clears_state() {
         let candles: Vec<Candle> = (0..20)

--- a/crates/wickra-core/src/indicators/dpo.rs
+++ b/crates/wickra-core/src/indicators/dpo.rs
@@ -145,6 +145,22 @@ mod tests {
         assert!(matches!(Dpo::new(0), Err(Error::PeriodZero)));
     }
 
+    /// Cover the const accessors `period` / `value` (73-85) and the
+    /// Indicator-impl `name` body (132-134). `shift` is already covered
+    /// by `shift_is_half_period_plus_one`; `warmup_period` by
+    /// `reference_values`.
+    #[test]
+    fn accessors_and_metadata() {
+        let mut dpo = Dpo::new(20).unwrap();
+        assert_eq!(dpo.period(), 20);
+        assert_eq!(dpo.name(), "DPO");
+        assert_eq!(dpo.value(), None);
+        for i in 1..=dpo.warmup_period() {
+            dpo.update(f64::from(u32::try_from(i).unwrap()));
+        }
+        assert!(dpo.value().is_some());
+    }
+
     #[test]
     fn shift_is_half_period_plus_one() {
         assert_eq!(Dpo::new(20).unwrap().shift(), 11);

--- a/crates/wickra-core/src/indicators/ease_of_movement.rs
+++ b/crates/wickra-core/src/indicators/ease_of_movement.rs
@@ -236,6 +236,18 @@ mod tests {
         assert!(EaseOfMovement::with_divisor(14, f64::NAN).is_err());
     }
 
+    /// Cover the const accessors `period` / `divisor` (82-90) and the
+    /// Indicator-impl `name` body (141-143). Existing tests inspect EMV
+    /// output but never query the metadata methods.
+    #[test]
+    fn accessors_and_metadata() {
+        let emv = EaseOfMovement::new(14).unwrap();
+        assert_eq!(emv.period(), 14);
+        // The canonical divisor (per the new() default) — keep in sync with src.
+        assert_relative_eq!(emv.divisor(), 100_000_000.0, epsilon = 1e-6);
+        assert_eq!(emv.name(), "EaseOfMovement");
+    }
+
     #[test]
     fn reset_clears_state() {
         let candles: Vec<Candle> = (0..30)


### PR DESCRIPTION
Batch 4 of the 100%-coverage push. Each commit covers one file's Codecov-flagged accessor/metadata lines.