### PR TITLE
chore(docs): refresh docs/README counter and family list; extend sync-about scope

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -1,13 +1,14 @@
 name: Sync indicator count
 
-# Indicator count appears in four places that must stay in sync with
+# Indicator count appears in five places that must stay in sync with
 # the number of `mod xxx;` lines in crates/wickra-core/src/indicators/mod.rs:
 #
 #   1. README.md prose                       — synced on PR branches (this workflow)
-#   2. GitHub repo "About" description       — synced on push to main / v* tag
-#   3. Wiki: Home.md / FAQ.md / Streaming-vs-Batch.md
+#   2. docs/README.md prose                  — synced on PR branches (this workflow)
+#   3. GitHub repo "About" description       — synced on push to main / v* tag
+#   4. Wiki: Home.md / FAQ.md / Streaming-vs-Batch.md
 #                                            — synced on push to main / v* tag
-#   4. site/index.md (local-only marketing site, not synced from CI)
+#   5. site/index.md (local-only marketing site, not synced from CI)
 #
 # Design: keep README in sync *before* a PR is merged, by pushing a
 # fix-up commit to the PR head branch. After squash-merge into main
@@ -88,29 +89,37 @@ jobs:
         id: pr_check
         run: |
           n="${{ steps.count.outputs.count }}"
+          readme_ok=false
+          docs_ok=false
           if grep -qE "^${n} streaming-first indicators" README.md; then
+            readme_ok=true
+          fi
+          if grep -qE "\*\*${n} indicators\*\*" docs/README.md; then
+            docs_ok=true
+          fi
+          if [ "$readme_ok" = "true" ] && [ "$docs_ok" = "true" ]; then
             echo "matches=true" >> "$GITHUB_OUTPUT"
-            echo "README counter already at ${n}; nothing to do."
+            echo "Counter already at ${n} in README.md + docs/README.md; nothing to do."
           else
             echo "matches=false" >> "$GITHUB_OUTPUT"
-            echo "README counter does not match ${n}; will fix up."
+            echo "Counter mismatch: README=$readme_ok docs/README=$docs_ok; will fix up."
           fi
 
       - name: Fix counter on fork PR head (read-only, fail loud)
         if: github.event_name == 'pull_request' && steps.pr_check.outputs.matches == 'false' && steps.ctx.outputs.can_push == 'false'
         run: |
           n="${{ steps.count.outputs.count }}"
-          echo "::error::README.md says a different indicator count than mod.rs (${n}). This PR is from a fork, so the workflow cannot push the fix; please update README.md to '${n} streaming-first indicators' and push again."
+          echo "::error::README.md or docs/README.md disagrees with mod.rs indicator count (${n}). This PR is from a fork, so the workflow cannot push the fix; please update both files and push again."
           exit 1
 
-      - name: Patch README on PR head
+      - name: Patch README + docs/README on PR head
         if: github.event_name == 'pull_request' && steps.pr_check.outputs.matches == 'false' && steps.ctx.outputs.can_push == 'true'
         id: pr_patch
         run: |
           n="${{ steps.count.outputs.count }}"
-          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" README.md
+          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" README.md docs/README.md
           if git diff --quiet; then
-            echo "No README changes after sed (counter regex did not match anything); skipping push."
+            echo "No changes after sed (counter regex did not match anything); skipping push."
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -121,7 +130,7 @@ jobs:
         run: |
           git config user.name "wickra-bot"
           git config user.email "wickra-bot@users.noreply.github.com"
-          git add README.md
+          git add README.md docs/README.md
           git commit -m "chore: sync indicator count to ${{ steps.count.outputs.count }}"
           git push origin "HEAD:${{ steps.ctx.outputs.head_ref }}"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,12 @@ That includes:
   [Python](https://github.com/kingchenc/wickra/wiki/Quickstart-Python.md),
   [Node](https://github.com/kingchenc/wickra/wiki/Quickstart-Node.md), and
   [WASM](https://github.com/kingchenc/wickra/wiki/Quickstart-WASM.md).
-- A per-indicator deep dive for every one of the **71 indicators** across
-  the eight families (Moving Averages, Momentum Oscillators, Trend &
-  Directional, Price Oscillators, Volatility & Bands, Trailing Stops,
-  Volume, Price Statistics) — see the
+- A per-indicator deep dive for every one of the **214 indicators** across
+  the sixteen families (Moving Averages, Momentum Oscillators, Trend &
+  Directional, Price Oscillators, Volatility & Bands, Bands & Channels,
+  Trailing Stops, Volume, Price Statistics, Ehlers / Cycle (DSP),
+  Pivots & S/R, DeMark, Ichimoku & Charts, Candlestick Patterns,
+  Market Profile, Risk / Performance) — see the
   [indicators overview](https://github.com/kingchenc/wickra/wiki/Indicators-Overview.md).
 - **Reference pages**: [warmup periods](https://github.com/kingchenc/wickra/wiki/Warmup-Periods.md),
   [streaming vs batch](https://github.com/kingchenc/wickra/wiki/Streaming-vs-Batch.md),

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ That includes:
   [Python](https://github.com/kingchenc/wickra/wiki/Quickstart-Python.md),
   [Node](https://github.com/kingchenc/wickra/wiki/Quickstart-Node.md), and
   [WASM](https://github.com/kingchenc/wickra/wiki/Quickstart-WASM.md).
-- A per-indicator deep dive for every one of the **214 indicators** across
+- A per-indicator deep dive for every one of the **213 indicators** across
   the sixteen families (Moving Averages, Momentum Oscillators, Trend &
   Directional, Price Oscillators, Volatility & Bands, Bands & Channels,
   Trailing Stops, Volume, Price Statistics, Ehlers / Cycle (DSP),


### PR DESCRIPTION
## Summary

\`docs/README.md\` still advertised *71 indicators across the eight families* from the early Wickra catalogue. The Family-9 through Family-16 batches (market profile, candlesticks, risk/performance, etc.) bumped the live count to 214 / sixteen families months ago, but this file was missed by the existing \`sync-about.yml\` workflow because the workflow only scanned \`README.md\`.

## Changes

### 1. \`docs/README.md\` content

- *71 indicators* → *214 indicators*
- *eight families* → *sixteen families*
- Inline family list expanded from 8 to all 16 (adds Bands & Channels, Ehlers / Cycle (DSP), Pivots & S/R, DeMark, Ichimoku & Charts, Candlestick Patterns, Market Profile, Risk / Performance).

### 2. \`.github/workflows/sync-about.yml\`

The PR-flow now also checks and patches \`docs/README.md\` alongside \`README.md\`. The same sed regex covers both files because docs/README's \`**N indicators**\` prose matches the existing \`[0-9]+ (streaming-first )?indicators\` pattern. The *Check counter* step explicitly verifies both files; the patch + commit steps cover both; the fork-PR error message updated to mention both files.

Wiki-sync portion of the workflow is unchanged — \`docs/README.md\` is local to the main repo, not in the wiki.

## Conflicts

This PR touches \`docs/README.md\` which PR #59 (org/email migration) also touches via URL substitutions. The two PRs touch different lines (URL strings vs counter / family-list prose), so the rebase after #59 lands should be clean.

## CI expectation

29 standard checks. The sync-about job in particular will now also probe docs/README on this very PR — its own counter is already correct (214), so the check step will report *matches=true* and skip the patch path.