### PR TITLE
docs(readme): show the Wickra banner + drop redundant heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Wickra
+<p align="center">
+  <a href="https://wickra.org"><img src="https://wickra.org/og-banner.webp" alt="Wickra — streaming-first technical indicators" width="100%"></a>
+</p>
 
 [![CI](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml/badge.svg)](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/wickra-lib/wickra/actions/workflows/codeql.yml/badge.svg)](https://github.com/wickra-lib/wickra/actions/workflows/codeql.yml)


### PR DESCRIPTION
Embed the brand banner at the top of the README (linked to wickra.org) and drop the redundant `# Wickra` heading (the banner shows the wordmark).

The image is served from `https://wickra.org/og-banner.webp`, which the webpage build regenerates on every deploy from the current indicator count (4K WebP) — so the README banner **auto-updates** with no committed binary in this repo, and the absolute URL renders on GitHub, crates.io and docs.rs alike.