### PR TITLE
release: 0.2.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
           - { host: macos-latest, target: x86_64-apple-darwin }
           - { host: macos-latest, target: aarch64-apple-darwin }
           - { host: windows-latest, target: x86_64-pc-windows-msvc }
-          # NOTE: aarch64-pc-windows-msvc is temporarily skipped for 0.2.1.
+          # NOTE: aarch64-pc-windows-msvc is temporarily skipped for 0.2.5.
           # The wickra-win32-arm64-msvc npm subpackage name is blocked by the
           # npm spam-detection filter for new accounts (same situation that
           # affected wickra-win32-x64-msvc through 0.1.4 until npm Support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-05-24
+
+### Added
+- `BinanceConfig` plus `BinanceKlineStream::connect_with_config(symbols, interval, config)`
+  in `wickra-data`'s `live::binance` module. `connect()` keeps its previous
+  signature and now forwards to the new entry-point with the defaults, so the
+  public API is backwards-compatible. The config lets callers point the
+  stream at Binance Testnet (`wss://testnet.binance.vision`) or tune the
+  read timeout, reconnect attempt count, initial / capped backoff and frame
+  size limits without rewriting the connector.
+- README **Disclaimer** section clarifying that Wickra is an indicator
+  toolkit (not a trading system) and that any production-trading use is at
+  the caller's own risk. The legal terms in [LICENSE](LICENSE) are
+  unchanged.
+
+### Changed
+- `BinanceKlineStream::next_event` now writes the Pong reply to a server
+  `Ping` on a best-effort basis. A failed write means the connection is
+  already dead, so the existing timeout / read-error reconnect arm one
+  loop iteration later picks it up — the previous explicit reconnect on
+  Pong-write failure is gone. Observable behaviour is unchanged for every
+  healthy connection.
+
 ## [0.2.1] - 2026-05-23
 
 ### Changed
@@ -329,7 +352,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/kingchenc/wickra/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/kingchenc/wickra/compare/v0.2.5...HEAD
+[0.2.5]: https://github.com/kingchenc/wickra/compare/v0.2.1...v0.2.5
 [0.2.1]: https://github.com/kingchenc/wickra/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/kingchenc/wickra/compare/v0.1.4...v0.2.0
 [0.1.4]: https://github.com/kingchenc/wickra/compare/v0.1.3...v0.1.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.2.1"
+version = "0.2.5"
 dependencies = [
  "approx",
  "criterion",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "0.2.1"
+version = "0.2.5"
 dependencies = [
  "approx",
  "proptest",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.2.1"
+version = "0.2.5"
 dependencies = [
  "approx",
  "csv",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.2.1"
+version = "0.2.5"
 dependencies = [
  "napi",
  "napi-build",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.2.1"
+version = "0.2.5"
 dependencies = [
  "numpy",
  "pyo3",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.2.1"
+version = "0.2.5"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.5"
 authors = ["kingchenc <kingchencp@gmail.com>"]
 edition = "2021"
 rust-version = "1.86"
@@ -24,7 +24,7 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.2.1" }
+wickra-core = { path = "crates/wickra-core", version = "0.2.5" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/README.md
+++ b/README.md
@@ -287,6 +287,16 @@ government, hobby trading bots: all fine. The one thing that's not allowed is
 commercial sale of the software or of services built around it. If you want to
 use Wickra commercially, get in touch about a license.
 
+## Disclaimer
+
+Wickra is an indicator toolkit, not a trading system. Values it computes are
+deterministic transforms of the input data — they are not financial advice and
+they do not predict the market. Any use of this library in a production
+trading context is at your own risk.
+
+The library is provided **as is**, without warranty of any kind; see
+[LICENSE](LICENSE) for the full terms.
+
 ---
 
 <p align="center">

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.2.1",
+  "version": "0.2.5",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.2.1",
+  "version": "0.2.5",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.2.1",
+  "version": "0.2.5",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.2.1",
+  "version": "0.2.5",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.2.1",
+  "version": "0.2.5",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.2.1",
+  "version": "0.2.5",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <kingchencp@gmail.com>",
   "main": "index.js",
@@ -46,11 +46,11 @@
     "node": ">= 18"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.2.1",
-    "wickra-linux-arm64-gnu": "0.2.1",
-    "wickra-darwin-x64": "0.2.1",
-    "wickra-darwin-arm64": "0.2.1",
-    "wickra-win32-x64-msvc": "0.2.1"
+    "wickra-linux-x64-gnu": "0.2.5",
+    "wickra-linux-arm64-gnu": "0.2.5",
+    "wickra-darwin-x64": "0.2.5",
+    "wickra-darwin-arm64": "0.2.5",
+    "wickra-win32-x64-msvc": "0.2.5"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.2.1"
+version = "0.2.5"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = { text = "PolyForm-Noncommercial-1.0.0" }


### PR DESCRIPTION
## Summary
- Workspace + every binding (`wickra-core`, `wickra-data`, `wickra` umbrella, `wickra-python`, `wickra-node` + 5 platform stubs, `wickra-wasm`) bumped from **0.2.1 → 0.2.5**.
- README gains a short **Disclaimer** section (indicator toolkit, not a trading system; production use at the caller's own risk). Legal terms in `LICENSE` are unchanged — PolyForm-Noncommercial-1.0.0's "No Liability" already covers warranty / as-is.
- CHANGELOG `[0.2.5]` entry documents the user-facing changes from PR #34:
  - **Added** `BinanceConfig` + `BinanceKlineStream::connect_with_config(...)` for Binance Testnet endpoints and tunable read-timeout / reconnect knobs.
  - **Changed** the `Message::Ping` arm to write the Pong reply best-effort — a failed write means the connection is already dead, so the next read surfaces the error and reconnect happens one loop iteration later. Same observable behaviour on healthy connections.
- `wickra-win32-arm64-msvc` stays excluded for this release; the release.yml comment is updated from `0.2.1` to `0.2.5`.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` — every crate green; the new binance.rs mock-WS suite from #34 still passes
- [x] `grep -rn "0\.2\.1"` shows only CHANGELOG history references remain
- [ ] CI matrix passes on the bump branch