### PR TITLE
chore: contact/author email -> support@wickra.org; drop dead sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -3,4 +3,3 @@
 # Leave a key empty (e.g. patreon:) to skip a platform.
 
 github: [kingchenc]
-custom: ["https://wickra.org/sponsor"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,7 +428,7 @@ jobs:
           node -e "
             const fs = require('fs');
             const pkg = JSON.parse(fs.readFileSync('package.json'));
-            pkg.author = 'kingchenc <wickra.lib@gmail.com>';
+            pkg.author = 'kingchenc <support@wickra.org>';
             pkg.repository = { type: 'git', url: 'https://github.com/wickra-lib/wickra' };
             pkg.homepage = 'https://github.com/wickra-lib/wickra';
             pkg.bugs = { url: 'https://github.com/wickra-lib/wickra/issues' };

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ message: >-
 type: software
 authors:
   - alias: kingchenc
-    email: wickra.lib@gmail.com
+    email: support@wickra.org
 repository-code: "https://github.com/wickra-lib/wickra"
 url: "https://wickra.org"
 abstract: >-

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -33,7 +33,7 @@ project in public spaces.
 ## Enforcement
 
 Instances of unacceptable behaviour may be reported to the project maintainer
-at **wickra.lib@gmail.com**. All reports will be reviewed and investigated
+at **support@wickra.org**. All reports will be reviewed and investigated
 promptly and fairly, and the maintainer will respect the privacy and security
 of the reporter.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["fuzz"]
 
 [workspace.package]
 version = "0.3.1"
-authors = ["kingchenc <wickra.lib@gmail.com>"]
+authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
 license = "PolyForm-Noncommercial-1.0.0"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ Report it privately through one of:
 
 - GitHub's [private vulnerability reporting](https://github.com/wickra-lib/wickra/security/advisories/new)
   ("Report a vulnerability" under the repository's *Security* tab), or
-- email to **wickra.lib@gmail.com** with a subject line starting with
+- email to **support@wickra.org** with a subject line starting with
   `[wickra security]`.
 
 Please include:

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -2,7 +2,7 @@
   "name": "wickra",
   "version": "0.3.1",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
-  "author": "kingchenc <wickra.lib@gmail.com>",
+  "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
   "types": "index.d.ts",
   "license": "PolyForm-Noncommercial-1.0.0",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.3.1"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = { text = "PolyForm-Noncommercial-1.0.0" }
-authors = [{ name = "kingchenc", email = "wickra.lib@gmail.com" }]
+authors = [{ name = "kingchenc", email = "support@wickra.org" }]
 requires-python = ">=3.9"
 keywords = ["finance", "trading", "indicators", "technical-analysis", "ta-lib"]
 classifiers = [

--- a/repo-metadata.toml
+++ b/repo-metadata.toml
@@ -21,7 +21,7 @@ security_url = "https://github.com/wickra-lib/wickra/security/advisories/new"
 # not move with the GitHub org transfer. `github` is the org @-mention slug
 # used in CODEOWNERS and prose.
 handle = "kingchenc"
-email  = "wickra.lib@gmail.com"
+email  = "support@wickra.org"
 github = "wickra-lib"
 
 [badges]


### PR DESCRIPTION
Now that the **wickra.org catch-all mailbox** exists, move the project contact + package-author email off the personal gmail to **support@wickra.org** across every surface:

- `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CITATION.cff` (contact — effective immediately)
- `Cargo.toml`, `bindings/node/package.json`, `bindings/python/pyproject.toml`, `release.yml` npm author (published metadata — effective on the next release)
- `repo-metadata.toml` `[maintainer].email`

`repo-metadata.toml` `[audit].forbidden` still pins `kingchencp@gmail.com` (the private commit email) as a banned substring — unchanged. `metadata audit` (`sync-metadata.py --check`) verified clean locally (`email='support@wickra.org'`).

Also removes the `FUNDING.yml` custom `https://wickra.org/sponsor` entry — that page 404s, so the Sponsor button linked to a dead URL. The GitHub Sponsors entry stays.

Scan scope: webpage / wickra-docs / .github repos had no email/link issues.