### PR TITLE
feat(release): add CycloneDX SBOMs and npm provenance attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,30 @@ jobs:
           name: crate-files
           path: target/package/*.crate
 
+      # CycloneDX SBOM per published crate. Attached to the GitHub Release
+      # alongside the .crate / .whl / .tgz artefacts so downstream
+      # consumers can audit the published dependency tree without
+      # re-resolving Cargo.lock.
+      - name: Install cargo-cyclonedx
+        uses: taiki-e/install-action@6c1f7cf125e42770ff087ea443901b487cc5471a # v2.79.5
+        with:
+          tool: cargo-cyclonedx
+
+      - name: Generate CycloneDX SBOMs
+        run: |
+          cargo cyclonedx --format json --top-level -p wickra-core
+          cargo cyclonedx --format json --top-level -p wickra-data
+          cargo cyclonedx --format json --top-level -p wickra
+          mkdir -p sboms
+          find . -name "*.cdx.json" -not -path "./target/*" -exec cp {} sboms/ \;
+          ls -lh sboms/
+
+      - name: Upload SBOMs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sboms
+          path: sboms/*.cdx.json
+
   # --------------------------------------------------------------------------
   # PyPI: cross-platform wheels + sdist
   # --------------------------------------------------------------------------
@@ -208,6 +232,14 @@ jobs:
     needs: node-build
     runs-on: ubuntu-latest
     environment: release
+    # `id-token: write` lets npm publish embed a Sigstore provenance
+    # attestation generated from the GitHub Actions OIDC token. The npm
+    # registry then shows a "Verified provenance" badge and lets
+    # consumers verify the package was built from this exact workflow
+    # run.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -266,13 +298,13 @@ jobs:
             # scripts during publish (npm runs prepublishOnly/prepare/etc. from
             # the package being published — a malicious or stray script would
             # execute with the npm token in the environment).
-            (cd "$dir" && npm publish --access public --ignore-scripts)
+            (cd "$dir" && npm publish --access public --ignore-scripts --provenance)
             local rc=$?
             echo "::endgroup::"
             if [ "$rc" -ne 0 ]; then
               echo "::warning::first attempt of $pkgname failed (rc=$rc); retrying after 30s"
               sleep 30
-              (cd "$dir" && npm publish --access public --ignore-scripts)
+              (cd "$dir" && npm publish --access public --ignore-scripts --provenance)
               rc=$?
             fi
             if [ "$rc" -ne 0 ]; then
@@ -313,12 +345,12 @@ jobs:
           # --ignore-scripts so any leftover prepublish hooks (which would
           # otherwise try to republish the already-published platform
           # subpackages) can't sabotage the main publish.
-          npm publish --access public --ignore-scripts
+          npm publish --access public --ignore-scripts --provenance
           rc=$?
           if [ "$rc" -ne 0 ]; then
             echo "::warning::first attempt failed (rc=$rc); retrying after 30s"
             sleep 30
-            npm publish --access public --ignore-scripts
+            npm publish --access public --ignore-scripts --provenance
             rc=$?
           fi
           exit $rc
@@ -346,10 +378,18 @@ jobs:
   # --------------------------------------------------------------------------
   # WASM: wasm-pack build + npm publish (as `wickra-wasm`)
   # --------------------------------------------------------------------------
+  # Note: this job's npm publish call uses `--provenance` (see below),
+  # which requires the `id-token: write` permission set at the job level.
   wasm-publish:
     name: Publish wickra-wasm to npm
     runs-on: ubuntu-latest
     environment: release
+    # `id-token: write` lets npm publish embed a Sigstore provenance
+    # attestation generated from the GitHub Actions OIDC token (same
+    # mechanism as the node-publish job above).
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -405,7 +445,7 @@ jobs:
       - name: Publish wickra-wasm to npm (idempotent)
         working-directory: bindings/wasm/pkg
         run: |
-          out=$(npm publish --access public 2>&1) && echo "$out" \
+          out=$(npm publish --access public --provenance 2>&1) && echo "$out" \
             || (echo "$out" | grep -q "You cannot publish over" && echo "skip: version already on npm" \
                 || (echo "$out"; exit 1))
         env:
@@ -459,6 +499,8 @@ jobs:
           find artifacts -type f -name "wickra-*.tgz" -exec cp {} release-assets/ \;
           # Cargo .crate files (one per workspace member).
           find artifacts -type f -name "*.crate" -exec cp {} release-assets/ \;
+          # CycloneDX SBOMs (one per published crate).
+          find artifacts -type f -name "*.cdx.json" -exec cp {} release-assets/ \;
           ls -lh release-assets/
           echo "asset-count=$(ls release-assets/ | wc -l)"
 


### PR DESCRIPTION
## Summary

Two modern supply-chain-trust additions to the release pipeline. Neither changes what gets published — they only add verifiable signals attached to existing releases.

### 1. CycloneDX SBOMs per crate

\`cargo-cyclonedx\` runs in the \`cargo-publish\` job after the \`.crate\` files are built, generating one \`*.cdx.json\` per published crate (wickra-core, wickra-data, wickra). The files are uploaded as the \`sboms\` artifact and attached to the GitHub Release alongside the existing wheels / tarballs / \`.node\` binaries / \`.crate\` files.

**Why:** future security advisories can answer *is crate X transitively in wickra Y.Z?* by reading the SBOM directly, without re-resolving Cargo.lock or rebuilding the workspace. Future-proof for EU Cyber Resilience Act 2027 SBOM requirements.

### 2. npm \`--provenance\` on every npm publish call

Added to:
- main \`wickra\` package (node-publish: first attempt + retry)
- per-platform \`wickra-<triple>\` subpackages (node-publish loop)
- \`wickra-wasm\` (wasm-publish)

Publishing jobs gain \`permissions: id-token: write\` so the runner can exchange the GitHub Actions OIDC token for the npm registry. The npm page for each published version will carry the *Verified provenance* badge, proving the tarball was built by **this** workflow run and not by an arbitrary local laptop with the NPM_TOKEN.

## Skipped deliberately (potential follow-ups)

- **Sigstore cosign** signing of artefacts — different audit story; layer on top of npm-provenance later.
- **SLSA build-provenance** via \`actions/attest-build-provenance\` — would attach attestations to every artefact uniformly; npm-provenance is the more pragmatic first cut.

## Merge order

This PR touches the same file (\`release.yml\`) as PR #59 (org-email migration). #59 modifies specific URL strings in lines ~390 of the workflow; this PR adds new steps in completely different sections. **Rebase order: merge #59 first, then rebase + merge this PR.** The 3-way merge should be clean — no textual overlap.

## Verification

- \`python -c "import yaml; yaml.safe_load(open('release.yml'))"\` — YAML structure valid, 8 jobs intact.
- Dry-run requires a tag push on a throwaway tag; not exercised here.
- After merge + transfer + v0.2.8 tag, verify:
  - SBOM artefacts visible on the GitHub Release page
  - npm packages show *Verified provenance* badge on the npmjs.com page

## CI expectation

29 standard checks. \`release.yml\` itself runs only on \`v*\` tags so it does not execute on this PR.