### PR TITLE
release: 0.2.7 (Windows ARM64 restored + CPU label fix)

### DIFF
--- a/.github/ISSUE_TEMPLATE/performance_regression.md
+++ b/.github/ISSUE_TEMPLATE/performance_regression.md
@@ -44,7 +44,7 @@ ema/update              time:   [38.5 ns 38.7 ns 38.9 ns]
 
 | Field        | Value                                  |
 | ------------ | -------------------------------------- |
-| CPU          | `e.g. Ryzen 9 7950X, AVX2 + AVX512`    |
+| CPU          | `e.g. Ryzen 9 9950X, AVX2 + AVX512`    |
 | OS / arch    | `e.g. Linux 6.8 x86_64`                |
 | Toolchain    | `rustc 1.x.y`                          |
 | Build flags  | `RUSTFLAGS=...`, `--release`, profile  |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,15 +173,7 @@ jobs:
           - { host: macos-latest, target: x86_64-apple-darwin }
           - { host: macos-latest, target: aarch64-apple-darwin }
           - { host: windows-latest, target: x86_64-pc-windows-msvc }
-          # NOTE: aarch64-pc-windows-msvc is temporarily skipped for 0.2.6.
-          # The wickra-win32-arm64-msvc npm subpackage name is blocked by the
-          # npm spam-detection filter for new accounts (same situation that
-          # affected wickra-win32-x64-msvc through 0.1.4 until npm Support
-          # unblocked it). A support ticket is open; once the new arm64 name
-          # is unblocked this matrix entry will be restored alongside the
-          # corresponding optionalDependencies / napi.triples / npm/<target>
-          # entries in a follow-up release.
-          # - { host: windows-11-arm, target: aarch64-pc-windows-msvc }
+          - { host: windows-11-arm, target: aarch64-pc-windows-msvc }
     runs-on: ${{ matrix.host }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-05-24
+
+### Added
+- **Windows ARM64 is back.** npm Support unblocked the
+  `wickra-win32-arm64-msvc` sub-package name (same path
+  `wickra-win32-x64-msvc` took through 0.1.4) and transferred write
+  access to @kingchenc. 0.2.7 ships the binding for
+  `aarch64-pc-windows-msvc` alongside the existing five platforms:
+  the `napi.triples.additional` entry, the `optionalDependencies`
+  pin, the `bindings/node/npm/win32-arm64-msvc/` sub-package and the
+  `windows-11-arm` row of the release.yml node-build matrix are all
+  restored from 8aa74cb. `npm install wickra` on Windows ARM64 now
+  resolves to a native build instead of failing the loader's
+  optional-dep lookup. PyPI's `win_arm64` wheel was unaffected and
+  carries through as before.
+
+### Changed
+- **Benchmark CPU renamed.** The "Reproduced on" line in every
+  README listed an AMD Ryzen 9 7950X3D; the canonical machine is
+  actually a Ryzen 9 9950X. Speedup ratios in the tables are
+  unchanged (they're relative across libraries on the same machine),
+  only the labelling is corrected. The performance-regression issue
+  template's CPU example was updated for consistency.
+
 ## [0.2.6] - 2026-05-24
 
 ### Fixed
@@ -375,7 +399,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/kingchenc/wickra/compare/v0.2.6...HEAD
+[Unreleased]: https://github.com/kingchenc/wickra/compare/v0.2.7...HEAD
+[0.2.7]: https://github.com/kingchenc/wickra/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/kingchenc/wickra/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/kingchenc/wickra/compare/v0.2.1...v0.2.5
 [0.2.1]: https://github.com/kingchenc/wickra/compare/v0.2.0...v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "approx",
  "criterion",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "approx",
  "proptest",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "approx",
  "csv",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "napi",
  "napi-build",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "numpy",
  "pyo3",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 authors = ["kingchenc <kingchencp@gmail.com>"]
 edition = "2021"
 rust-version = "1.86"
@@ -24,7 +24,7 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.2.6" }
+wickra-core = { path = "crates/wickra-core", version = "0.2.7" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ depend on CPU, memory clock and OS scheduler. Read them as **relative
 speedups** between libraries on identical input, not as a universal
 performance contract.
 
-- **Reproduced on:** Windows 11 Pro 26200, AMD Ryzen 9 7950X3D, 64 GB DDR5,
+- **Reproduced on:** Windows 11 Pro 26200, AMD Ryzen 9 9950X, 64 GB DDR5,
   Rust 1.92 (release profile, `lto = "fat"`, `codegen-units = 1`),
   Python 3.12, Node 20.
 - **Reproduce yourself:** `pip install -e bindings/python[bench]` then

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -58,7 +58,7 @@ depend on CPU, memory clock and OS scheduler. Read them as **relative
 speedups** between libraries on identical input, not as a universal
 performance contract.
 
-- **Reproduced on:** Windows 11 Pro 26200, AMD Ryzen 9 7950X3D, 64 GB DDR5,
+- **Reproduced on:** Windows 11 Pro 26200, AMD Ryzen 9 9950X, 64 GB DDR5,
   Rust 1.92 (release profile, `lto = "fat"`, `codegen-units = 1`),
   Python 3.12, Node 20.
 - **Reproduce yourself:** `pip install -e bindings/python[bench]` then

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "wickra-win32-arm64-msvc",
+  "version": "0.2.6",
+  "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
+  "main": "wickra.win32-arm64-msvc.node",
+  "files": [
+    "wickra.win32-arm64-msvc.node"
+  ],
+  "license": "PolyForm-Noncommercial-1.0.0",
+  "engines": {
+    "node": ">= 18"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kingchenc/wickra"
+  },
+  "homepage": "https://github.com/kingchenc/wickra"
+}

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <kingchencp@gmail.com>",
   "main": "index.js",
@@ -47,12 +47,12 @@
     "node": ">= 18"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.2.6",
-    "wickra-linux-arm64-gnu": "0.2.6",
-    "wickra-darwin-x64": "0.2.6",
-    "wickra-darwin-arm64": "0.2.6",
-    "wickra-win32-x64-msvc": "0.2.6",
-    "wickra-win32-arm64-msvc": "0.2.6"
+    "wickra-linux-x64-gnu": "0.2.7",
+    "wickra-linux-arm64-gnu": "0.2.7",
+    "wickra-darwin-x64": "0.2.7",
+    "wickra-darwin-arm64": "0.2.7",
+    "wickra-win32-x64-msvc": "0.2.7",
+    "wickra-win32-arm64-msvc": "0.2.7"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -38,7 +38,8 @@
         "aarch64-unknown-linux-gnu",
         "x86_64-apple-darwin",
         "aarch64-apple-darwin",
-        "x86_64-pc-windows-msvc"
+        "x86_64-pc-windows-msvc",
+        "aarch64-pc-windows-msvc"
       ]
     }
   },
