### PR TITLE
ci: pin remaining GitHub Actions to commit SHAs (P21.1c)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,15 +33,15 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,12 +24,12 @@ jobs:
       id-token: write # OIDC token to publish results to the OpenSSF API
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -37,13 +37,13 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -92,7 +92,7 @@ jobs:
       # any fix-up commit we make goes onto the PR branch itself. On
       # push events we check out the default ref. fetch-depth: 0 lets
       # us push back without "shallow update not allowed".
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/sync-metadata.yml
+++ b/.github/workflows/sync-metadata.yml
@@ -14,8 +14,8 @@ jobs:
     name: metadata audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
       - name: Audit repo-metadata.toml drift


### PR DESCRIPTION
## What

Pins the last 10 GitHub Actions references that were still floating on a
mutable tag to their exact commit SHA, satisfying OpenSSF Scorecard's
**Pinned-Dependencies** check (currently 7/10). The rest of the workflow
suite (ci / release / bench / pages) was already SHA-pinned.

| Workflow | Action | Pinned to |
|---|---|---|
| codeql.yml | actions/checkout | `34e1148` # v4.3.1 |
| codeql.yml | github/codeql-action/init | `03e4368` # v3.36.0 |
| codeql.yml | github/codeql-action/analyze | `03e4368` # v3.36.0 |
| scorecard.yml | actions/checkout | `34e1148` # v4.3.1 |
| scorecard.yml | ossf/scorecard-action | `4eaacf0` # v2.4.3 |
| scorecard.yml | actions/upload-artifact | `ea165f8` # v4.6.2 |
| scorecard.yml | github/codeql-action/upload-sarif | `03e4368` # v3.36.0 |
| sync-about.yml | actions/checkout | `de0fac2` # v6.0.2 |
| sync-metadata.yml | actions/checkout | `de0fac2` # v6.0.2 |
| sync-metadata.yml | actions/setup-python | `a26af69` # v5.6.0 |

## Why it's safe

Each pin is the **exact commit the existing tag resolves to today** — no major
or minor version bump, so behaviour is unchanged. Each line keeps a `# vX.Y.Z`
comment so Dependabot can keep updating them. checkout@v6 resolves to the same
SHA already pinned in bench.yml (v6.0.2).

Scorecard impact: Pinned-Dependencies 7 → 10. Not for merge yet.