### PR TITLE
docs: document the repo-wide lockfile policy (P4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,10 @@ tarpaulin-report.html
 bindings/node/*.node
 bindings/node/index.d.ts
 bindings/node/npm-debug.log*
-# package-lock.json is committed (under bindings/node/) so contributors
-# get reproducible npm installs. Top-level lockfiles still aren't expected.
+# package-lock.json is committed for the tracked Node packages — bindings/node/
+# and examples/node/ — so contributors get reproducible npm installs. There is
+# no top-level npm package, and the ghost-ignored site/ keeps its lockfile local.
+# See CONTRIBUTING.md "Lockfile policy" for the full per-component breakdown.
 
 # WASM build output
 bindings/wasm/pkg/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,21 @@ wasm-pack build bindings/wasm --target web --release --features panic-hook
 wasm-pack test --node bindings/wasm
 ```
 
+## Lockfile policy
+
+| Component | Lockfile | Tracked? | Why |
+| --- | --- | --- | --- |
+| Workspace (Rust) | `Cargo.lock` | **yes** | The workspace ships binaries (examples, fuzz harness) and CI builds, so the dependency graph is pinned for reproducible builds. |
+| `bindings/node` | `package-lock.json` | **yes** | Reproducible `npm install` for the native binding. |
+| `examples/node` | `package-lock.json` | **yes** | Same — the runnable Node examples link the binding via a `file:` dependency. |
+| `bindings/python` | — | n/a (no lockfile) | PyO3 convention: the Python package has no Python runtime dependencies of its own, and its native code is already pinned through the workspace `Cargo.lock`. CI installs build/test tooling (`maturin`, `pytest`, `numpy`, `hypothesis`) directly via `pip`. |
+| `fuzz` | `fuzz/Cargo.lock` | **no** (ignored) | `fuzz/` is a detached crate; `cargo-fuzz init` generates `fuzz/.gitignore` which ignores its `Cargo.lock`. The fuzz smoke job resolves dependencies fresh, so the lock is not needed for reproducibility here. |
+| `site` (marketing) | `package-lock.json` | **no** (ghost-ignored) | The VitePress site is a local-only project excluded via `.git/info/exclude`; its lockfile stays local. |
+
+When adding a new committed Node package, commit its `package-lock.json` too and
+remove any matching ignore rule. Do **not** add a top-level `package-lock.json` —
+the repository root is not an npm package.
+
 ## Standards for a change
 
 - **Formatting & lints.** `cargo fmt` must leave the tree unchanged and


### PR DESCRIPTION
## What

Repo-hygiene / documentation pass on the lockfile situation (findings **P4**). **No actual lockfile changes** — every lockfile state was already correct or intentional; this only fixes a stale comment and documents the policy.

## Why

The `.gitignore` comment claimed `package-lock.json` is committed only "under `bindings/node/`", but `examples/node/package-lock.json` has been tracked since #80 (findings P4.1). The by-design choices (no Python lockfile, ignored `fuzz/Cargo.lock`) were undocumented.

## Changes

- **`.gitignore`** — corrected the package-lock policy comment (names both tracked Node packages, points to CONTRIBUTING).
- **`CONTRIBUTING.md`** — new **Lockfile policy** section: a per-component table (workspace `Cargo.lock`, both Node package-locks → tracked; `fuzz/Cargo.lock` → ignored, cargo-fuzz default; Python → no lockfile, PyO3 convention pinned via `Cargo.lock`; `site` → ghost-ignored) plus guidance for adding new Node packages.

Covers findings P4.1 (already resolved in #80) + P4.2 (Python no-lockfile, now documented).