### PR TITLE
ci: prevent shell injection from untrusted workflow contexts (P21.1a)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -56,10 +56,16 @@ jobs:
 
       - name: Run cross-library benchmark
         working-directory: bindings/python
+        # workflow_dispatch inputs are untrusted; pass them through the
+        # environment and quote them rather than interpolating into the shell
+        # command (OpenSSF Scorecard: Dangerous-Workflow).
+        env:
+          BENCH_SIZE: ${{ github.event.inputs.size || '20000' }}
+          BENCH_ITERATIONS: ${{ github.event.inputs.iterations || '10' }}
         run: |
           python -m benchmarks.compare_libraries \
-            --size ${{ github.event.inputs.size || '20000' }} \
-            --iterations ${{ github.event.inputs.iterations || '10' }} \
+            --size "$BENCH_SIZE" \
+            --iterations "$BENCH_ITERATIONS" \
             --streaming-window 5000 --streaming-iterations 2 \
             | tee benchmark.txt
 

--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -74,11 +74,20 @@ jobs:
       # falls back to a hard failure when push isn't possible.
       - name: Determine if push to PR head is possible
         id: ctx
+        # Untrusted PR contexts (head.ref / head.repo.full_name are attacker
+        # controlled on fork PRs) are passed through the environment, never
+        # interpolated straight into the shell, so a crafted branch name cannot
+        # inject commands (OpenSSF Scorecard: Dangerous-Workflow).
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
               echo "can_push=true" >> "$GITHUB_OUTPUT"
-              echo "head_ref=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+              echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
             else
               echo "can_push=false" >> "$GITHUB_OUTPUT"
               echo "head_ref=" >> "$GITHUB_OUTPUT"
@@ -154,12 +163,18 @@ jobs:
 
       - name: Commit & push counter fix to PR head
         if: github.event_name == 'pull_request' && steps.pr_patch.outputs.changed == 'true'
+        # head_ref still carries the (untrusted) PR branch name forwarded by the
+        # ctx step; pass it through the environment so the push refspec cannot be
+        # used to inject shell commands (OpenSSF Scorecard: Dangerous-Workflow).
+        env:
+          COUNT: ${{ steps.count.outputs.count }}
+          HEAD_REF: ${{ steps.ctx.outputs.head_ref }}
         run: |
           git config user.name "wickra-bot"
           git config user.email "wickra-bot@users.noreply.github.com"
           git add README.md
-          git commit -m "chore: sync indicator count to ${{ steps.count.outputs.count }}"
-          git push origin "HEAD:${{ steps.ctx.outputs.head_ref }}"
+          git commit -m "chore: sync indicator count to ${COUNT}"
+          git push origin "HEAD:${HEAD_REF}"
 
       # ----- main / tag flow ------------------------------------------
       #


### PR DESCRIPTION
## What

Closes the script-injection sinks flagged by OpenSSF Scorecard's
**Dangerous-Workflow** check (currently scored 0). Untrusted, attacker-controlled
template contexts were interpolated directly into `run:` shell scripts; they are
now passed through the step environment and referenced as quoted shell variables,
so a crafted value (e.g. a fork branch name containing `$(...)` or backticks)
can no longer execute commands.

## Sinks fixed

- **`sync-about.yml`** — `Determine if push to PR head is possible`:
  `github.event.pull_request.head.ref` and `…head.repo.full_name` → `env:` (`HEAD_REF`, `HEAD_REPO`).
- **`sync-about.yml`** — `Commit & push counter fix to PR head`: the same branch name
  is forwarded via `steps.ctx.outputs.head_ref` into the `git push` refspec → now `env:` (`HEAD_REF`).
- **`bench.yml`** — `Run cross-library benchmark`: `github.event.inputs.size` /
  `…inputs.iterations` → `env:` (`BENCH_SIZE`, `BENCH_ITERATIONS`).

## Why it's safe

Behaviour is **identical** for all legitimate values — moving a value into `env:`
and quoting (`"$VAR"`) only stops command substitution on the value. No logic
changes. YAML validated; the only remaining `github.event.*` interpolations are
in `env:`/`with:` blocks (never a shell).

Scorecard impact: Dangerous-Workflow 0 → 10 (Critical weight). Not for merge yet.