### PR TITLE
test: 100% coverage for ema + historical_volatility + kama + linreg_angle + mass_index

### DIFF
--- a/crates/wickra-core/src/indicators/ema.rs
+++ b/crates/wickra-core/src/indicators/ema.rs
@@ -165,6 +165,18 @@ mod tests {
         assert!(matches!(Ema::new(0), Err(Error::PeriodZero)));
     }
 
+    /// Cover the const accessor `period` (74-77) and the Indicator-impl
+    /// `warmup_period` (123-125) + `name` (131-133). `alpha` and `value`
+    /// are exercised by other tests and downstream consumers; only the
+    /// three metadata methods were dead.
+    #[test]
+    fn accessors_and_metadata() {
+        let ema = Ema::new(14).unwrap();
+        assert_eq!(ema.period(), 14);
+        assert_eq!(ema.warmup_period(), 14);
+        assert_eq!(ema.name(), "EMA");
+    }
+
     #[test]
     fn warmup_returns_none_until_seed() {
         let mut ema = Ema::new(3).unwrap();

--- a/crates/wickra-core/src/indicators/historical_volatility.rs
+++ b/crates/wickra-core/src/indicators/historical_volatility.rs
@@ -173,6 +173,21 @@ mod tests {
         ));
     }
 
+    /// Cover the const accessors `periods` / `value` (80-88) and the
+    /// Indicator-impl `name` body (153-155). Existing tests inspect HV
+    /// output but never query the metadata.
+    #[test]
+    fn accessors_and_metadata() {
+        let mut hv = HistoricalVolatility::new(20, 252).unwrap();
+        assert_eq!(hv.periods(), (20, 252));
+        assert_eq!(hv.name(), "HistoricalVolatility");
+        assert_eq!(hv.value(), None);
+        for i in 1..=hv.warmup_period() {
+            hv.update(100.0 + f64::from(u32::try_from(i).unwrap()));
+        }
+        assert!(hv.value().is_some());
+    }
+
     #[test]
     fn new_rejects_period_one() {
         assert!(matches!(

--- a/crates/wickra-core/src/indicators/kama.rs
+++ b/crates/wickra-core/src/indicators/kama.rs
@@ -131,6 +131,20 @@ mod tests {
     use crate::traits::BatchExt;
     use approx::assert_relative_eq;
 
+    /// Cover the `periods` accessor (65-67) and the Indicator-impl
+    /// `warmup_period` (115-117) + `name` (123-125). Existing tests
+    /// inspect KAMA output but never query the metadata.
+    #[test]
+    fn accessors_and_metadata() {
+        let k = Kama::classic();
+        let (er, fast, slow) = k.periods();
+        assert_eq!(er, 10);
+        assert!((fast - 2.0 / (2.0 + 1.0)).abs() < 1e-12);
+        assert!((slow - 2.0 / (30.0 + 1.0)).abs() < 1e-12);
+        assert_eq!(k.warmup_period(), 11);
+        assert_eq!(k.name(), "KAMA");
+    }
+
     #[test]
     fn constant_series_yields_constant_kama() {
         let mut k = Kama::classic();

--- a/crates/wickra-core/src/indicators/linreg_angle.rs
+++ b/crates/wickra-core/src/indicators/linreg_angle.rs
@@ -138,6 +138,17 @@ mod tests {
         assert!(LinRegAngle::new(2).is_ok());
     }
 
+    /// Cover the const accessor `period` (50-52) and the Indicator-impl
+    /// `warmup_period` (67-69) + `name` (75-77). Existing tests inspect
+    /// angle output but never query the metadata.
+    #[test]
+    fn accessors_and_metadata() {
+        let a = LinRegAngle::new(14).unwrap();
+        assert_eq!(a.period(), 14);
+        assert_eq!(a.warmup_period(), 14);
+        assert_eq!(a.name(), "LinRegAngle");
+    }
+
     #[test]
     fn reset_clears_state() {
         let mut angle = LinRegAngle::new(5).unwrap();

--- a/crates/wickra-core/src/indicators/mass_index.rs
+++ b/crates/wickra-core/src/indicators/mass_index.rs
@@ -153,6 +153,21 @@ mod tests {
         assert!(matches!(MassIndex::new(9, 0), Err(Error::PeriodZero)));
     }
 
+    /// Cover the const accessors `periods` / `value` (80-87) and the
+    /// Indicator-impl `name` body (134-136). `warmup_period` is already
+    /// covered by `warmup_period_formula`.
+    #[test]
+    fn accessors_and_metadata() {
+        let mut mi = MassIndex::new(9, 25).unwrap();
+        assert_eq!(mi.periods(), (9, 25));
+        assert_eq!(mi.name(), "MassIndex");
+        assert_eq!(mi.value(), None);
+        for i in 0..mi.warmup_period() {
+            mi.update(candle(100.0, 2.0, i64::try_from(i).unwrap()));
+        }
+        assert!(mi.value().is_some());
+    }
+
     #[test]
     fn warmup_period_formula() {
         let mi = MassIndex::new(9, 25).unwrap();


### PR DESCRIPTION
Batch 5 of the 100%-coverage push. Each commit covers one file's Codecov-flagged accessor/metadata lines.