@@ -50,7 +51,8 @@
     "wickra-linux-arm64-gnu": "0.2.6",
     "wickra-darwin-x64": "0.2.6",
     "wickra-darwin-arm64": "0.2.6",
-    "wickra-win32-x64-msvc": "0.2.6"
+    "wickra-win32-x64-msvc": "0.2.6",
+    "wickra-win32-arm64-msvc": "0.2.6"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -58,7 +58,7 @@ depend on CPU, memory clock and OS scheduler. Read them as **relative
 speedups** between libraries on identical input, not as a universal
 performance contract.
 
-- **Reproduced on:** Windows 11 Pro 26200, AMD Ryzen 9 7950X3D, 64 GB DDR5,
+- **Reproduced on:** Windows 11 Pro 26200, AMD Ryzen 9 9950X, 64 GB DDR5,
   Rust 1.92 (release profile, `lto = "fat"`, `codegen-units = 1`),
   Python 3.12, Node 20.
 - **Reproduce yourself:** `pip install -e bindings/python[bench]` then

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.2.6"
+version = "0.2.7"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = { text = "PolyForm-Noncommercial-1.0.0" }

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -58,7 +58,7 @@ depend on CPU, memory clock and OS scheduler. Read them as **relative
 speedups** between libraries on identical input, not as a universal
 performance contract.
 
-- **Reproduced on:** Windows 11 Pro 26200, AMD Ryzen 9 7950X3D, 64 GB DDR5,
+- **Reproduced on:** Windows 11 Pro 26200, AMD Ryzen 9 9950X, 64 GB DDR5,
   Rust 1.92 (release profile, `lto = "fat"`, `codegen-units = 1`),
   Python 3.12, Node 20.
 - **Reproduce yourself:** `pip install -e bindings/python[bench]` then


### PR DESCRIPTION
## Summary
Three commits, two user-visible changes:

- **`chore(npm): restore Windows ARM64 sub-package + napi matrix entry`** — npm Support unblocked the `wickra-win32-arm64-msvc` package name and transferred write access to @kingchenc (placeholder `0.0.1-security` is theirs; our first real version lands on top). Reverses 8aa74cb's three "temporarily skipped" changes:
  - `bindings/node/package.json` — re-add `aarch64-pc-windows-msvc` to `napi.triples.additional` and `wickra-win32-arm64-msvc` to `optionalDependencies`.
  - `bindings/node/npm/win32-arm64-msvc/package.json` — restored.
  - `.github/workflows/release.yml` — re-enable the `windows-11-arm / aarch64-pc-windows-msvc` row in the node-build matrix and drop the "temporarily skipped" comment block.

- **`chore(docs): rename benchmark CPU from 7950X3D to 9950X`** — the "Reproduced on" line in every README and the site benchmark page listed the wrong AMD CPU. Speedup ratios in the tables are unchanged because they're relative across libraries on the same machine; only the labelling is corrected. Issue-template CPU example also updated.

- **`release: bump`** — workspace, every binding (Python, Node, six platform stubs incl. the restored arm64 one), `wickra-wasm` site dep, and the `CHANGELOG` all move 0.2.6 → 0.2.7.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` — every crate green
- [x] `grep "0\.2\.6"` shows only CHANGELOG history references
- [ ] CI matrix passes on the bump branch (Windows runner has previously flaked on setup-node — if so, rerun the failed job)
- [ ] After merge + `v0.2.7` tag push: the release pipeline now includes the `windows-11-arm` matrix row; `wickra-win32-arm64-msvc@0.2.7` publishes to npm cleanly.