### PR TITLE
chore(migration): switch org to wickra-lib + maintainer email

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # The owner listed here is requested for review automatically on every pull
 # request. See https://docs.github.com/articles/about-code-owners.
 
-*       @kingchenc
+*       @wickra-lib

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/kingchenc/wickra/security/advisories/new
+    url: https://github.com/wickra-lib/wickra/security/advisories/new
     about: Report security issues privately — do not open a public issue.
   - name: Question or discussion
-    url: https://github.com/kingchenc/wickra/discussions
+    url: https://github.com/wickra-lib/wickra/discussions
     about: Ask usage questions and discuss ideas here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,9 +24,9 @@
 - [ ] New behaviour has tests; bug fixes have a regression test.
 - [ ] Public API changes are mirrored in the Python / Node / WASM bindings
       and their type stubs (If applicable).
-- [ ] The relevant page on the [project Wiki](https://github.com/kingchenc/wickra/wiki)
+- [ ] The relevant page on the [project Wiki](https://github.com/wickra-lib/wickra/wiki)
       and the `README.md` are updated (If applicable). Wiki edits go to a
-      separate repository: `https://github.com/kingchenc/wickra.wiki.git`.
+      separate repository: `https://github.com/wickra-lib/wickra.wiki.git`.
 - [ ] An entry was added under `## [Unreleased]` in `CHANGELOG.md`.
 
 ## Notes for reviewers

--- a/.github/scripts/sync-metadata.py
+++ b/.github/scripts/sync-metadata.py
@@ -1,0 +1,113 @@
+"""Audit that no file in the repo contains the pre-migration org slug or
+maintainer email. Driven by `repo-metadata.toml` at the repo root.
+
+This is the read-only side of the metadata pipeline. It does not patch any
+files — it just fails CI when drift sneaks in. Pair with a future
+`--write` mode (auto-fix + signed commit on main) once the migration has
+settled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+METADATA_PATH = REPO_ROOT / "repo-metadata.toml"
+
+
+def load_metadata() -> dict:
+    with METADATA_PATH.open("rb") as f:
+        return tomllib.load(f)
+
+
+def is_allowlisted(rel_path: str, allowlist: list[str]) -> bool:
+    norm = rel_path.replace(os.sep, "/")
+    for entry in allowlist:
+        entry_norm = entry.replace(os.sep, "/")
+        if entry_norm.endswith("/"):
+            if norm.startswith(entry_norm):
+                return True
+        else:
+            if norm == entry_norm:
+                return True
+    return False
+
+
+def tracked_files() -> list[str]:
+    """List git-tracked files relative to the repo root."""
+    out = subprocess.run(
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def scan(forbidden: list[str], allowlist: list[str]) -> list[tuple[str, int, str, str]]:
+    """Return a list of (rel_path, line_no, needle, line_text) findings.
+
+    Only git-tracked files are scanned, so local-only ghost-ignored files
+    (`.claude/`, drafts) never trigger false positives.
+    """
+    findings: list[tuple[str, int, str, str]] = []
+    for rel_path in tracked_files():
+        if is_allowlisted(rel_path, allowlist):
+            continue
+        abs_path = REPO_ROOT / rel_path
+        if not abs_path.is_file():
+            continue
+        try:
+            lines = abs_path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(lines, start=1):
+            for needle in forbidden:
+                if needle in line:
+                    findings.append((rel_path, lineno, needle, line.strip()))
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="audit-only (default)")
+    args = parser.parse_args()
+    _ = args  # currently only --check is supported
+
+    meta = load_metadata()
+    audit = meta.get("audit", {})
+    forbidden: list[str] = list(audit.get("forbidden", []))
+    allowlist: list[str] = list(audit.get("allowlist", []))
+
+    if not forbidden:
+        print("repo-metadata.toml [audit].forbidden is empty — nothing to scan.")
+        return 0
+
+    findings = scan(forbidden, allowlist)
+    if findings:
+        print(f"sync-metadata: {len(findings)} forbidden-substring hits:", file=sys.stderr)
+        for rel_path, lineno, needle, text in findings:
+            print(f"  {rel_path}:{lineno}: matched {needle!r}", file=sys.stderr)
+            print(f"      {text}", file=sys.stderr)
+        print(
+            "\nUpdate the offending lines to use the values from repo-metadata.toml,",
+            "or add the path to [audit].allowlist if the reference is intentional",
+            "(e.g. historical CHANGELOG entries).",
+            file=sys.stderr,
+        )
+        return 1
+
+    org = meta["repo"]["org"]
+    email = meta["maintainer"]["email"]
+    print(f"sync-metadata: clean. org={org!r} email={email!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,10 +384,10 @@ jobs:
           node -e "
             const fs = require('fs');
             const pkg = JSON.parse(fs.readFileSync('package.json'));
-            pkg.author = 'kingchenc <kingchencp@gmail.com>';
-            pkg.repository = { type: 'git', url: 'https://github.com/kingchenc/wickra' };
-            pkg.homepage = 'https://github.com/kingchenc/wickra';
-            pkg.bugs = { url: 'https://github.com/kingchenc/wickra/issues' };
+            pkg.author = 'kingchenc <wickra.lib@gmail.com>';
+            pkg.repository = { type: 'git', url: 'https://github.com/wickra-lib/wickra' };
+            pkg.homepage = 'https://github.com/wickra-lib/wickra';
+            pkg.bugs = { url: 'https://github.com/wickra-lib/wickra/issues' };
             pkg.license = 'PolyForm-Noncommercial-1.0.0';
             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
           "

--- a/.github/workflows/sync-metadata.yml
+++ b/.github/workflows/sync-metadata.yml
@@ -1,0 +1,22 @@
+name: sync-metadata
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: metadata audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Audit repo-metadata.toml drift
+        run: python .github/scripts/sync-metadata.py --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -817,14 +817,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/kingchenc/wickra/compare/v0.2.7...HEAD
-[0.2.7]: https://github.com/kingchenc/wickra/compare/v0.2.6...v0.2.7
-[0.2.6]: https://github.com/kingchenc/wickra/compare/v0.2.5...v0.2.6
-[0.2.5]: https://github.com/kingchenc/wickra/compare/v0.2.1...v0.2.5
-[0.2.1]: https://github.com/kingchenc/wickra/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/kingchenc/wickra/compare/v0.1.4...v0.2.0
-[0.1.4]: https://github.com/kingchenc/wickra/compare/v0.1.3...v0.1.4
-[0.1.3]: https://github.com/kingchenc/wickra/compare/v0.1.2...v0.1.3
-[0.1.2]: https://github.com/kingchenc/wickra/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/kingchenc/wickra/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/kingchenc/wickra/releases/tag/v0.1.0
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.2.7...HEAD
+[0.2.7]: https://github.com/wickra-lib/wickra/compare/v0.2.6...v0.2.7
+[0.2.6]: https://github.com/wickra-lib/wickra/compare/v0.2.5...v0.2.6
+[0.2.5]: https://github.com/wickra-lib/wickra/compare/v0.2.1...v0.2.5
+[0.2.1]: https://github.com/wickra-lib/wickra/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/wickra-lib/wickra/compare/v0.1.4...v0.2.0
+[0.1.4]: https://github.com/wickra-lib/wickra/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/wickra-lib/wickra/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/wickra-lib/wickra/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/wickra-lib/wickra/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/wickra-lib/wickra/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -33,7 +33,7 @@ project in public spaces.
 ## Enforcement
 
 Instances of unacceptable behaviour may be reported to the project maintainer
-at **kingchencp@gmail.com**. All reports will be reviewed and investigated
+at **wickra.lib@gmail.com**. All reports will be reviewed and investigated
 promptly and fairly, and the maintainer will respect the privacy and security
 of the reporter.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,9 +76,9 @@ wasm-pack test --node bindings/wasm
 - **Bindings.** A change to a public indicator API must be mirrored across the
   Python, Node, and WASM bindings, including their type stubs / `.d.ts`.
 - **Docs.** Update the relevant page on the
-  [project Wiki](https://github.com/kingchenc/wickra/wiki) and the
+  [project Wiki](https://github.com/wickra-lib/wickra/wiki) and the
   `README.md` when behaviour or the public API changes. The Wiki lives in
-  a separate git repository: `https://github.com/kingchenc/wickra.wiki.git`.
+  a separate git repository: `https://github.com/wickra-lib/wickra.wiki.git`.
 - **Changelog.** Add an entry under `## [Unreleased]` in `CHANGELOG.md`.
 
 ## Commit and pull-request workflow

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ exclude = ["fuzz"]
 
 [workspace.package]
 version = "0.2.7"
-authors = ["kingchenc <kingchencp@gmail.com>"]
+authors = ["kingchenc <wickra.lib@gmail.com>"]
 edition = "2021"
 rust-version = "1.86"
 license = "PolyForm-Noncommercial-1.0.0"
-repository = "https://github.com/kingchenc/wickra"
-homepage = "https://github.com/kingchenc/wickra"
+repository = "https://github.com/wickra-lib/wickra"
+homepage = "https://github.com/wickra-lib/wickra"
 readme = "README.md"
 keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]

--- a/LICENSE
+++ b/LICENSE
@@ -35,7 +35,7 @@ URL for them above, as well as copies of any plain-text lines
 beginning with `Required Notice:` that the licensor provided
 with the software. For example:
 
-> Required Notice: Copyright 2026 kingchenc (https://github.com/kingchenc/wickra)
+> Required Notice: Copyright 2026 kingchenc (https://github.com/wickra-lib/wickra)
 
 ## Changes and New Works License
 
@@ -133,4 +133,4 @@ of your licenses.
 
 ---
 
-Required Notice: Copyright 2026 kingchenc (https://github.com/kingchenc/wickra)
+Required Notice: Copyright 2026 kingchenc (https://github.com/wickra-lib/wickra)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Wickra
 
-[![CI](https://github.com/kingchenc/wickra/actions/workflows/ci.yml/badge.svg)](https://github.com/kingchenc/wickra/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/kingchenc/wickra/branch/main/graph/badge.svg)](https://codecov.io/gh/kingchenc/wickra)
+[![CI](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml/badge.svg)](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/wickra-lib/wickra/branch/main/graph/badge.svg)](https://codecov.io/gh/wickra-lib/wickra)
 [![crates.io](https://img.shields.io/crates/v/wickra.svg?logo=rust&color=orange)](https://crates.io/crates/wickra)
 [![PyPI](https://img.shields.io/pypi/v/wickra.svg?logo=pypi&color=blue)](https://pypi.org/project/wickra/)
 [![npm](https://img.shields.io/npm/v/wickra.svg?logo=npm&color=red)](https://www.npmjs.com/package/wickra)
@@ -264,7 +264,7 @@ Every layer is covered; run the suites with the commands in
 ## Contributing
 
 Contributions are very welcome — issues, bug reports, ideas, and pull requests
-all land in the same place: <https://github.com/kingchenc/wickra>.
+all land in the same place: <https://github.com/wickra-lib/wickra>.
 
 A short orientation for first-time contributors:
 
@@ -308,14 +308,14 @@ The library is provided **as is**, without warranty of any kind; see
 ---
 
 <p align="center">
-  <a href="https://github.com/kingchenc/wickra/stargazers">
-    <img alt="GitHub stars" src="https://img.shields.io/github/stars/kingchenc/wickra?style=for-the-badge&logo=github&logoColor=white&color=ffd866">
+  <a href="https://github.com/wickra-lib/wickra/stargazers">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=ffd866">
   </a>
-  <a href="https://github.com/kingchenc/wickra/network/members">
-    <img alt="GitHub forks" src="https://img.shields.io/github/forks/kingchenc/wickra?style=for-the-badge&logo=github&logoColor=white&color=78dce8">
+  <a href="https://github.com/wickra-lib/wickra/network/members">
+    <img alt="GitHub forks" src="https://img.shields.io/github/forks/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=78dce8">
   </a>
-  <a href="https://github.com/kingchenc/wickra/issues">
-    <img alt="GitHub issues" src="https://img.shields.io/github/issues/kingchenc/wickra?style=for-the-badge&logo=github&logoColor=white&color=ff6188">
+  <a href="https://github.com/wickra-lib/wickra/issues">
+    <img alt="GitHub issues" src="https://img.shields.io/github/issues/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=ff6188">
   </a>
 </p>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,9 +16,9 @@ version only; please upgrade to the newest release before reporting an issue.
 
 Report it privately through one of:
 
-- GitHub's [private vulnerability reporting](https://github.com/kingchenc/wickra/security/advisories/new)
+- GitHub's [private vulnerability reporting](https://github.com/wickra-lib/wickra/security/advisories/new)
   ("Report a vulnerability" under the repository's *Security* tab), or
-- email to **kingchencp@gmail.com** with a subject line starting with
+- email to **wickra.lib@gmail.com** with a subject line starting with
   `[wickra security]`.
 
 Please include:

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -1,7 +1,7 @@
 # Wickra
 
-[![CI](https://github.com/kingchenc/wickra/actions/workflows/ci.yml/badge.svg)](https://github.com/kingchenc/wickra/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/kingchenc/wickra/branch/main/graph/badge.svg)](https://codecov.io/gh/kingchenc/wickra)
+[![CI](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml/badge.svg)](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/wickra-lib/wickra/branch/main/graph/badge.svg)](https://codecov.io/gh/wickra-lib/wickra)
 [![crates.io](https://img.shields.io/crates/v/wickra.svg?logo=rust&color=orange)](https://crates.io/crates/wickra)
 [![PyPI](https://img.shields.io/pypi/v/wickra.svg?logo=pypi&color=blue)](https://pypi.org/project/wickra/)
 [![npm](https://img.shields.io/npm/v/wickra.svg?logo=npm&color=red)](https://www.npmjs.com/package/wickra)
@@ -256,7 +256,7 @@ Every layer is covered; run the suites with the commands in
 ## Contributing
 
 Contributions are very welcome — issues, bug reports, ideas, and pull requests
-all land in the same place: <https://github.com/kingchenc/wickra>.
+all land in the same place: <https://github.com/wickra-lib/wickra>.
 
 A short orientation for first-time contributors:
 
@@ -290,14 +290,14 @@ use Wickra commercially, get in touch about a license.
 ---
 
 <p align="center">
-  <a href="https://github.com/kingchenc/wickra/stargazers">
-    <img alt="GitHub stars" src="https://img.shields.io/github/stars/kingchenc/wickra?style=for-the-badge&logo=github&logoColor=white&color=ffd866">
+  <a href="https://github.com/wickra-lib/wickra/stargazers">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=ffd866">
   </a>
-  <a href="https://github.com/kingchenc/wickra/network/members">
-    <img alt="GitHub forks" src="https://img.shields.io/github/forks/kingchenc/wickra?style=for-the-badge&logo=github&logoColor=white&color=78dce8">
+  <a href="https://github.com/wickra-lib/wickra/network/members">
+    <img alt="GitHub forks" src="https://img.shields.io/github/forks/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=78dce8">
   </a>
-  <a href="https://github.com/kingchenc/wickra/issues">
-    <img alt="GitHub issues" src="https://img.shields.io/github/issues/kingchenc/wickra?style=for-the-badge&logo=github&logoColor=white&color=ff6188">
+  <a href="https://github.com/wickra-lib/wickra/issues">
+    <img alt="GitHub issues" src="https://img.shields.io/github/issues/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=ff6188">
   </a>
 </p>
 

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kingchenc/wickra"
+    "url": "https://github.com/wickra-lib/wickra"
   },
-  "homepage": "https://github.com/kingchenc/wickra"
+  "homepage": "https://github.com/wickra-lib/wickra"
 }

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kingchenc/wickra"
+    "url": "https://github.com/wickra-lib/wickra"
   },
-  "homepage": "https://github.com/kingchenc/wickra"
+  "homepage": "https://github.com/wickra-lib/wickra"
 }

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -21,7 +21,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kingchenc/wickra"
+    "url": "https://github.com/wickra-lib/wickra"
   },
-  "homepage": "https://github.com/kingchenc/wickra"
+  "homepage": "https://github.com/wickra-lib/wickra"
 }

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -21,7 +21,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kingchenc/wickra"
+    "url": "https://github.com/wickra-lib/wickra"
   },
-  "homepage": "https://github.com/kingchenc/wickra"
+  "homepage": "https://github.com/wickra-lib/wickra"
 }

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kingchenc/wickra"
+    "url": "https://github.com/wickra-lib/wickra"
   },
-  "homepage": "https://github.com/kingchenc/wickra"
+  "homepage": "https://github.com/wickra-lib/wickra"
 }

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kingchenc/wickra"
+    "url": "https://github.com/wickra-lib/wickra"
   },
-  "homepage": "https://github.com/kingchenc/wickra"
+  "homepage": "https://github.com/wickra-lib/wickra"
 }

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -2,7 +2,7 @@
   "name": "wickra",
   "version": "0.2.7",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
-  "author": "kingchenc <kingchencp@gmail.com>",
+  "author": "kingchenc <wickra.lib@gmail.com>",
   "main": "index.js",
   "types": "index.d.ts",
   "license": "PolyForm-Noncommercial-1.0.0",
@@ -17,12 +17,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kingchenc/wickra"
+    "url": "https://github.com/wickra-lib/wickra"
   },
   "bugs": {
-    "url": "https://github.com/kingchenc/wickra/issues"
+    "url": "https://github.com/wickra-lib/wickra/issues"
   },
-  "homepage": "https://github.com/kingchenc/wickra",
+  "homepage": "https://github.com/wickra-lib/wickra",
   "files": [
     "index.js",
     "index.d.ts",

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,7 +1,7 @@
 # Wickra
 
-[![CI](https://github.com/kingchenc/wickra/actions/workflows/ci.yml/badge.svg)](https://github.com/kingchenc/wickra/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/kingchenc/wickra/branch/main/graph/badge.svg)](https://codecov.io/gh/kingchenc/wickra)
+[![CI](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml/badge.svg)](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/wickra-lib/wickra/branch/main/graph/badge.svg)](https://codecov.io/gh/wickra-lib/wickra)
 [![crates.io](https://img.shields.io/crates/v/wickra.svg?logo=rust&color=orange)](https://crates.io/crates/wickra)
 [![PyPI](https://img.shields.io/pypi/v/wickra.svg?logo=pypi&color=blue)](https://pypi.org/project/wickra/)
 [![npm](https://img.shields.io/npm/v/wickra.svg?logo=npm&color=red)](https://www.npmjs.com/package/wickra)
@@ -256,7 +256,7 @@ Every layer is covered; run the suites with the commands in
 ## Contributing
 
 Contributions are very welcome — issues, bug reports, ideas, and pull requests
-all land in the same place: <https://github.com/kingchenc/wickra>.
+all land in the same place: <https://github.com/wickra-lib/wickra>.
 
 A short orientation for first-time contributors:
 
@@ -290,14 +290,14 @@ use Wickra commercially, get in touch about a license.
 ---
 
 <p align="center">
-  <a href="https://github.com/kingchenc/wickra/stargazers">
-    <img alt="GitHub stars" src="https://img.shields.io/github/stars/kingchenc/wickra?style=for-the-badge&logo=github&logoColor=white&color=ffd866">
+  <a href="https://github.com/wickra-lib/wickra/stargazers">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=ffd866">
   </a>
-  <a href="https://github.com/kingchenc/wickra/network/members">
-    <img alt="GitHub forks" src="https://img.shields.io/github/forks/kingchenc/wickra?style=for-the-badge&logo=github&logoColor=white&color=78dce8">
+  <a href="https://github.com/wickra-lib/wickra/network/members">
+    <img alt="GitHub forks" src="https://img.shields.io/github/forks/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=78dce8">
   </a>
-  <a href="https://github.com/kingchenc/wickra/issues">
-    <img alt="GitHub issues" src="https://img.shields.io/github/issues/kingchenc/wickra?style=for-the-badge&logo=github&logoColor=white&color=ff6188">
+  <a href="https://github.com/wickra-lib/wickra/issues">
+    <img alt="GitHub issues" src="https://img.shields.io/github/issues/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=ff6188">
   </a>
 </p>
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.2.7"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = { text = "PolyForm-Noncommercial-1.0.0" }
-authors = [{ name = "kingchenc", email = "kingchencp@gmail.com" }]
+authors = [{ name = "kingchenc", email = "wickra.lib@gmail.com" }]
 requires-python = ">=3.9"
 keywords = ["finance", "trading", "indicators", "technical-analysis", "ta-lib"]
 classifiers = [
@@ -47,9 +47,9 @@ bench = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/kingchenc/wickra"
-Repository = "https://github.com/kingchenc/wickra"
-Issues = "https://github.com/kingchenc/wickra/issues"
+Homepage = "https://github.com/wickra-lib/wickra"
+Repository = "https://github.com/wickra-lib/wickra"
+Issues = "https://github.com/wickra-lib/wickra/issues"
 
 [tool.maturin]
 manifest-path = "Cargo.toml"

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -1,7 +1,7 @@
 # Wickra
 
-[![CI](https://github.com/kingchenc/wickra/actions/workflows/ci.yml/badge.svg)](https://github.com/kingchenc/wickra/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/kingchenc/wickra/branch/main/graph/badge.svg)](https://codecov.io/gh/kingchenc/wickra)
+[![CI](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml/badge.svg)](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/wickra-lib/wickra/branch/main/graph/badge.svg)](https://codecov.io/gh/wickra-lib/wickra)
 [![crates.io](https://img.shields.io/crates/v/wickra.svg?logo=rust&color=orange)](https://crates.io/crates/wickra)
 [![PyPI](https://img.shields.io/pypi/v/wickra.svg?logo=pypi&color=blue)](https://pypi.org/project/wickra/)
 [![npm](https://img.shields.io/npm/v/wickra.svg?logo=npm&color=red)](https://www.npmjs.com/package/wickra)
@@ -256,7 +256,7 @@ Every layer is covered; run the suites with the commands in
 ## Contributing
 
 Contributions are very welcome — issues, bug reports, ideas, and pull requests
-all land in the same place: <https://github.com/kingchenc/wickra>.
+all land in the same place: <https://github.com/wickra-lib/wickra>.
 
 A short orientation for first-time contributors:
 
@@ -290,14 +290,14 @@ use Wickra commercially, get in touch about a license.
 ---
 
 <p align="center">
-  <a href="https://github.com/kingchenc/wickra/stargazers">
-    <img alt="GitHub stars" src="https://img.shields.io/github/stars/kingchenc/wickra?style=for-the-badge&logo=github&logoColor=white&color=ffd866">
+  <a href="https://github.com/wickra-lib/wickra/stargazers">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=ffd866">
   </a>
-  <a href="https://github.com/kingchenc/wickra/network/members">
-    <img alt="GitHub forks" src="https://img.shields.io/github/forks/kingchenc/wickra?style=for-the-badge&logo=github&logoColor=white&color=78dce8">
+  <a href="https://github.com/wickra-lib/wickra/network/members">
+    <img alt="GitHub forks" src="https://img.shields.io/github/forks/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=78dce8">
   </a>
-  <a href="https://github.com/kingchenc/wickra/issues">
-    <img alt="GitHub issues" src="https://img.shields.io/github/issues/kingchenc/wickra?style=for-the-badge&logo=github&logoColor=white&color=ff6188">
+  <a href="https://github.com/wickra-lib/wickra/issues">
+    <img alt="GitHub issues" src="https://img.shields.io/github/issues/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=ff6188">
   </a>
 </p>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,28 +1,28 @@
 # Documentation
 
-Wickra's full documentation lives in the **[GitHub Wiki](https://github.com/kingchenc/wickra/wiki)**.
+Wickra's full documentation lives in the **[GitHub Wiki](https://github.com/wickra-lib/wickra/wiki)**.
 
 That includes:
 
-- **Quickstarts** for [Rust](https://github.com/kingchenc/wickra/wiki/Quickstart-Rust.md),
-  [Python](https://github.com/kingchenc/wickra/wiki/Quickstart-Python.md),
-  [Node](https://github.com/kingchenc/wickra/wiki/Quickstart-Node.md), and
-  [WASM](https://github.com/kingchenc/wickra/wiki/Quickstart-WASM.md).
+- **Quickstarts** for [Rust](https://github.com/wickra-lib/wickra/wiki/Quickstart-Rust.md),
+  [Python](https://github.com/wickra-lib/wickra/wiki/Quickstart-Python.md),
+  [Node](https://github.com/wickra-lib/wickra/wiki/Quickstart-Node.md), and
+  [WASM](https://github.com/wickra-lib/wickra/wiki/Quickstart-WASM.md).
 - A per-indicator deep dive for every one of the **71 indicators** across
   the eight families (Moving Averages, Momentum Oscillators, Trend &
   Directional, Price Oscillators, Volatility & Bands, Trailing Stops,
   Volume, Price Statistics) — see the
-  [indicators overview](https://github.com/kingchenc/wickra/wiki/Indicators-Overview.md).
-- **Reference pages**: [warmup periods](https://github.com/kingchenc/wickra/wiki/Warmup-Periods.md),
-  [streaming vs batch](https://github.com/kingchenc/wickra/wiki/Streaming-vs-Batch.md),
-  [indicator chaining](https://github.com/kingchenc/wickra/wiki/Indicator-Chaining.md), and the
-  [data layer](https://github.com/kingchenc/wickra/wiki/Data-Layer.md).
-- **Guides**: [Cookbook](https://github.com/kingchenc/wickra/wiki/Cookbook.md),
-  [TA-Lib migration](https://github.com/kingchenc/wickra/wiki/TA-Lib-Migration.md),
-  [FAQ](https://github.com/kingchenc/wickra/wiki/FAQ.md).
+  [indicators overview](https://github.com/wickra-lib/wickra/wiki/Indicators-Overview.md).
+- **Reference pages**: [warmup periods](https://github.com/wickra-lib/wickra/wiki/Warmup-Periods.md),
+  [streaming vs batch](https://github.com/wickra-lib/wickra/wiki/Streaming-vs-Batch.md),
+  [indicator chaining](https://github.com/wickra-lib/wickra/wiki/Indicator-Chaining.md), and the
+  [data layer](https://github.com/wickra-lib/wickra/wiki/Data-Layer.md).
+- **Guides**: [Cookbook](https://github.com/wickra-lib/wickra/wiki/Cookbook.md),
+  [TA-Lib migration](https://github.com/wickra-lib/wickra/wiki/TA-Lib-Migration.md),
+  [FAQ](https://github.com/wickra-lib/wickra/wiki/FAQ.md).
 
 ## Editing the wiki
 
-The wiki is a separate git repository at `https://github.com/kingchenc/wickra.wiki.git`.
+The wiki is a separate git repository at `https://github.com/wickra-lib/wickra.wiki.git`.
 Clone it locally if you want to bulk-edit; otherwise the GitHub web UI's "Edit" button on any
 wiki page is fine for one-off changes.

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -45,7 +45,7 @@ Then open the demo you want at `http://localhost:8000/examples/wasm/<file>`.
 
 ## See also
 
-- [Quickstart: WASM](https://github.com/kingchenc/wickra/wiki/Quickstart-WASM.md) — module-load
+- [Quickstart: WASM](https://github.com/wickra-lib/wickra/wiki/Quickstart-WASM.md) — module-load
   flow, `wasm-pack` targets, and the streaming API.
 - [examples/README.md](../README.md) — cross-language index, including
   the Rust, Python and Node siblings of every demo above.

--- a/repo-metadata.toml
+++ b/repo-metadata.toml
@@ -1,0 +1,54 @@
+# Single source of truth for repo-level identity (org slug, maintainer email,
+# canonical URLs). The audit workflow `.github/workflows/sync-metadata.yml`
+# parses this file and fails CI if any tracked file disagrees.
+#
+# Do NOT edit downstream files by hand for these fields. Edit here, then run
+# the workflow locally to spot drift, fix the downstream files until the
+# audit is green.
+
+[repo]
+org          = "wickra-lib"
+name         = "wickra"
+url          = "https://github.com/wickra-lib/wickra"
+wiki_url     = "https://github.com/wickra-lib/wickra/wiki"
+wiki_git     = "https://github.com/wickra-lib/wickra.wiki.git"
+issues_url   = "https://github.com/wickra-lib/wickra/issues"
+discussions  = "https://github.com/wickra-lib/wickra/discussions"
+security_url = "https://github.com/wickra-lib/wickra/security/advisories/new"
+
+[maintainer]
+# `handle` is the natural-person credit shown in package manifests; it does
+# not move with the GitHub org transfer. `github` is the org @-mention slug
+# used in CODEOWNERS and prose.
+handle = "kingchenc"
+email  = "wickra.lib@gmail.com"
+github = "wickra-lib"
+
+[badges]
+codecov_repo = "wickra-lib/wickra"
+ci_workflow  = "ci.yml"
+
+[audit]
+# Forbidden substrings that must not appear anywhere in the repo outside the
+# allowlist below. These are the pre-migration values; if any one of them
+# resurfaces in source, the audit workflow fails.
+forbidden = [
+    "kingchenc/wickra",
+    "kingchencp@gmail.com",
+]
+
+# Paths that are exempt from the forbidden-substring scan. Historical
+# CHANGELOG sections keep their prose unchanged; auto-generated and ignored
+# folders never reach the repo but are listed for parity with `.git/info/exclude`.
+allowlist = [
+    "target/",
+    "node_modules/",
+    "fuzz/target/",
+    ".venv/",
+    "Cargo.lock",
+    "package-lock.json",
+    "bindings/node/index.js",
+    "bindings/node/index.d.ts",
+    "repo-metadata.toml",
+    ".github/scripts/sync-metadata.py",
+]


### PR DESCRIPTION
## Summary

- Introduces `repo-metadata.toml` as the single source of truth for org slug, maintainer email, and canonical URLs.
- Adds `.github/workflows/sync-metadata.yml` with `.github/scripts/sync-metadata.py` audit — fails CI if any tracked file drifts back to `kingchenc/wickra` or `kingchencp@gmail.com`.
- Bulk-replaces across 24 tracked files (108 substitutions):
  - URL: `kingchenc/wickra` → `wickra-lib/wickra`
  - Email: `kingchencp@gmail.com` → `wickra.lib@gmail.com`
  - CODEOWNERS mention: `@kingchenc` → `@wickra-lib`

## What is preserved (per Section F of the migration plan)

- LICENSE copyright holder string `kingchenc` (natural person, only the URL next to it changes)
- `Cargo.toml` authors `kingchenc <...>` (handle stays, email updated)
- Historical CHANGELOG prose at line 434 (`@kingchenc` reference to the npm write-access transfer)
- Crate / PyPI / npm package names (`wickra`, `wickra-*`)

## Merge gate

**Do NOT merge before the GitHub-side org transfer** (`kingchenc/wickra` → `wickra-lib`). Otherwise every badge and repo link in README hits a 404 until the transfer is performed.

Sequence:
1. Wait for `feat/family-api` PR (companion) to also be green
2. User: GitHub-UI transfer + Wiki transfer + re-add secrets on `wickra-lib` org page (incl. new `META_SYNC_TOKEN` PAT for sync-metadata.yml main-mode auto-commits, currently audit-only)
3. User: Codecov re-connect
4. Merge this PR + the family-api PR
5. Follow-up wiki commit (separate repo)

## CI expectation

29 existing checks + new `sync-metadata / metadata audit` job = 30 total. All must be green.