### PR TITLE
release: bump 0.2.7 -> 0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-05-27
+
+### Changed
+- **GitHub org migrated from `kingchenc` to `wickra-lib`.** All repository URLs
+  in badges, manifests, READMEs, license notice, and CHANGELOG compare links
+  now point at `https://github.com/wickra-lib/wickra`. Maintainer contact
+  email switched to `wickra.lib@gmail.com` (SECURITY.md and
+  CODE_OF_CONDUCT.md). Package names on crates.io / PyPI / npm are
+  unchanged. GitHub's automatic 301-redirects keep the old URLs working,
+  but new references should use the new ones.
+
 ### Added
+- **`wickra_core::FAMILIES` constant.** A machine-readable `&[(&str, &[&str])]`
+  taxonomy that maps each built-in indicator to one of 16 families. Comes
+  with two compile-time guards (`no_duplicates_across_families`,
+  `total_count_matches_expected`) so the table cannot drift silently as
+  new indicators are added.
+- **`repo-metadata.toml` + `.github/workflows/sync-metadata.yml`** — single
+  source of truth for repo identity (org, email, canonical URLs) plus an
+  audit workflow that fails CI if any tracked file drifts back to a
+  pre-migration value.
 - **Family 15 — Risk / Performance metrics (17 new indicators).** Implemented
   pragmatically as standard `Indicator`s rather than a separate
   `wickra-metrics` crate; the input is a scalar `f64` per bar (period return,
@@ -817,7 +837,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/kingchenc/wickra/compare/v0.2.7...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.2.8...HEAD
+[0.2.8]: https://github.com/wickra-lib/wickra/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/kingchenc/wickra/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/kingchenc/wickra/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/kingchenc/wickra/compare/v0.2.1...v0.2.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "approx",
  "criterion",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "approx",
  "proptest",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "approx",
  "csv",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "napi",
  "napi-build",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "numpy",
  "pyo3",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.2.7"
+version = "0.2.8"
 authors = ["kingchenc <kingchencp@gmail.com>"]
 edition = "2021"
 rust-version = "1.86"
@@ -24,7 +24,7 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.2.7" }
+wickra-core = { path = "crates/wickra-core", version = "0.2.8" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <kingchencp@gmail.com>",
   "main": "index.js",
@@ -47,12 +47,12 @@
     "node": ">= 18"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.2.7",
-    "wickra-linux-arm64-gnu": "0.2.7",
-    "wickra-darwin-x64": "0.2.7",
-    "wickra-darwin-arm64": "0.2.7",
-    "wickra-win32-x64-msvc": "0.2.7",
-    "wickra-win32-arm64-msvc": "0.2.7"
+    "wickra-linux-x64-gnu": "0.2.8",
+    "wickra-linux-arm64-gnu": "0.2.8",
+    "wickra-darwin-x64": "0.2.8",
+    "wickra-darwin-arm64": "0.2.8",
+    "wickra-win32-x64-msvc": "0.2.8",
+    "wickra-win32-arm64-msvc": "0.2.8"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.2.7"
+version = "0.2.8"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = { text = "PolyForm-Noncommercial-1.0.0" }


### PR DESCRIPTION
## Summary

Version bump from `0.2.7` to `0.2.8` across the workspace and all binding manifests, plus the corresponding CHANGELOG section opening this release.

## Files touched (11)

- `Cargo.toml` — workspace package version + `wickra-core` workspace dependency
- `bindings/python/pyproject.toml`
- `bindings/node/package.json` — main version + 6 `optionalDependencies` entries
- 6× `bindings/node/npm/*/package.json` — platform sub-packages
- `CHANGELOG.md` — opens `[0.2.8] - 2026-05-27` section, reseeds `[Unreleased]`, adds new compare URL
- `Cargo.lock` — regenerated by `cargo check`

## What 0.2.8 contains

- **GitHub org migration** (`kingchenc/wickra` → `wickra-lib/wickra`) — see PR #59
- **`FAMILIES` const + 16-family taxonomy** — see PR #60
- All Family 12-16 indicators that already landed on main since 0.2.7 (Statistik/Regression, Ichimoku, Candlesticks, Market Profile, Risk/Performance)

## Merge order (important!)

1. PR #59 (org migration) — requires GitHub-side org transfer first
2. PR #60 (family-api) — independent, can land anytime post-transfer
3. **This PR** — rebase on top of #59 + #60, then merge
4. **Manual tag-push `v0.2.8`** (user, AFTER merge) — triggers `release.yml`'s irreversible publish to crates.io / PyPI / npm

The new `[0.2.8]` and `[Unreleased]` compare URLs in this PR already point at `wickra-lib/wickra` because they will only be valid post-#59-merge. The 11 historical URLs at the bottom of the file still show `kingchenc/wickra` — PR #59 rewrites those in its diff, this PR does not touch them.

## CI expectation

- Pre-#59-merge: ~29 standard checks (sync-metadata.yml audit doesn't exist on this branch yet).
- Post-rebase on #59-merged main: 30 checks including audit, all green.