### PR TITLE
ci: Auto-sync indicator count to About, README, site & wiki

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -1,0 +1,82 @@
+name: Sync indicator count
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.ABOUT_SYNC_TOKEN }}
+
+      - name: Count indicators
+        id: count
+        run: |
+          n=$(grep -c '^mod ' crates/wickra-core/src/indicators/mod.rs)
+          echo "count=$n" >> "$GITHUB_OUTPUT"
+          echo "Indicator count: $n"
+
+      - name: Update GitHub About description
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.ABOUT_SYNC_TOKEN }}
+        run: |
+          n="${{ steps.count.outputs.count }}"
+          desc="Streaming-first technical indicators with a Rust core and Python, Node.js, and WebAssembly bindings. ${n} indicators, O(1) per-tick updates, no system dependencies. Drop-in TA-Lib replacement."
+          current=$(gh repo view --json description -q .description)
+          if [ "$current" = "$desc" ]; then
+            echo "About unchanged."
+          else
+            gh repo edit --description "$desc"
+            echo "About updated."
+          fi
+
+      - name: Patch README + site counters
+        if: github.event_name != 'pull_request'
+        id: patch
+        run: |
+          n="${{ steps.count.outputs.count }}"
+          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" README.md site/index.md
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit & push README + site
+        if: steps.patch.outputs.changed == 'true' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "wickra-bot"
+          git config user.email "wickra-bot@users.noreply.github.com"
+          git add README.md site/index.md
+          git commit -m "chore: sync indicator count to ${{ steps.count.outputs.count }} [skip ci]"
+          git push
+
+      - name: Sync Wiki
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.ABOUT_SYNC_TOKEN }}
+        run: |
+          n="${{ steps.count.outputs.count }}"
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.wiki.git" wiki
+          cd wiki
+          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" Home.md FAQ.md Streaming-vs-Batch.md
+          if git diff --quiet; then
+            echo "Wiki unchanged."
+            exit 0
+          fi
+          git config user.name "wickra-bot"
+          git config user.email "wickra-bot@users.noreply.github.com"
+          git add Home.md FAQ.md Streaming-vs-Batch.md
+          git commit -m "chore: sync indicator count to ${n}"
+          git push


### PR DESCRIPTION
## Summary

Adds a new workflow `sync-about.yml` that counts `mod xxx;` declarations in `crates/wickra-core/src/indicators/mod.rs` and propagates the number into every place where it appears.

**Sync targets (only on `main` push and `v*` tag push, never on PRs):**
- GitHub repo **About** description (via `gh repo edit`)
- `README.md` + `site/index.md` (commit back to `main` with `[skip ci]`)
- Wiki: `Home.md`, `FAQ.md`, `Streaming-vs-Batch.md` (separate push to the wiki repo)

PR runs are **read-only**: count is logged but nothing is mutated, so forks cannot trigger writes.

**Requires one new repo secret:** `ABOUT_SYNC_TOKEN`
- Classic PAT with `repo` scope, **or**
- Fine-grained PAT with `Administration: write` + `Contents: write` on `kingchenc/wickra`.

Without the secret the workflow fails on the first push to `main` — set it before merging or expect a red check on the merge commit.

## Trigger matrix impact

| Workflow | Trigger | Checks |
|---|---|---|
| `ci.yml` | push to main, PR | 28 |
| `release.yml` | tag `v*` | 18 |
| **`sync-about.yml`** (new) | push to main, PR, tag `v*` | **1** |

- Normal push/PR: 28 + 1 = **29** checks
- Tag-Push `v*` (commits + tag together): 28 + 18 + 2 = **48** checks

## Test plan

- [ ] Create `ABOUT_SYNC_TOKEN` repo secret before merge.
- [ ] After merge, manually trigger via Actions → "Sync indicator count" → Run workflow.
- [ ] Verify log shows `Indicator count: 71` and either `About unchanged.` or an update line.
- [ ] Confirm no spurious commit is made (since 71 already matches everywhere).
- [ ] Add a new indicator in a follow-up PR and confirm the counter auto-bumps.