### PR TITLE
docs: surface docs.wickra.org + keep the wiki pointer count in sync

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -20,10 +20,15 @@ name: Sync indicator count
 #                                            — synced on v* tag only*
 #   8. Marketing site version (wickra-lib/webpage: api/*.md "Latest" lines, the
 #      nav version label, and the wickra-wasm dep) — synced on v* tag only*
+#   9. Wiki pointer page count (wickra-lib/wickra.wiki, Home.md — the wiki was
+#      collapsed to a single page that points at docs.wickra.org but still names
+#      the count) — synced on push to main / v* tag*
 #
 #   *Surfaces 3 + 7 need the ABOUT_SYNC_TOKEN to have write on
 #   wickra-lib/wickra-docs, surfaces 4 + 8 on wickra-lib/webpage; surfaces 5 + 6
-#   need write on wickra-lib/.github and admin:org for the org-description PATCH.
+#   need write on wickra-lib/.github and admin:org for the org-description PATCH;
+#   surface 9 needs write on wickra-lib/wickra (the wiki rides on the parent
+#   repo's permission).
 #   Until that scope is granted these steps emit a ::warning:: and soft-skip —
 #   they never fail the run. The repo "About" homepage URL is also enforced in
 #   step 2 (constant value, no extra scope); it points at docs.wickra.org.
@@ -246,6 +251,40 @@ jobs:
             echo "::warning::push to wickra-lib/wickra-docs failed — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a)."
           else
             echo "Docs indicator count synced to ${n}."
+          fi
+
+      # The GitHub wiki (wickra-lib/wickra.wiki) was collapsed to a single
+      # Home.md pointer page that sends visitors to docs.wickra.org, but that
+      # page still names the count ("… for all N indicators"), so keep it in
+      # sync here too. Mirrors the docs/webpage count steps: own clone dir
+      # (wiki-count) and the same soft-skip contract. Wiki write rides on the
+      # parent repo's permission, so the PAT needs write on wickra-lib/wickra;
+      # the wiki has no signing gate, so a plain wickra-bot commit is fine.
+      - name: Sync wiki pointer indicator count (wickra.wiki)
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.ABOUT_SYNC_TOKEN }}
+        run: |
+          n="${{ steps.count.outputs.count }}"
+          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/wickra.wiki.git" wiki-count 2>/dev/null; then
+            echo "::warning::cannot clone wickra-lib/wickra.wiki — ABOUT_SYNC_TOKEN likely lacks write on the wiki. Skipping wiki count sync."
+            exit 0
+          fi
+          cd wiki-count
+          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" Home.md
+          if git diff --quiet; then
+            echo "Wiki pointer indicator count unchanged."
+            exit 0
+          fi
+          git config user.name "wickra-bot"
+          git config user.email "wickra-bot@users.noreply.github.com"
+          git add Home.md
+          git commit -m "chore: sync indicator count to ${n}"
+          if ! git push 2>/dev/null; then
+            echo "::warning::push to wickra-lib/wickra.wiki failed — ABOUT_SYNC_TOKEN likely lacks write on the wiki."
+          else
+            echo "Wiki pointer indicator count synced to ${n}."
           fi
 
       # ----- org-profile sync (soft-skip until PAT scope lands) -------

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![License: PolyForm-NC](https://img.shields.io/badge/license-PolyForm--NC--1.0.0-purple)](LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/wickra-lib/wickra/badge)](https://scorecard.dev/viewer/?uri=github.com/wickra-lib/wickra)
 [![Build provenance](https://img.shields.io/badge/provenance-attested-brightgreen?logo=github)](https://github.com/wickra-lib/wickra/attestations)
+[![Docs](https://img.shields.io/badge/docs-docs.wickra.org-0ea5e9?logo=readthedocs&logoColor=white)](https://docs.wickra.org)
 
 **Streaming-first technical indicators. Install with `pip install wickra` — no system dependencies.**
 
@@ -36,6 +37,25 @@ for price in live_feed:
     if value is not None and value > 70:
         print("overbought")
 ```
+
+## Documentation
+
+Full documentation lives at **[docs.wickra.org](https://docs.wickra.org)**:
+
+- **Quickstarts** — [Rust](https://docs.wickra.org/Quickstart-Rust),
+  [Python](https://docs.wickra.org/Quickstart-Python),
+  [Node](https://docs.wickra.org/Quickstart-Node),
+  [WASM](https://docs.wickra.org/Quickstart-WASM).
+- **Indicators** — a per-indicator deep dive (formula, parameters, warmup) for
+  every one of the 214 indicators; start at the
+  [indicators overview](https://docs.wickra.org/Indicators-Overview).
+- **Reference** — [warmup periods](https://docs.wickra.org/Warmup-Periods),
+  [streaming vs batch](https://docs.wickra.org/Streaming-vs-Batch),
+  [indicator chaining](https://docs.wickra.org/Indicator-Chaining), the
+  [data layer](https://docs.wickra.org/Data-Layer).
+- **Guides** — [Cookbook](https://docs.wickra.org/Cookbook),
+  [TA-Lib migration](https://docs.wickra.org/TA-Lib-Migration),
+  [FAQ](https://docs.wickra.org/FAQ).
 
 ## Why Wickra exists
 
@@ -117,7 +137,8 @@ python -m benchmarks.compare_libraries
 
 214 streaming-first indicators across sixteen families. Every one passes the
 `batch == streaming` equivalence test, reference-value tests, and reset
-semantics tests.
+semantics tests. Each has a per-indicator deep dive (formula, parameters,
+warmup) at [docs.wickra.org](https://docs.wickra.org/Indicators-Overview).
 
 | Family | Indicators |
 |--------|-----------|


### PR DESCRIPTION
Part of consolidating documentation onto **docs.wickra.org** and turning the GitHub wiki into a thin pointer instead of a stale 1:1 duplicate.

### 1. README → docs site (commit 1)
The main README never linked the canonical docs at docs.wickra.org — only the wickra.org banner. A repo visitor had no path to the per-indicator deep dives, quickstarts, or guides. This wires it directly, consistent with the binding READMEs, `docs/README.md`, `CONTRIBUTING.md`, and the PR template:
- Docs badge in the badge row.
- A `## Documentation` section (quickstarts, indicators overview, reference, guides).
- Indicators section links the per-indicator deep dives at docs.wickra.org/Indicators-Overview.

### 2. sync-about: keep the wiki pointer count current (commit 2)
The GitHub wiki was collapsed to a single `Home.md` that points at docs.wickra.org but still names the indicator count ("… for all N indicators"). Added a count-sync step that mirrors the existing docs/webpage steps — clone `wickra.wiki`, `sed` `Home.md`, commit as wickra-bot, push — with the same `continue-on-error` soft-skip so a missing PAT scope never fails the run.

Docs/CI only; no library code paths touched.