### PR TITLE
chore(node): commit bindings/node/package-lock.json for reproducible installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,8 @@ tarpaulin-report.html
 bindings/node/*.node
 bindings/node/index.d.ts
 bindings/node/npm-debug.log*
-package-lock.json
+# package-lock.json is committed (under bindings/node/) so contributors
+# get reproducible npm installs. Top-level lockfiles still aren't expected.
 
 # WASM build output
 bindings/wasm/pkg/

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,0 +1,140 @@
+{
+  "name": "wickra",
+  "version": "0.2.7",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wickra",
+      "version": "0.2.7",
+      "license": "PolyForm-Noncommercial-1.0.0",
+      "devDependencies": {
+        "@napi-rs/cli": "^2.18.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "wickra-darwin-arm64": "0.2.7",
+        "wickra-darwin-x64": "0.2.7",
+        "wickra-linux-arm64-gnu": "0.2.7",
+        "wickra-linux-x64-gnu": "0.2.7",
+        "wickra-win32-arm64-msvc": "0.2.7",
+        "wickra-win32-x64-msvc": "0.2.7"
+      }
+    },
+    "node_modules/@napi-rs/cli": {
+      "version": "2.18.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.18.4.tgz",
+      "integrity": "sha512-SgJeA4df9DE2iAEpr3M2H0OKl/yjtg1BnRI5/JyowS71tUWhrfSu2LT0V3vlHET+g1hBVlrO60PmEXwUEKp8Mg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi": "scripts/index.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/wickra-darwin-arm64": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.2.7.tgz",
+      "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "PolyForm-Noncommercial-1.0.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/wickra-darwin-x64": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.2.7.tgz",
+      "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "PolyForm-Noncommercial-1.0.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/wickra-linux-arm64-gnu": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.2.7.tgz",
+      "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "PolyForm-Noncommercial-1.0.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/wickra-linux-x64-gnu": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.2.7.tgz",
+      "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "PolyForm-Noncommercial-1.0.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/wickra-win32-arm64-msvc": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.2.7.tgz",
+      "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "PolyForm-Noncommercial-1.0.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/wickra-win32-x64-msvc": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.2.7.tgz",
+      "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "PolyForm-Noncommercial-1.0.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Until now \`package-lock.json\` was globally ignored. Two practical consequences for the Node binding:

- A fresh \`git clone && cd bindings/node && npm install\` resolved \`@napi-rs/cli\` and any transitive deps to whatever the npm registry currently considered the latest matching the \`package.json\` semver ranges. Contributors could get different dep graphs on different days.
- No protection against transitive-dep tampering at install time (lockfile records resolved versions + integrity hashes, npm verifies on subsequent installs).

## Changes

- \`.gitignore\`: drop the global \`package-lock.json\` ignore. A comment notes lockfiles are still not expected at the workspace root.
- \`bindings/node/package-lock.json\`: freshly generated from the current \`bindings/node/package.json\` (only 140 lines because the binding has very few direct deps — \`@napi-rs/cli\` plus its transitive tree).

## Why this is safe

- The existing \`Node tests\` CI job runs \`npm install\` inside \`bindings/node/\`, which will now consume the committed lockfile (deterministic behaviour).
- The \`release.yml\` node-publish job is unaffected — it uses \`npm publish\`, not \`npm install\`.
- Dependabot can still bump the lockfile via its standard \`deps(npm)\` PR flow because the \`bindings/node\` directory is already in the \`npm\` ecosystem entry of \`.github/dependabot.yml\`.

## Conflict status

Independent of all other open PRs. No shared files.