### PR TITLE
ci: retry transient registry/DNS flakes at the tool level (cargo/npm/pip)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,6 +31,17 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  # Network-flake resilience: retry transient registry/DNS failures at the tool
+  # level so a blip fetching crates.io / PyPI inside any build step (cargo,
+  # maturin, pip) retries automatically instead of failing the job. Cargo treats
+  # "couldn't resolve host" / connect / timeout as spurious and retries with
+  # backoff; 10 attempts ride out a transient DNS blip on a runner.
+  CARGO_NET_RETRY: "10"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  npm_config_fetch_retries: "5"
+  npm_config_fetch_retry_maxtimeout: "120000"
+  PIP_RETRIES: "5"
+  PIP_DEFAULT_TIMEOUT: "120"
 
 jobs:
   cross-library-bench:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,19 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
+  # Network-flake resilience: retry transient registry/DNS failures at the tool
+  # level so a blip fetching crates.io / npm / PyPI inside any build step (cargo,
+  # napi, maturin, wasm-pack, npm ci, pip) retries automatically instead of
+  # failing the job and needing a manual re-run. Cargo treats "couldn't resolve
+  # host" / connect / timeout as spurious and retries with backoff; 10 attempts
+  # ride out a transient DNS blip on a runner. Complements the setup-action /
+  # cache retries (which only covered toolchain download + cache restore).
+  CARGO_NET_RETRY: "10"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  npm_config_fetch_retries: "5"
+  npm_config_fetch_retry_maxtimeout: "120000"
+  PIP_RETRIES: "5"
+  PIP_DEFAULT_TIMEOUT: "120"
 
 jobs:
   rust:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,17 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  # Network-flake resilience: retry transient registry/DNS failures at the tool
+  # level so a blip fetching crates.io / npm inside any build or publish step
+  # (cargo, napi, maturin, wasm-pack, npm) retries automatically instead of
+  # failing the job. Cargo treats "couldn't resolve host" / connect / timeout as
+  # spurious and retries with backoff; 10 attempts ride out a transient DNS blip.
+  CARGO_NET_RETRY: "10"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  npm_config_fetch_retries: "5"
+  npm_config_fetch_retry_maxtimeout: "120000"
+  PIP_RETRIES: "5"
+  PIP_DEFAULT_TIMEOUT: "120"
 
 jobs:
   # --------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The CI failure right after the v0.4.0 merges was a **runner network blip**, not a code bug: `napi build` invokes cargo, whose fetch of `index.crates.io` hit *"Could not resolve host: index.crates.io"* → the Node-on-macOS job failed → manual re-run needed.

The earlier flake-hardening only retried **setup-node/setup-python** (toolchain download) and the **rust-cache** restore — **not** the registry fetches inside the actual build/publish steps. So a DNS blip during `cargo`/`napi`/`maturin`/`npm` still failed the job.

## Fix — tool-level network retries (workflow `env:`)

These env vars are inherited by **every** job and by the **nested** cargo calls inside napi/maturin/wasm-pack, so all registry traffic retries automatically:

| Var | Effect |
|---|---|
| `CARGO_NET_RETRY=10` | cargo classes DNS-resolve / connect / timeout as spurious and retries with backoff (default 3 → 10) — rides out a transient blip |
| `CARGO_NET_GIT_FETCH_WITH_CLI=true` | more robust git-dep fetches |
| `npm_config_fetch_retries=5` / `…maxtimeout=120000` | `npm ci`/`install` registry retries |
| `PIP_RETRIES=5` / `PIP_DEFAULT_TIMEOUT=120` | pip install resilience |

Applied to **ci.yml**, **release.yml**, **bench.yml** (the building workflows). `sync-about`/`sync-metadata`/`codeql`/`scorecard`/`pages` don't fetch from these registries.

## Result

No more manual re-runs for transient registry/DNS flakes — the exact class that just failed (and the historical Windows setup flakes are already covered).

## Verification
- All three workflow files pass `yaml.safe_load`.
- Retry env present in all three (3/3 vars each).
- Behaviour otherwise unchanged (env-only).