### PR TITLE
test: 100% coverage for balance_of_power + median_price + true_range + typical_price + weighted_close

### DIFF
--- a/crates/wickra-core/src/indicators/balance_of_power.rs
+++ b/crates/wickra-core/src/indicators/balance_of_power.rs
@@ -132,6 +132,13 @@ mod tests {
         );
     }
 
+    /// Cover the Indicator-impl `name` body (73-75).
+    #[test]
+    fn name_metadata() {
+        let bop = BalanceOfPower::new();
+        assert_eq!(bop.name(), "BalanceOfPower");
+    }
+
     #[test]
     fn emits_from_first_candle() {
         let mut bop = BalanceOfPower::new();

--- a/crates/wickra-core/src/indicators/median_price.rs
+++ b/crates/wickra-core/src/indicators/median_price.rs
@@ -85,6 +85,13 @@ mod tests {
         );
     }
 
+    /// Cover the Indicator-impl `name` body (62-64).
+    #[test]
+    fn name_metadata() {
+        let mp = MedianPrice::new();
+        assert_eq!(mp.name(), "MedianPrice");
+    }
+
     #[test]
     fn emits_from_first_candle() {
         let mut mp = MedianPrice::new();

--- a/crates/wickra-core/src/indicators/true_range.rs
+++ b/crates/wickra-core/src/indicators/true_range.rs
@@ -95,6 +95,13 @@ mod tests {
         assert_relative_eq!(out[1].unwrap(), 2.0, epsilon = 1e-12);
     }
 
+    /// Cover the Indicator-impl `name` body (73-75).
+    #[test]
+    fn name_metadata() {
+        let tr = TrueRange::new();
+        assert_eq!(tr.name(), "TrueRange");
+    }
+
     #[test]
     fn emits_from_first_candle() {
         let mut tr = TrueRange::new();

--- a/crates/wickra-core/src/indicators/typical_price.rs
+++ b/crates/wickra-core/src/indicators/typical_price.rs
@@ -85,6 +85,13 @@ mod tests {
         );
     }
 
+    /// Cover the Indicator-impl `name` body (62-64).
+    #[test]
+    fn name_metadata() {
+        let tp = TypicalPrice::new();
+        assert_eq!(tp.name(), "TypicalPrice");
+    }
+
     #[test]
     fn emits_from_first_candle() {
         let mut tp = TypicalPrice::new();

--- a/crates/wickra-core/src/indicators/weighted_close.rs
+++ b/crates/wickra-core/src/indicators/weighted_close.rs
@@ -84,6 +84,13 @@ mod tests {
         );
     }
 
+    /// Cover the Indicator-impl `name` body (61-63).
+    #[test]
+    fn name_metadata() {
+        let wc = WeightedClose::new();
+        assert_eq!(wc.name(), "WeightedClose");
+    }
+
     #[test]
     fn emits_from_first_candle() {
         let mut wc = WeightedClose::new();


### PR DESCRIPTION
Batch 13 (final small-files batch) of the 100%-coverage push. All five files only missed their 3-line Indicator-impl name() body.