### PR TITLE
ci: OpenSSF Scorecard workflow + badge (P13.1)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,49 @@
+name: OpenSSF Scorecard
+
+# Supply-chain / security-posture analysis (findings P13.1). Runs on a weekly
+# schedule, on branch-protection changes, and on push to main. `publish_results`
+# uploads the score to the public OpenSSF API so the README badge resolves, and
+# the SARIF is surfaced under the repo's Security → Code scanning tab.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '27 7 * * 2' # Tuesdays 07:27 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Read-only by default; the analysis job widens to exactly what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF result to code-scanning
+      id-token: write # OIDC token to publish results to the OpenSSF API
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the public OpenSSF endpoint that backs the README badge.
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![PyPI](https://img.shields.io/pypi/v/wickra.svg?logo=pypi&color=blue)](https://pypi.org/project/wickra/)
 [![npm](https://img.shields.io/npm/v/wickra.svg?logo=npm&color=red)](https://www.npmjs.com/package/wickra)
 [![License: PolyForm-NC](https://img.shields.io/badge/license-PolyForm--NC--1.0.0-purple)](LICENSE)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/wickra-lib/wickra/badge)](https://scorecard.dev/viewer/?uri=github.com/wickra-lib/wickra)
 
 **Streaming-first technical indicators. Install with `pip install wickra` — no system dependencies.**
 


### PR DESCRIPTION
Adds the OpenSSF Scorecard analysis (`ossf/scorecard-action@v2.4.3`, official template) + README badge. Runs weekly + on branch-protection changes + push to main; `publish_results: true` backs the badge via the public OpenSSF API, and the SARIF lands under Security → Code scanning.

Wickra's existing posture (signed commits/tags, cargo-deny, fuzzing, CycloneDX SBOM, `forbid(unsafe)`) should score well — this just makes it visible. Read-only token by default; the job widens to `security-events: write` + `id-token: write` only as the action requires.

**To go live (USER):** nothing secret needed — `publish_results` uses OIDC. Just merge; first run populates the badge. Branch protection on `main` would raise the Branch-Protection check. Held for manual merge.