### PR TITLE
ci(release): fix CycloneDX SBOM generation (cargo-cyclonedx has no -p flag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,11 +90,15 @@ jobs:
 
       - name: Generate CycloneDX SBOMs
         run: |
-          cargo cyclonedx --format json --top-level -p wickra-core
-          cargo cyclonedx --format json --top-level -p wickra-data
-          cargo cyclonedx --format json --top-level -p wickra
+          # cargo-cyclonedx walks the whole workspace in a single pass and
+          # writes a <package>.cdx.json next to each member's Cargo.toml; it
+          # has no -p/--package selector. Collect the three crates.io crates
+          # (the .crate files published by this job) into the upload dir.
+          cargo cyclonedx --format json --top-level
           mkdir -p sboms
-          find . -name "*.cdx.json" -not -path "./target/*" -exec cp {} sboms/ \;
+          cp crates/wickra-core/wickra-core.cdx.json sboms/
+          cp crates/wickra-data/wickra-data.cdx.json sboms/
+          cp crates/wickra/wickra.cdx.json sboms/
           ls -lh sboms/
 
       - name: Upload SBOMs


### PR DESCRIPTION
## Problem

`cargo-cyclonedx` 0.5.9 has **no** `-p`/`--package` selector — it walks the whole workspace in one pass and writes a `<package>.cdx.json` next to each member's `Cargo.toml`. The release workflow called it three times with `-p <crate>`, so the `Generate CycloneDX SBOMs` step aborted with:

```
error: unexpected argument '-p' found
```

This failed the **cargo-publish** job *after* all three crates were already published to crates.io. Because the `github-release` job needs all four publish jobs (`cargo-publish`, `python-publish`, `node-publish`, `wasm-publish`), the attach-assets step was skipped. Net result for v0.3.0: published to crates.io / PyPI / npm successfully, but **no GitHub Release page and no SBOM assets**.

## Fix

Replace the three invalid `-p` invocations with a single workspace pass, then copy the three crates.io crate SBOMs into the upload dir.

## v0.3.0 recovery

The missing v0.3.0 GitHub Release was reconstructed out-of-band from the failed run's still-valid artifacts plus locally-generated SBOMs (cargo-cyclonedx 0.5.9, identical to the pinned action) — 29 assets, matching the v0.2.7 release profile. No re-publish to any registry was performed (the packages are immutable and already live).