### PR TITLE
fix(ci): Drop site/index.md from sync-about workflow

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -41,24 +41,24 @@ jobs:
             echo "About updated."
           fi
 
-      - name: Patch README + site counters
+      - name: Patch README counter
         if: github.event_name != 'pull_request'
         id: patch
         run: |
           n="${{ steps.count.outputs.count }}"
-          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" README.md site/index.md
+          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" README.md
           if git diff --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit & push README + site
+      - name: Commit & push README
         if: steps.patch.outputs.changed == 'true' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         run: |
           git config user.name "wickra-bot"
           git config user.email "wickra-bot@users.noreply.github.com"
-          git add README.md site/index.md
+          git add README.md
           git commit -m "chore: sync indicator count to ${{ steps.count.outputs.count }} [skip ci]"
           git push
 


### PR DESCRIPTION
## Summary

`site/` is local-only (listed in `.git/info/exclude`), so the `sed` call inside the `Patch README + site counters` step aborted the workflow on every push to `main` with:

```
sed: can't read site/index.md: No such file or directory
```

That aborted the run before the README-commit and Wiki-sync steps could run. See the failing post-merge run after #39: https://github.com/kingchenc/wickra/actions/runs/26401833883/job/77715736760

## Changes

- Drop `site/index.md` from the `sed` and `git add` lists.
- Rename the two steps from `… README + site …` to `… README …`.

About-description sync, README patch, and Wiki sync are now independent again. site/ stays out of CI until the marketing site is promoted from local-only.

## Test plan

- [x] PR runs are read-only (count is logged, nothing mutated)
- [ ] After merge: `Sync indicator count` workflow on `main` succeeds, README line 198 gets updated from 71 to 78, Wiki gets a sync commit if any of its three target pages still says 71