### PR TITLE
ci(sync-about): fix docs version-sync clone collision + webpage npm race

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -437,13 +437,25 @@ jobs:
           sed -i -E "s/(Latest:\*\* \[.wickra(-wasm)? )[0-9]+\.[0-9]+\.[0-9]+/\1${version}/" api/*.md
           sed -i -E "s/(text: .v)[0-9]+\.[0-9]+\.[0-9]+/\1${version}/" .vitepress/config.ts
           sed -i -E "s/(.wickra-wasm.: .\^)[0-9]+\.[0-9]+\.[0-9]+/\1${version}/" package.json
+          # Keep package-lock.json in sync with the package.json bump. The site's
+          # Cloudflare build runs `npm clean-install` (npm ci), which hard-fails
+          # with EUSAGE if the lockfile still pins the previous wickra-wasm —
+          # editing package.json alone is not enough. The npm-wait above already
+          # proved wickra-wasm@$version is resolvable, so --package-lock-only
+          # regenerates the lock (version + resolved + integrity) without fetching
+          # node_modules. Guard it: if the regen fails, skip the whole commit so we
+          # never push a package.json/lock mismatch that would break the build.
+          if ! npm install --package-lock-only --no-audit --no-fund; then
+            echo "::warning::could not regenerate package-lock.json for wickra-wasm@${version}; skipping webpage version sync to avoid a lockfile-drift build break."
+            exit 0
+          fi
           if git diff --quiet; then
             echo "Webpage version already at ${version}."
             exit 0
           fi
           git config user.name "wickra-bot"
           git config user.email "wickra-bot@users.noreply.github.com"
-          git add api/*.md .vitepress/config.ts package.json
+          git add api/*.md .vitepress/config.ts package.json package-lock.json
           git commit -m "chore: sync published version to ${version}"
           if ! git push 2>/dev/null; then
             echo "::warning::push to wickra-lib/webpage failed — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a)."

--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -325,11 +325,19 @@ jobs:
             echo "::warning::tag '${GITHUB_REF}' is not a plain vMAJOR.MINOR.PATCH release; skipping docs version sync."
             exit 0
           fi
-          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/wickra-docs.git" docs 2>/dev/null; then
+          # Clone into `docs-ver`, NOT `docs`: on a tag push this job checks out
+          # the wickra repo at the workspace root, which already contains a
+          # top-level `docs/` directory, so `git clone … docs` fails with
+          # "destination path 'docs' already exists" — silently, because of the
+          # 2>/dev/null below — and the version sync never runs (this is exactly
+          # why v0.4.0 did not bump the docs table). `docs-ver` mirrors the
+          # `docs-count` dir used by the count step above and collides with
+          # nothing in the repo.
+          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/wickra-docs.git" docs-ver 2>/dev/null; then
             echo "::warning::cannot clone wickra-lib/wickra-docs — ABOUT_SYNC_TOKEN likely lacks write on that repo (findings P10.0a). Skipping docs version sync."
             exit 0
           fi
-          cd docs
+          cd docs-ver
           # Published-versions table rows (crates.io / PyPI / npm): replace only the
           # version number, leaving the trailing padding + pipe intact. The '.' in
           # the quickstart pattern matches the literal backtick around the version
@@ -397,6 +405,26 @@ jobs:
             echo "::warning::tag '${GITHUB_REF}' is not a plain vMAJOR.MINOR.PATCH release; skipping webpage version sync."
             exit 0
           fi
+          # The webpage pins wickra-wasm to the released version in package.json,
+          # and its Cloudflare Pages build runs `npm clean-install`. release.yml
+          # publishes wickra-wasm to npm in parallel on this same tag and finishes
+          # minutes later, so committing the bump immediately would point the site
+          # at a version npm cannot resolve yet (ETARGET) and break the build —
+          # exactly what happened on v0.4.0. Wait until wickra-wasm@$version is
+          # actually live on npm before committing; if it never appears (the wasm
+          # publish failed), skip rather than push a build-breaking commit.
+          echo "Waiting for wickra-wasm@${version} on npm before bumping the webpage..."
+          attempts=0
+          until npm view "wickra-wasm@${version}" version >/dev/null 2>&1; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge 30 ]; then
+              echo "::warning::wickra-wasm@${version} not on npm after ~15 min; skipping webpage version sync to avoid a broken Cloudflare build."
+              exit 0
+            fi
+            echo "  not on npm yet (attempt ${attempts}/30); waiting 30s..."
+            sleep 30
+          done
+          echo "wickra-wasm@${version} is live on npm; proceeding with the webpage version bump."
           if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/webpage.git" webpage-ver 2>/dev/null; then
             echo "::warning::cannot clone wickra-lib/webpage — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a). Skipping webpage version sync."
             exit 0


### PR DESCRIPTION
## Why

The **v0.4.0** release exposed three real bugs in the tag-triggered release sync. The docs version table never bumped, and the webpage Cloudflare build failed (twice — two distinct npm causes). All three are fixed here; the two live sites were also unblocked out-of-band (docs bumped to 0.4.0, webpage lockfile synced).

## Bug 1 — docs version sync never ran (clone-dir collision)

`Sync docs version` cloned into a dir named **`docs`**, but on a tag push the job checks out the **wickra** repo at the workspace root, which already has a top-level **`docs/`** folder → `git clone … docs` fails with *"destination path 'docs' already exists"*, silenced by `2>/dev/null` and **misreported** as *"ABOUT_SYNC_TOKEN likely lacks write"*. → clone into **`docs-ver`** (mirrors the `docs-count` dir the count step already uses).

## Bug 2 — webpage build race (ETARGET)

`Sync webpage version` bumps `package.json`'s `wickra-wasm` pin and pushes immediately, but `release.yml` publishes `wickra-wasm` to npm **in parallel** and finishes minutes later → Cloudflare `npm ci` hit `ETARGET: No matching version found for wickra-wasm@^0.4.0`. → **poll `npm view wickra-wasm@<version>`** (≤~15 min) before committing; skip with a warning if it never appears.

## Bug 3 — webpage lockfile drift (EUSAGE)

The same step seds `package.json` but never updated **`package-lock.json`**, so even once wickra-wasm was live `npm ci` failed with `EUSAGE: lock file's wickra-wasm@0.3.1 does not satisfy wickra-wasm@0.4.0`. → after the sed, run **`npm install --package-lock-only`** to regenerate the lock (version + resolved + integrity) and commit it alongside `package.json`. Guarded: if the regen fails, skip the commit rather than push a mismatch.

## Verification

- All 8 workflow files pass `yaml.safe_load`.
- `docs-ver`/`cd docs-ver` confirmed; no bare `docs` clone remains.
- npm-wait poll + `--package-lock-only` regen + `git add … package-lock.json` confirmed in the webpage step.
- Both live sites already green with these exact fixes applied manually: wickra-docs build success at 0.4.0; webpage Cloudflare build success after the lockfile sync.

Both steps were designed to mirror each other across docs/webpage; these fixes restore that so every release self-heals both sites.