### PR TITLE
release: 0.2.6 (docs.rs fix + README table reordering)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
           - { host: macos-latest, target: x86_64-apple-darwin }
           - { host: macos-latest, target: aarch64-apple-darwin }
           - { host: windows-latest, target: x86_64-pc-windows-msvc }
-          # NOTE: aarch64-pc-windows-msvc is temporarily skipped for 0.2.5.
+          # NOTE: aarch64-pc-windows-msvc is temporarily skipped for 0.2.6.
           # The wickra-win32-arm64-msvc npm subpackage name is blocked by the
           # npm spam-detection filter for new accounts (same situation that
           # affected wickra-win32-x64-msvc through 0.1.4 until npm Support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-05-24
+
+### Fixed
+- **docs.rs build.** Rust 1.92 removed the `doc_auto_cfg` feature gate
+  and folded it back into `doc_cfg` (rust-lang/rust#138907). docs.rs
+  builds against the latest nightly and sets `--cfg docsrs`, so every
+  published 0.2.x failed with E0557 on the
+  `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` line at the top of
+  `wickra`, `wickra-core`, and `wickra-data`. GitHub CI didn't see
+  this — stable rustc never enables the `docsrs` cfg. The three
+  library crates now gate on `doc_cfg` (same intent, same rendered
+  output on docs.rs, builds again on nightly).
+
+### Changed
+- **README — Wickra is now the top row of every comparison table.**
+  The "Why Wickra exists" library matrix and the per-indicator
+  benchmark tables previously placed Wickra at the bottom; a reader
+  landing on the README is here to compare *against* Wickra, so the
+  pivot row belongs at the top with a ★ marker. Same column data,
+  same winner annotations — only row order changed. Mirrored across
+  the umbrella README and every binding README so crates.io / PyPI /
+  npm landing pages stay in sync.
+
 ## [0.2.5] - 2026-05-24
 
 ### Added
@@ -352,7 +375,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/kingchenc/wickra/compare/v0.2.5...HEAD
+[Unreleased]: https://github.com/kingchenc/wickra/compare/v0.2.6...HEAD
+[0.2.6]: https://github.com/kingchenc/wickra/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/kingchenc/wickra/compare/v0.2.1...v0.2.5
 [0.2.1]: https://github.com/kingchenc/wickra/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/kingchenc/wickra/compare/v0.1.4...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "approx",
  "criterion",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "approx",
  "proptest",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "approx",
  "csv",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "napi",
  "napi-build",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "numpy",
  "pyo3",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 authors = ["kingchenc <kingchencp@gmail.com>"]
 edition = "2021"
 rust-version = "1.86"
@@ -24,7 +24,7 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.2.5" }
+wickra-core = { path = "crates/wickra-core", version = "0.2.6" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ for price in live_feed:
 The Python TA ecosystem has plenty of libraries — TA-Lib, pandas-ta, finta,
 talipp, tulipy — and every one of them shares the same blind spot:
 
-| Library            | Install pain    | Streaming | Multi-language | Active |
-|--------------------|-----------------|-----------|----------------|--------|
-| TA-Lib (Python)    | yes (C deps)    | no        | no             | barely |
-| pandas-ta          | clean           | no        | no             | slow   |
-| finta              | clean           | no        | no             | stale  |
-| ta-lib-python      | yes (C deps)    | no        | no             | barely |
-| talipp             | clean           | yes       | no             | yes    |
-| Tulip Indicators   | yes (C deps)    | no        | partial        | stale  |
-| ooples (C#)        | clean           | no        | C# only        | yes    |
-| **Wickra**         | **clean**       | **yes**   | **Python+Node+WASM+Rust** | **yes** |
+| Library                | Install pain    | Streaming | Multi-language | Active |
+|------------------------|-----------------|-----------|----------------|--------|
+| **★&nbsp;Wickra**      | **clean**       | **yes**   | **Python + Node + WASM + Rust** | **yes** |
+| TA-Lib (Python)        | yes (C deps)    | no        | no             | barely |
+| pandas-ta              | clean           | no        | no             | slow   |
+| finta                  | clean           | no        | no             | stale  |
+| ta-lib-python          | yes (C deps)    | no        | no             | barely |
+| talipp                 | clean           | yes       | no             | yes    |
+| Tulip Indicators       | yes (C deps)    | no        | partial        | stale  |
+| ooples (C#)            | clean           | no        | C# only        | yes    |
 
 Wickra is the only library that combines all of: clean install, streaming,
 multi-language reach, and active maintenance.
@@ -76,7 +76,7 @@ to recompute on every tick.
 Reading the table: each cell shows that library's runtime, plus how many times
 slower it is than Wickra in parentheses. **★** marks the winner per row.
 
-| Indicator           | Wickra              | finta                       | talipp                        |
+| Indicator           | **★&nbsp;Wickra**   | finta                       | talipp                        |
 |---------------------|---------------------|-----------------------------|-------------------------------|
 | SMA(20)             | **95.6 µs ★**       | 343.5 µs (3.6× slower)      | 7 640.6 µs (79.9× slower)     |
 | EMA(20)             | **64.6 µs ★**       | 223.1 µs (3.5× slower)      | 12 160.9 µs (188.2× slower)   |
@@ -90,7 +90,7 @@ slower it is than Wickra in parentheses. **★** marks the winner per row.
 A batch-only library has to re-run its full indicator over the entire history on
 every new tick; Wickra updates state in O(1).
 
-| Indicator | Wickra (per tick)   | talipp (per tick)         |
+| Indicator | **★&nbsp;Wickra (per tick)** | talipp (per tick)         |
 |-----------|---------------------|---------------------------|
 | RSI(14)   | **0.119 µs ★**      | 1.644 µs (13.8× slower)   |
 

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -36,16 +36,16 @@ for price in live_feed:
 The Python TA ecosystem has plenty of libraries — TA-Lib, pandas-ta, finta,
 talipp, tulipy — and every one of them shares the same blind spot:
 
-| Library            | Install pain    | Streaming | Multi-language | Active |
-|--------------------|-----------------|-----------|----------------|--------|
-| TA-Lib (Python)    | yes (C deps)    | no        | no             | barely |
-| pandas-ta          | clean           | no        | no             | slow   |
-| finta              | clean           | no        | no             | stale  |
-| ta-lib-python      | yes (C deps)    | no        | no             | barely |
-| talipp             | clean           | yes       | no             | yes    |
-| Tulip Indicators   | yes (C deps)    | no        | partial        | stale  |
-| ooples (C#)        | clean           | no        | C# only        | yes    |
-| **Wickra**         | **clean**       | **yes**   | **Python+Node+WASM+Rust** | **yes** |
+| Library                | Install pain    | Streaming | Multi-language | Active |
+|------------------------|-----------------|-----------|----------------|--------|
+| **★&nbsp;Wickra**      | **clean**       | **yes**   | **Python + Node + WASM + Rust** | **yes** |
+| TA-Lib (Python)        | yes (C deps)    | no        | no             | barely |
+| pandas-ta              | clean           | no        | no             | slow   |
+| finta                  | clean           | no        | no             | stale  |
+| ta-lib-python          | yes (C deps)    | no        | no             | barely |
+| talipp                 | clean           | yes       | no             | yes    |
+| Tulip Indicators       | yes (C deps)    | no        | partial        | stale  |
+| ooples (C#)            | clean           | no        | C# only        | yes    |
 
 Wickra is the only library that combines all of: clean install, streaming,
 multi-language reach, and active maintenance.
@@ -76,7 +76,7 @@ to recompute on every tick.
 Reading the table: each cell shows that library's runtime, plus how many times
 slower it is than Wickra in parentheses. **★** marks the winner per row.
 
-| Indicator           | Wickra              | finta                       | talipp                        |
+| Indicator           | **★&nbsp;Wickra**   | finta                       | talipp                        |
 |---------------------|---------------------|-----------------------------|-------------------------------|
 | SMA(20)             | **95.6 µs ★**       | 343.5 µs (3.6× slower)      | 7 640.6 µs (79.9× slower)     |
 | EMA(20)             | **64.6 µs ★**       | 223.1 µs (3.5× slower)      | 12 160.9 µs (188.2× slower)   |
@@ -90,7 +90,7 @@ slower it is than Wickra in parentheses. **★** marks the winner per row.
 A batch-only library has to re-run its full indicator over the entire history on
 every new tick; Wickra updates state in O(1).
 
-| Indicator | Wickra (per tick)   | talipp (per tick)         |
+| Indicator | **★&nbsp;Wickra (per tick)** | talipp (per tick)         |
 |-----------|---------------------|---------------------------|
 | RSI(14)   | **0.119 µs ★**      | 1.644 µs (13.8× slower)   |
 

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <kingchencp@gmail.com>",
   "main": "index.js",
@@ -46,11 +46,11 @@
     "node": ">= 18"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.2.5",
-    "wickra-linux-arm64-gnu": "0.2.5",
-    "wickra-darwin-x64": "0.2.5",
-    "wickra-darwin-arm64": "0.2.5",
-    "wickra-win32-x64-msvc": "0.2.5"
+    "wickra-linux-x64-gnu": "0.2.6",
+    "wickra-linux-arm64-gnu": "0.2.6",
+    "wickra-darwin-x64": "0.2.6",
+    "wickra-darwin-arm64": "0.2.6",
+    "wickra-win32-x64-msvc": "0.2.6"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -36,16 +36,16 @@ for price in live_feed:
 The Python TA ecosystem has plenty of libraries — TA-Lib, pandas-ta, finta,
 talipp, tulipy — and every one of them shares the same blind spot:
 
-| Library            | Install pain    | Streaming | Multi-language | Active |
-|--------------------|-----------------|-----------|----------------|--------|
-| TA-Lib (Python)    | yes (C deps)    | no        | no             | barely |
-| pandas-ta          | clean           | no        | no             | slow   |
-| finta              | clean           | no        | no             | stale  |
-| ta-lib-python      | yes (C deps)    | no        | no             | barely |
-| talipp             | clean           | yes       | no             | yes    |
-| Tulip Indicators   | yes (C deps)    | no        | partial        | stale  |
-| ooples (C#)        | clean           | no        | C# only        | yes    |
-| **Wickra**         | **clean**       | **yes**   | **Python+Node+WASM+Rust** | **yes** |
+| Library                | Install pain    | Streaming | Multi-language | Active |
+|------------------------|-----------------|-----------|----------------|--------|
+| **★&nbsp;Wickra**      | **clean**       | **yes**   | **Python + Node + WASM + Rust** | **yes** |
+| TA-Lib (Python)        | yes (C deps)    | no        | no             | barely |
+| pandas-ta              | clean           | no        | no             | slow   |
+| finta                  | clean           | no        | no             | stale  |
+| ta-lib-python          | yes (C deps)    | no        | no             | barely |
+| talipp                 | clean           | yes       | no             | yes    |
+| Tulip Indicators       | yes (C deps)    | no        | partial        | stale  |
+| ooples (C#)            | clean           | no        | C# only        | yes    |
 
 Wickra is the only library that combines all of: clean install, streaming,
 multi-language reach, and active maintenance.
@@ -76,7 +76,7 @@ to recompute on every tick.
 Reading the table: each cell shows that library's runtime, plus how many times
 slower it is than Wickra in parentheses. **★** marks the winner per row.
 
-| Indicator           | Wickra              | finta                       | talipp                        |
+| Indicator           | **★&nbsp;Wickra**   | finta                       | talipp                        |
 |---------------------|---------------------|-----------------------------|-------------------------------|
 | SMA(20)             | **95.6 µs ★**       | 343.5 µs (3.6× slower)      | 7 640.6 µs (79.9× slower)     |
 | EMA(20)             | **64.6 µs ★**       | 223.1 µs (3.5× slower)      | 12 160.9 µs (188.2× slower)   |
@@ -90,7 +90,7 @@ slower it is than Wickra in parentheses. **★** marks the winner per row.
 A batch-only library has to re-run its full indicator over the entire history on
 every new tick; Wickra updates state in O(1).
 
-| Indicator | Wickra (per tick)   | talipp (per tick)         |
+| Indicator | **★&nbsp;Wickra (per tick)** | talipp (per tick)         |
 |-----------|---------------------|---------------------------|
 | RSI(14)   | **0.119 µs ★**      | 1.644 µs (13.8× slower)   |
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.2.5"
+version = "0.2.6"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = { text = "PolyForm-Noncommercial-1.0.0" }

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -36,16 +36,16 @@ for price in live_feed:
 The Python TA ecosystem has plenty of libraries — TA-Lib, pandas-ta, finta,
 talipp, tulipy — and every one of them shares the same blind spot:
 
-| Library            | Install pain    | Streaming | Multi-language | Active |
-|--------------------|-----------------|-----------|----------------|--------|
-| TA-Lib (Python)    | yes (C deps)    | no        | no             | barely |
-| pandas-ta          | clean           | no        | no             | slow   |
-| finta              | clean           | no        | no             | stale  |
-| ta-lib-python      | yes (C deps)    | no        | no             | barely |
-| talipp             | clean           | yes       | no             | yes    |
-| Tulip Indicators   | yes (C deps)    | no        | partial        | stale  |
-| ooples (C#)        | clean           | no        | C# only        | yes    |
-| **Wickra**         | **clean**       | **yes**   | **Python+Node+WASM+Rust** | **yes** |
+| Library                | Install pain    | Streaming | Multi-language | Active |
+|------------------------|-----------------|-----------|----------------|--------|
+| **★&nbsp;Wickra**      | **clean**       | **yes**   | **Python + Node + WASM + Rust** | **yes** |
+| TA-Lib (Python)        | yes (C deps)    | no        | no             | barely |
+| pandas-ta              | clean           | no        | no             | slow   |
+| finta                  | clean           | no        | no             | stale  |
+| ta-lib-python          | yes (C deps)    | no        | no             | barely |
+| talipp                 | clean           | yes       | no             | yes    |
+| Tulip Indicators       | yes (C deps)    | no        | partial        | stale  |
+| ooples (C#)            | clean           | no        | C# only        | yes    |
 
 Wickra is the only library that combines all of: clean install, streaming,
 multi-language reach, and active maintenance.
@@ -76,7 +76,7 @@ to recompute on every tick.
 Reading the table: each cell shows that library's runtime, plus how many times
 slower it is than Wickra in parentheses. **★** marks the winner per row.
 
-| Indicator           | Wickra              | finta                       | talipp                        |
+| Indicator           | **★&nbsp;Wickra**   | finta                       | talipp                        |
 |---------------------|---------------------|-----------------------------|-------------------------------|
 | SMA(20)             | **95.6 µs ★**       | 343.5 µs (3.6× slower)      | 7 640.6 µs (79.9× slower)     |
 | EMA(20)             | **64.6 µs ★**       | 223.1 µs (3.5× slower)      | 12 160.9 µs (188.2× slower)   |
@@ -90,7 +90,7 @@ slower it is than Wickra in parentheses. **★** marks the winner per row.
 A batch-only library has to re-run its full indicator over the entire history on
 every new tick; Wickra updates state in O(1).
 
-| Indicator | Wickra (per tick)   | talipp (per tick)         |
+| Indicator | **★&nbsp;Wickra (per tick)** | talipp (per tick)         |
 |-----------|---------------------|---------------------------|
 | RSI(14)   | **0.119 µs ★**      | 1.644 µs (13.8× slower)   |
 

--- a/crates/wickra-core/src/lib.rs
+++ b/crates/wickra-core/src/lib.rs
@@ -34,7 +34,7 @@
 //! assert_eq!(out, vec![None, None, Some(2.0), Some(3.0)]);
 //! ```
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod error;
 mod ohlcv;

--- a/crates/wickra-data/src/lib.rs
+++ b/crates/wickra-data/src/lib.rs
@@ -7,7 +7,7 @@
 //! - [`live`] (feature `live-binance`): connect to exchange websockets and yield
 //!   typed events compatible with the rest of the crate.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 // `tokio_tungstenite::Error` is large by itself (~200 B). Boxing every Err
 // variant per clippy::result_large_err just shifts allocation pressure into
 // the hot path. We accept the size because errors are rare in this crate.

--- a/crates/wickra/src/lib.rs
+++ b/crates/wickra/src/lib.rs
@@ -16,6 +16,6 @@
 //! assert_eq!(out, vec![None, None, Some(2.0), Some(3.0), Some(4.0)]);
 //! ```
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use wickra_core::*;


### PR DESCRIPTION
## Summary
Three commits land together for the 0.2.6 patch:

- **`fix(docs-rs)`** — `doc_auto_cfg` was removed in Rust 1.92 and merged into `doc_cfg` (rust-lang/rust#138907). docs.rs builds against the latest nightly with `--cfg docsrs`, so every published 0.2.x tripped E0557 on the `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` lines in `wickra`, `wickra-core`, `wickra-data`. Stable rustc never enables that cfg, so GitHub CI couldn't see it. All three crates now gate on `doc_cfg` (same rendered output, builds again on nightly).

- **`docs(readme)`** — Wickra is now the **first** row of every comparison table across the umbrella + binding READMEs (with a ★ marker), instead of the last. Same column data, same winner annotations, just the pivot row in the position a reader actually wants it.

- **`release: bump`** — workspace, every binding (Python, Node, 5 platform stubs), the `release.yml` comment, and the `CHANGELOG` all move from 0.2.5 → 0.2.6. `wickra-win32-arm64-msvc` stays excluded with the same npm-spam-filter rationale.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` — every crate green
- [x] `grep "0\.2\.5"` shows only the historical CHANGELOG entries + one historical "Since 0.2.5, BinanceConfig" doc-line
- [ ] CI matrix passes on the bump branch
- [ ] After merge + `v0.2.6` tag push: docs.rs successfully builds 0.2.6 (the whole reason for this PR)