### PR TITLE
ci: least-privilege top-level token permissions (P21.1b)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,6 +22,13 @@ on:
         required: false
         default: "10"
 
+# Least-privilege default for the auto-injected GITHUB_TOKEN. The single job
+# only builds and uploads an artifact (upload-artifact uses the artifact
+# storage API, not the contents scope), so it never needs repo write (OpenSSF
+# Scorecard: Token-Permissions).
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege default for the auto-injected GITHUB_TOKEN. None of the CI
+# jobs write back to the repo — coverage uploads via CODECOV_TOKEN, everything
+# else is build/test/lint — so a read-only token is sufficient (OpenSSF
+# Scorecard: Token-Permissions).
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,13 @@ on:
   schedule:
     - cron: '31 3 * * 0' # Sundays 03:31 UTC
 
+# Least-privilege default for the auto-injected GITHUB_TOKEN. The analyze job
+# raises exactly the scopes CodeQL needs (security-events: write to upload
+# results) in its own job-level block below; this top-level read-only default
+# covers any future job (OpenSSF Scorecard: Token-Permissions).
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,17 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+# Least-privilege default for the auto-injected GITHUB_TOKEN. The publish jobs
+# (cargo/python/node) push to external registries via their own secrets
+# (CARGO_REGISTRY_TOKEN / PYPI_API_TOKEN / NPM_TOKEN), not the GITHUB_TOKEN, so
+# they need no repo write. The jobs that genuinely write through the
+# GITHUB_TOKEN — github-release (contents: write), node-/wasm-publish and
+# attestations (id-token / attestations: write) — declare those rights in their
+# own job-level permissions blocks, which override this default (OpenSSF
+# Scorecard: Token-Permissions).
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -55,18 +55,24 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
-# `contents: write` is needed so the workflow can push the counter
-# fix-up commit to the PR head branch via the auto-provided
-# GITHUB_TOKEN. The wider About / Wiki writes still go through the
-# fine-grained PAT (ABOUT_SYNC_TOKEN) because they need
-# `Administration: write` (gh repo edit) which GITHUB_TOKEN lacks.
+# Least-privilege default for the auto-injected GITHUB_TOKEN. The `contents:
+# write` the workflow needs — to push the counter fix-up commit to the PR head
+# branch — is raised at the job level below, not here, so the top-level default
+# stays read-only (OpenSSF Scorecard: Token-Permissions). The wider About /
+# docs / webpage / org writes still go through the fine-grained PAT
+# (ABOUT_SYNC_TOKEN), which the `permissions:` key does not govern at all.
 permissions:
-  contents: write
+  contents: read
   pull-requests: read
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # The only GITHUB_TOKEN write in this workflow: pushing the counter fix-up
+    # commit onto a same-repo PR head branch (git push origin HEAD:<ref>).
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       # On PRs from forks the head ref lives in another repo; pushing
       # back to it from this workflow is blocked by GitHub. We still


### PR DESCRIPTION
## What

Adds a least-privilege top-level `permissions:` block to the four workflows whose auto-injected `GITHUB_TOKEN` still defaulted to **write-all**, and tightens `sync-about.yml` from a top-level write to a job-level write. Closes the OpenSSF Scorecard **Token-Permissions** finding (currently 0/10, High weight).

`permissions:` governs **only** the ephemeral `GITHUB_TOKEN`. All registry publishing (crates.io/PyPI/npm via `CARGO_REGISTRY_TOKEN`/`PYPI_API_TOKEN`/`NPM_TOKEN`) and all cross-repo syncs (`ABOUT_SYNC_TOKEN`) use **secrets**, which are unaffected by this change.

## Per-file

| File | Before | After |
|---|---|---|
| `ci.yml` | none → write-all | top-level `contents: read` (no job writes back) |
| `bench.yml` | none → write-all | top-level `contents: read` (only uploads an artifact) |
| `release.yml` | none → write-all | top-level `contents: read`; write-jobs keep their own blocks |
| `codeql.yml` | job-level only | + top-level `contents: read` (job keeps `security-events: write`) |
| `sync-about.yml` | top-level `contents: write` | top-level `read`; `contents: write` moved to the `sync` job |

## Write-jobs that keep their rights (verified)

- `release.yml` → `github-release` (`contents: write`), `node-publish`/`wasm-publish` (`id-token: write`), `attestations` (`id-token` + `attestations: write`)
- `codeql.yml` → `analyze` (`security-events: write`)
- `sync-about.yml` → `sync` (`contents: write`, now job-level)

## Verification

- All 8 workflow files pass `yaml.safe_load`.
- Audited every job: each one that writes through the `GITHUB_TOKEN` retains an explicit job-level grant; the rest fall back to read-only.
- Behaviour-preserving — no step logic changed.

Part of the P21 Scorecard-hardening series (follows #99 Dangerous-Workflow, #100 Pinned-Dependencies).