### PR TITLE
ci(sync-about): auto-sync published version to wickra-docs on release (P0.5 automation)

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -14,12 +14,19 @@ name: Sync indicator count
 #                                            — synced on push to main / v* tag*
 #   6. org description ("… N indicators, install-free.")
 #                                            — synced on push to main / v* tag*
+#   7. docs site published version (wickra-lib/wickra-docs: the
+#      "Published versions" table in overview.md + the Rust quickstart prose)
+#                                            — synced on v* tag only*
 #
 #   *Surfaces 5 + 6 need the ABOUT_SYNC_TOKEN to carry extra scope (write on
-#   wickra-lib/.github, and admin:org for the org-description PATCH). Until that
-#   scope is granted these two steps emit a ::warning:: and soft-skip — they
-#   never fail the run. The repo "About" homepage URL is also enforced in step 2
-#   (constant value, no extra scope) so it can never drift back to the old org.
+#   wickra-lib/.github, and admin:org for the org-description PATCH); surface 7
+#   needs write on wickra-lib/wickra-docs. Until that scope is granted these
+#   steps emit a ::warning:: and soft-skip — they never fail the run. The repo
+#   "About" homepage URL is also enforced in step 2 (constant value, no extra
+#   scope) so it can never drift back to the old org.
+#
+#   Note: surface 7 carries the release *version*, not the indicator count, so
+#   it is driven by the v* tag (which is the version) rather than the count.
 #
 # We count public types (not `mod xxx;` lines) because some modules export
 # more than one indicator — e.g. `vwap.rs` exposes both `Vwap` and
@@ -260,4 +267,52 @@ jobs:
             echo "Org description synced to ${n}."
           else
             echo "::warning::org description PATCH failed — ABOUT_SYNC_TOKEN likely lacks admin:org (findings P10.0b)."
+          fi
+
+      # ----- docs version sync (tag-only, soft-skip until PAT scope lands) -----
+      #
+      # Surface 7: the docs site (wickra-lib/wickra-docs) carries the published
+      # version in the "Published versions" table (overview.md) and the Rust
+      # quickstart prose. Unlike the indicator count these change only on a
+      # release, so this step runs on v* tag pushes only and takes the version
+      # straight from the tag. It needs ABOUT_SYNC_TOKEN to have write on
+      # wickra-lib/wickra-docs (findings P10.0a). Until that scope is granted it
+      # soft-skips with a ::warning:: and never fails the run; once granted, every
+      # release self-heals the docs version with no code change (replaces the old
+      # manual P0.5 post-release wiki bump).
+      - name: Sync docs version (wickra-docs)
+        if: startsWith(github.ref, 'refs/tags/v')
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.ABOUT_SYNC_TOKEN }}
+        run: |
+          version="${GITHUB_REF#refs/tags/v}"
+          if ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::warning::tag '${GITHUB_REF}' is not a plain vMAJOR.MINOR.PATCH release; skipping docs version sync."
+            exit 0
+          fi
+          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/wickra-docs.git" docs 2>/dev/null; then
+            echo "::warning::cannot clone wickra-lib/wickra-docs — ABOUT_SYNC_TOKEN likely lacks write on that repo (findings P10.0a). Skipping docs version sync."
+            exit 0
+          fi
+          cd docs
+          # Published-versions table rows (crates.io / PyPI / npm): replace only the
+          # version number, leaving the trailing padding + pipe intact. The '.' in
+          # the quickstart pattern matches the literal backtick around the version
+          # without needing a backtick in this shell string. Historical "since
+          # X.Y.Z" references contain no such anchor and are never matched.
+          sed -i -E "s/^(\| (crates\.io|PyPI|npm) .*\| )[0-9]+\.[0-9]+\.[0-9]+/\1${version}/" overview.md
+          sed -i -E "s/(published crate is at version .)[0-9]+\.[0-9]+\.[0-9]+/\1${version}/" Quickstart-Rust.md
+          if git diff --quiet; then
+            echo "Docs version already at ${version}."
+            exit 0
+          fi
+          git config user.name "wickra-bot"
+          git config user.email "wickra-bot@users.noreply.github.com"
+          git add overview.md Quickstart-Rust.md
+          git commit -m "chore: sync published version to ${version}"
+          if ! git push 2>/dev/null; then
+            echo "::warning::push to wickra-lib/wickra-docs failed — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a)."
+          else
+            echo "Docs version synced to ${version}."
           fi


### PR DESCRIPTION
## What

Adds a 7th sync surface to `sync-about.yml`: the **published version** on the docs site (`wickra-lib/wickra-docs`). On every `v*` tag push the step takes the version straight from the tag and rewrites:

- the **Published versions** table in `overview.md` (6 registry rows), and
- the Rust quickstart prose ("published crate is at version `X.Y.Z`").

This replaces the manual post-release **P0.5** wiki/docs version bump — the docs version self-heals on every release with no code change.

## Why this surface differs from the indicator count

The count changes on feature merges → it syncs on push-to-main + tag. The **version** changes only on a release → this step is gated to `v*` tags and reads the version from the tag itself.

## Safety / correctness

- **Precise seds, verified against the real docs files** (dummy `9.9.9` run): only the table version cells + the quickstart literal change. Historical `since 0.2.1 / 0.2.7+ arm64` refs in `Quickstart-Node.md` have no matching anchor and are never touched.
- **Soft-skip pattern** identical to the existing org-profile steps: `continue-on-error` + `::warning::` if the token can't reach `wickra-docs` — the run never fails.
- Gated on `refs/tags/v*`, so it does **not** run (and cannot push to docs) on this PR or on plain push-to-main.
- Bot commit via PAT over HTTPS, mirroring the existing "Sync Wiki" / org-profile steps.

## Prerequisite (now satisfied)

Needs `ABOUT_SYNC_TOKEN` to have **Contents: Read and write on `wickra-lib/wickra-docs`** (findings P10.0a). The org-owned fine-grained token was updated to include `wickra-docs` — so this goes live on the next `v*` release.

YAML validated. Held for manual merge (no auto-merge).