### PR TITLE
test: 100% coverage for rsi + accelerator_oscillator + aroon + atr_trailing_stop + chaikin_oscillator

### DIFF
--- a/crates/wickra-core/src/indicators/accelerator_oscillator.rs
+++ b/crates/wickra-core/src/indicators/accelerator_oscillator.rs
@@ -165,6 +165,16 @@ mod tests {
         assert!(AcceleratorOscillator::new(34, 5, 5).is_err());
     }
 
+    /// Cover the const accessor `params` (69-71) and the Indicator-impl
+    /// `name` body (99-101). Existing tests inspect numeric output but
+    /// never query the metadata.
+    #[test]
+    fn accessors_and_metadata() {
+        let ac = AcceleratorOscillator::classic();
+        assert_eq!(ac.params(), (5, 34, 5));
+        assert_eq!(ac.name(), "AcceleratorOscillator");
+    }
+
     #[test]
     fn reset_clears_state() {
         let candles: Vec<Candle> = (0..60).map(|i| c(11.0, 9.0, 10.0, i)).collect();

--- a/crates/wickra-core/src/indicators/aroon.rs
+++ b/crates/wickra-core/src/indicators/aroon.rs
@@ -182,4 +182,13 @@ mod tests {
         assert!(!a.is_ready());
         assert_eq!(a.update(candles[0]), None);
     }
+
+    /// Cover the const accessor `period` (56-58) and the Indicator-impl
+    /// `name` body (104-106). `warmup_period` is exercised elsewhere.
+    #[test]
+    fn accessors_and_metadata() {
+        let a = Aroon::new(14).unwrap();
+        assert_eq!(a.period(), 14);
+        assert_eq!(a.name(), "Aroon");
+    }
 }

--- a/crates/wickra-core/src/indicators/atr_trailing_stop.rs
+++ b/crates/wickra-core/src/indicators/atr_trailing_stop.rs
@@ -234,6 +234,17 @@ mod tests {
         assert!(AtrTrailingStop::new(14, f64::NAN).is_err());
     }
 
+    /// Cover the const accessor `params` (77-79) and the Indicator-impl
+    /// `name` body (130-132). `warmup_period` is exercised elsewhere.
+    #[test]
+    fn accessors_and_metadata() {
+        let s = AtrTrailingStop::classic();
+        let (atr_p, mult) = s.params();
+        assert_eq!(atr_p, 14);
+        assert!((mult - 3.0).abs() < 1e-12);
+        assert_eq!(s.name(), "AtrTrailingStop");
+    }
+
     #[test]
     fn reset_clears_state() {
         let candles: Vec<Candle> = (0..40)

--- a/crates/wickra-core/src/indicators/chaikin_oscillator.rs
+++ b/crates/wickra-core/src/indicators/chaikin_oscillator.rs
@@ -196,6 +196,15 @@ mod tests {
         assert!(ChaikinOscillator::new(5, 5).is_err());
     }
 
+    /// Cover the const accessor `periods` (76-78) and the Indicator-impl
+    /// `name` body (109-111). `warmup_period` is exercised elsewhere.
+    #[test]
+    fn accessors_and_metadata() {
+        let osc = ChaikinOscillator::classic();
+        assert_eq!(osc.periods(), (3, 10));
+        assert_eq!(osc.name(), "ChaikinOscillator");
+    }
+
     #[test]
     fn reset_clears_state() {
         let candles: Vec<Candle> = (0..40).map(|i| cdl(100.0 + i as f64, 50.0, i)).collect();

--- a/crates/wickra-core/src/indicators/rsi.rs
+++ b/crates/wickra-core/src/indicators/rsi.rs
@@ -202,6 +202,34 @@ mod tests {
         assert!(matches!(Rsi::new(0), Err(Error::PeriodZero)));
     }
 
+    /// Cover the const accessors `period` / `value` (60-67) and the
+    /// Indicator-impl `name` body (145-147). `warmup_period` is covered
+    /// already by `warmup_period_is_period_plus_one`.
+    #[test]
+    fn accessors_and_metadata() {
+        let mut rsi = Rsi::new(14).unwrap();
+        assert_eq!(rsi.period(), 14);
+        assert_eq!(rsi.name(), "RSI");
+        assert_eq!(rsi.value(), None);
+        for i in 1..=15 {
+            rsi.update(100.0 + f64::from(i));
+        }
+        assert!(rsi.value().is_some());
+    }
+
+    /// Cover the `ag == 0` branch (line 167) of the test-helper `rsi_naive`:
+    /// when both `avg_gain` and `avg_loss` are 0 (a perfectly flat series),
+    /// the helper must return the neutral 50.0. The proptest reference uses
+    /// random inputs that essentially never hit zero gains AND zero losses
+    /// simultaneously, leaving this branch dead in the helper.
+    #[test]
+    fn naive_helper_flat_series_yields_50() {
+        let ks = rsi_naive(&[42.0; 20], 5);
+        for r in ks.into_iter().skip(5) {
+            assert_eq!(r.expect("ready after period+1 inputs"), 50.0);
+        }
+    }
+
     #[test]
     fn warmup_period_is_period_plus_one() {
         let rsi = Rsi::new(14).unwrap();


### PR DESCRIPTION
Batch 9 of the 100%-coverage push.