### PR TITLE
docs: fix unresolved and private intra-doc links

### DIFF
--- a/crates/wickra-core/src/indicators/mama.rs
+++ b/crates/wickra-core/src/indicators/mama.rs
@@ -32,7 +32,7 @@ pub struct MamaOutput {
 /// + fama_prev * (1 - 0.5 * fast_limit)`, lagging MAMA so crossovers signal
 /// trend reversals.
 ///
-/// The indicator emits both lines as a [`MamaOutput`]. Use the [`Fama`] wrapper
+/// The indicator emits both lines as a [`MamaOutput`]. Use the [`crate::Fama`] wrapper
 /// in this module to expose just the slow line if needed (e.g. for chaining).
 ///
 /// # Example

--- a/crates/wickra-core/src/indicators/standard_error.rs
+++ b/crates/wickra-core/src/indicators/standard_error.rs
@@ -23,7 +23,7 @@ use crate::traits::Indicator;
 /// This is the textbook **standard error of estimate** of OLS: it measures
 /// the typical distance between the observed prices and the fitted line,
 /// using the residual degrees of freedom `n − 2`. It is the spread that
-/// drives [`crate::Bollinger`]-style bands around a regression instead of
+/// drives [`crate::BollingerBands`]-style bands around a regression instead of
 /// around an SMA — when the price hugs its trend, `StdErr` is small.
 ///
 /// Each `update` is O(1): the `Σx` and `Σxx` terms depend only on `period`

--- a/crates/wickra-data/src/aggregator.rs
+++ b/crates/wickra-data/src/aggregator.rs
@@ -346,7 +346,7 @@ impl TickAggregator {
     ///
     /// # Errors
     /// Returns an error if the open bar's accumulated volume is non-finite
-    /// (see [`OpenBar::into_candle`]).
+    /// (see the internal `OpenBar::into_candle`).
     pub fn flush(&mut self) -> Result<Option<Candle>> {
         self.open_bar.take().map(OpenBar::into_candle).transpose()
     }

--- a/crates/wickra-data/src/csv.rs
+++ b/crates/wickra-data/src/csv.rs
@@ -24,8 +24,9 @@ const REQUIRED_COLUMNS: [&str; 6] = ["timestamp", "open", "high", "low", "close"
 
 /// Default OHLCV CSV row layout.
 ///
-/// The timestamp is parsed as an `i64`; if your file ships an RFC3339 / ISO8601
-/// string instead, use [`CandleReader::with_timestamp_parser`].
+/// The timestamp is parsed as an `i64` (for example a Unix epoch). RFC3339 /
+/// ISO8601 string timestamps are not handled by this layout; convert them to
+/// integers before reading.
 #[derive(Debug, Clone, Deserialize)]
 pub struct DefaultRow {
     pub timestamp: i64,

--- a/crates/wickra-data/src/resample.rs
+++ b/crates/wickra-data/src/resample.rs
@@ -114,7 +114,7 @@ impl Resampler {
     ///
     /// # Errors
     /// Returns an error if the open bar's accumulated volume is non-finite
-    /// (see [`RolledBar::into_candle`]).
+    /// (see the internal `RolledBar::into_candle`).
     pub fn flush(&mut self) -> Result<Option<Candle>> {
         self.open.take().map(RolledBar::into_candle).transpose()
     }


### PR DESCRIPTION
## Summary

A full `cargo doc --workspace` emitted **five** broken intra-doc links. These are pre-existing (audit items P1.1/P1.2). docs.rs builds with `-D rustdoc::all`, so it treats every one of them as a hard error — any 0.2.x doc build was at risk of aborting the way 0.2.6 did. Fixing them now de-risks the 0.3.0 docs.rs build.

## Changes

| File | Before | Fix |
|------|--------|-----|
| `wickra-core/.../mama.rs` | `` [`Fama`] `` | `` [`crate::Fama`] `` — `Fama` is re-exported from a different module |
| `wickra-core/.../standard_error.rs` | `` [`crate::Bollinger`] `` | `` [`crate::BollingerBands`] `` — the public type is `BollingerBands` |
| `wickra-data/.../aggregator.rs` | link to private `OpenBar::into_candle` | plain code text (item is private) |
| `wickra-data/.../resample.rs` | link to private `RolledBar::into_candle` | plain code text |
| `wickra-data/.../csv.rs` | link to non-existent `CandleReader::with_timestamp_parser` | reworded — ISO/RFC timestamps must be converted to integers |

## Verification

```
RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links -D rustdoc::private_intra_doc_links" \
  cargo doc --workspace --no-deps
```
→ clean, **zero** warnings/errors (previously 5).