### PR TITLE
ci(sync-about): auto-sync repo homepage + org profile from the indicator count

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -10,6 +10,16 @@ name: Sync indicator count
 #   3. Wiki: Home.md / FAQ.md / Streaming-vs-Batch.md
 #                                            — synced on push to main / v* tag
 #   4. site/index.md (local-only marketing site, not synced from CI)
+#   5. org profile README count (wickra-lib/.github, profile/README.md)
+#                                            — synced on push to main / v* tag*
+#   6. org description ("… N indicators, install-free.")
+#                                            — synced on push to main / v* tag*
+#
+#   *Surfaces 5 + 6 need the ABOUT_SYNC_TOKEN to carry extra scope (write on
+#   wickra-lib/.github, and admin:org for the org-description PATCH). Until that
+#   scope is granted these two steps emit a ::warning:: and soft-skip — they
+#   never fail the run. The repo "About" homepage URL is also enforced in step 2
+#   (constant value, no extra scope) so it can never drift back to the old org.
 #
 # We count public types (not `mod xxx;` lines) because some modules export
 # more than one indicator — e.g. `vwap.rs` exposes both `Vwap` and
@@ -150,19 +160,26 @@ jobs:
       # wiki repo (separate repo, no main history pollution). README is
       # not touched on main any more.
 
-      - name: Update GitHub About description
+      - name: Update GitHub About (description + homepage)
         if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.ABOUT_SYNC_TOKEN }}
         run: |
           n="${{ steps.count.outputs.count }}"
+          # Canonical homepage. Swap to the docs domain (e.g.
+          # https://docs.wickra.org) here once the docs site is live — one place.
+          homepage="https://github.com/wickra-lib/wickra"
           desc="Streaming-first technical indicators with a Rust core and Python, Node.js, and WebAssembly bindings. ${n} indicators, O(1) per-tick updates, no system dependencies. Drop-in TA-Lib replacement."
+          # Enforce the homepage unconditionally — it is a constant, so this both
+          # corrects the stale kingchenc URL and self-heals any future drift.
+          # Same Administration-write permission as --description (no extra scope).
+          gh repo edit --homepage "$homepage"
           current=$(gh repo view --json description -q .description)
           if [ "$current" = "$desc" ]; then
-            echo "About unchanged."
+            echo "About description unchanged; homepage enforced."
           else
             gh repo edit --description "$desc"
-            echo "About updated."
+            echo "About description + homepage updated."
           fi
 
       - name: Sync Wiki
@@ -183,3 +200,64 @@ jobs:
           git add Home.md FAQ.md Streaming-vs-Batch.md
           git commit -m "chore: sync indicator count to ${n}"
           git push
+
+      # ----- org-profile sync (soft-skip until PAT scope lands) -------
+      #
+      # These two steps keep the org page (github.com/wickra-lib) in sync
+      # with the same count. They need ABOUT_SYNC_TOKEN scope the main-repo
+      # syncs do not: write on wickra-lib/.github, and admin:org for the org
+      # description PATCH. Both are written to soft-skip with a ::warning::
+      # (never fail the run) so this workflow stays green before the scope is
+      # granted — once it is, they start syncing with no further code change.
+
+      - name: Sync org profile README count
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.ABOUT_SYNC_TOKEN }}
+        run: |
+          n="${{ steps.count.outputs.count }}"
+          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/.github.git" orgprofile 2>/dev/null; then
+            echo "::warning::cannot clone wickra-lib/.github — ABOUT_SYNC_TOKEN likely lacks write on that repo (findings P10.0a). Skipping org profile sync."
+            exit 0
+          fi
+          cd orgprofile
+          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" profile/README.md
+          if git diff --quiet; then
+            echo "Org profile README count unchanged."
+            exit 0
+          fi
+          git config user.name "wickra-bot"
+          git config user.email "wickra-bot@users.noreply.github.com"
+          git add profile/README.md
+          git commit -m "chore: sync indicator count to ${n}"
+          if ! git push 2>/dev/null; then
+            echo "::warning::push to wickra-lib/.github failed — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a)."
+          else
+            echo "Org profile README synced to ${n}."
+          fi
+
+      - name: Sync org description
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.ABOUT_SYNC_TOKEN }}
+        run: |
+          n="${{ steps.count.outputs.count }}"
+          org="wickra-lib"
+          # Reading the org description is public; the PATCH needs admin:org.
+          current=$(gh api "orgs/${org}" --jq '.description // ""' 2>/dev/null || true)
+          if [ -z "$current" ]; then
+            echo "::warning::could not read org description (network/PAT?). Skipping."
+            exit 0
+          fi
+          updated=$(printf '%s' "$current" | sed -E "s/[0-9]+ indicators/${n} indicators/")
+          if [ "$current" = "$updated" ]; then
+            echo "Org description count unchanged."
+            exit 0
+          fi
+          if gh api -X PATCH "orgs/${org}" -f description="$updated" >/dev/null 2>&1; then
+            echo "Org description synced to ${n}."
+          else
+            echo "::warning::org description PATCH failed — ABOUT_SYNC_TOKEN likely lacks admin:org (findings P10.0b)."
+          fi


### PR DESCRIPTION
Makes the indicator count drive **all** the public surfaces from one source,
so nothing has to be touched by hand (findings P9 + P10).

## What changes in `sync-about.yml`

On push to `main` / `v*` tag, in addition to the existing README + About
description + Wiki sync:

1. **Repo About — homepage URL** (P9). The About box's website field still
   pointed at `github.com/kingchenc/wickra` (org-migration leftover). It is now
   enforced every run via `gh repo edit --homepage` in the existing About step —
   a constant value, so it corrects the stale URL **and** self-heals any future
   drift. Same Administration-write permission as `--description`, so **no extra
   token scope**. Swap-point to a docs domain (`docs.wickra.org`) is one line.
2. **Org profile README count** (P10). `wickra-lib/.github` →
   `profile/README.md` still says "75 indicators"; a new step clones it, seds the
   count, and bot-commits/pushes — same pattern as the Sync Wiki step.
3. **Org description field** (P10). The org bio still says "71 indicators,
   install-free"; a new step PATCHes it via `gh api`.

## Token scope (the only thing CI can't do itself)

Steps 2 + 3 need `ABOUT_SYNC_TOKEN` scope the main-repo syncs don't have:

- **write on `wickra-lib/.github`** (profile README) — findings P10.0a
- **`admin:org`** (org description PATCH) — findings P10.0b

Both new steps are written with `continue-on-error: true` and emit a
`::warning::` + soft-skip when the scope is missing, so **this workflow stays
green before the scope is granted**. The moment the scope lands, they start
syncing — no further code change. Step 1 (homepage) works immediately.

## Verification
- YAML validated (`yaml.safe_load`), 11 steps.
- No Rust touched; `ci.yml` fmt/clippy unaffected.
- Signed commit. No auto-merge.

Note: the org **repo-list** line ("wickra.wiki — 84 pages") is not a count the
workflow tracks; it is fixed manually when the wiki → wickra-docs migration
lands (findings P10.2).