### PR TITLE
release: bump 0.4.0 -> 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-01
+
 ### Added
 - **Cross-asset pairwise indicators.** A new two-series family of
   `Indicator<Input = (f64, f64)>` implementations that relate two distinct
@@ -898,7 +900,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/wickra-lib/wickra/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/wickra-lib/wickra/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/wickra-lib/wickra/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/wickra-lib/wickra/compare/v0.2.7...v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "approx",
  "criterion",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "approx",
  "proptest",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "approx",
  "csv",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "napi",
  "napi-build",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "numpy",
  "pyo3",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
@@ -24,7 +24,7 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.4.0" }
+wickra-core = { path = "crates/wickra-core", version = "0.4.1" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wickra",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wickra",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -15,12 +15,12 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.4.0",
-        "wickra-darwin-x64": "0.4.0",
-        "wickra-linux-arm64-gnu": "0.4.0",
-        "wickra-linux-x64-gnu": "0.4.0",
-        "wickra-win32-arm64-msvc": "0.4.0",
-        "wickra-win32-x64-msvc": "0.4.0"
+        "wickra-darwin-arm64": "0.4.1",
+        "wickra-darwin-x64": "0.4.1",
+        "wickra-linux-arm64-gnu": "0.4.1",
+        "wickra-linux-x64-gnu": "0.4.1",
+        "wickra-win32-arm64-msvc": "0.4.1",
+        "wickra-win32-x64-msvc": "0.4.1"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -41,8 +41,8 @@
       }
     },
     "node_modules/wickra-darwin-arm64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.4.0.tgz",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.4.1.tgz",
       "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
       "cpu": [
         "arm64"
@@ -57,8 +57,8 @@
       }
     },
     "node_modules/wickra-darwin-x64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.4.0.tgz",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.4.1.tgz",
       "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
       "cpu": [
         "x64"
@@ -73,8 +73,8 @@
       }
     },
     "node_modules/wickra-linux-arm64-gnu": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.4.0.tgz",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.4.1.tgz",
       "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
       "cpu": [
         "arm64"
@@ -89,8 +89,8 @@
       }
     },
     "node_modules/wickra-linux-x64-gnu": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.4.0.tgz",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.4.1.tgz",
       "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
       "cpu": [
         "x64"
@@ -105,8 +105,8 @@
       }
     },
     "node_modules/wickra-win32-arm64-msvc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.4.0.tgz",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.4.1.tgz",
       "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
       "cpu": [
         "arm64"
@@ -121,8 +121,8 @@
       }
     },
     "node_modules/wickra-win32-x64-msvc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.4.0.tgz",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.4.1.tgz",
       "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
       "cpu": [
         "x64"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
@@ -47,12 +47,12 @@
     "node": ">= 18"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.4.0",
-    "wickra-linux-arm64-gnu": "0.4.0",
-    "wickra-darwin-x64": "0.4.0",
-    "wickra-darwin-arm64": "0.4.0",
-    "wickra-win32-x64-msvc": "0.4.0",
-    "wickra-win32-arm64-msvc": "0.4.0"
+    "wickra-linux-x64-gnu": "0.4.1",
+    "wickra-linux-arm64-gnu": "0.4.1",
+    "wickra-darwin-x64": "0.4.1",
+    "wickra-darwin-arm64": "0.4.1",
+    "wickra-win32-x64-msvc": "0.4.1",
+    "wickra-win32-arm64-msvc": "0.4.1"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.4.0"
+version = "0.4.1"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = { text = "PolyForm-Noncommercial-1.0.0" }

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../../bindings/node": {
       "name": "wickra",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -26,12 +26,12 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.4.0",
-        "wickra-darwin-x64": "0.4.0",
-        "wickra-linux-arm64-gnu": "0.4.0",
-        "wickra-linux-x64-gnu": "0.4.0",
-        "wickra-win32-arm64-msvc": "0.4.0",
-        "wickra-win32-x64-msvc": "0.4.0"
+        "wickra-darwin-arm64": "0.4.1",
+        "wickra-darwin-x64": "0.4.1",
+        "wickra-linux-arm64-gnu": "0.4.1",
+        "wickra-linux-x64-gnu": "0.4.1",
+        "wickra-win32-arm64-msvc": "0.4.1",
+        "wickra-win32-x64-msvc": "0.4.1"
       }
     },
     "node_modules/wickra": {


### PR DESCRIPTION
Release **v0.4.1** — ships the cross-asset / pairwise indicator family
merged in #109.

## What's in 0.4.1

Five new two-series `Indicator<Input = (f64, f64)>` indicators (Rust +
Python + Node + WASM):

- **PairwiseBeta** — rolling OLS slope of one asset's log-returns on another's
- **PairSpreadZScore** — standardised log-spread of a pair (stat-arb signal)
- **LeadLagCrossCorrelation** — which asset leads the other, and by how many bars
- **Cointegration** — Engle–Granger hedge ratio + ADF stationarity test
- **RelativeStrengthAB** — ratio line `a/b` with its MA and RSI

Indicator count **214 → 219**.

## Version bump

- `Cargo.toml` (workspace + `wickra-core` dep), `Cargo.lock`
- `bindings/python/pyproject.toml`
- `bindings/node/package.json` (+ 6 optionalDependencies) and 6
  `bindings/node/npm/*/package.json`
- `bindings/node/package-lock.json`, `examples/node/package-lock.json`
- `CHANGELOG.md`: `[Unreleased] → [0.4.1] - 2026-06-01` + compare URL

No source changes — the indicators themselves landed in #109 (full test suite
green there: Rust 1792 unit + doctests, Node 301, Python 453).

Merging this PR and pushing the `v0.4.1` tag triggers `release.yml`
(crates.io / PyPI / npm / npm-wasm publish + GitHub release).