### PR TITLE
ci: self-updating README banner + fix webpage count sync

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -165,6 +165,10 @@ jobs:
         run: |
           n="${{ steps.count.outputs.count }}"
           sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" README.md
+          # Bump the banner cache-buster so GitHub's Camo proxy refetches the org
+          # profile image (regenerated with the new count by .github/banner.yml)
+          # instead of serving a stale cached copy.
+          sed -i -E "s|(wickra-banner\.webp\?v=)[0-9]+|\1${n}|" README.md
           if git diff --quiet; then
             echo "No README changes after sed (counter regex did not match anything); skipping push."
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -10,7 +10,7 @@ name: Sync indicator count
 #   3. Docs site: index.md / overview.md / Indicators-Overview.md
 #      (wickra-lib/wickra-docs) — synced on push to main / v* tag*
 #   4. Marketing site count (wickra-lib/webpage: index.md /
-#      .vitepress/config.ts / public/hero.svg) — push to main / v* tag*
+#      .vitepress/config.ts) — push to main / v* tag*
 #   5. org profile README count (wickra-lib/.github, profile/README.md)
 #                                            — synced on push to main / v* tag*
 #   6. org description ("… N indicators, install-free.")
@@ -424,14 +424,14 @@ jobs:
             exit 0
           fi
           cd webpage-count
-          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" index.md .vitepress/config.ts public/hero.svg
+          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" index.md .vitepress/config.ts
           if git diff --quiet; then
             echo "Webpage indicator count unchanged."
             exit 0
           fi
           git config user.name "wickra-bot"
           git config user.email "wickra-bot@users.noreply.github.com"
-          git add index.md .vitepress/config.ts public/hero.svg
+          git add index.md .vitepress/config.ts
           git commit -m "chore: sync indicator count to ${n}"
           if ! git push 2>/dev/null; then
             echo "::warning::push to wickra-lib/webpage failed — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a)."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every candlestick pattern, making the family a drop-in machine-learning
   feature where bullish and bearish instances share a single dimension.
 
+### Fixed
+- **README banner now self-updates.** The top README banner points at the org
+  profile image that `.github/banner.yml` regenerates from the indicator count,
+  and `sync-about.yml` bumps a `?v=<count>` cache-buster so GitHub's Camo proxy
+  refetches it immediately. Also fixes the webpage indicator-count sync, which
+  silently crashed on a removed `public/hero.svg` and left the marketing site's
+  count (and its OG banner) stale.
+
 ### Security
 - **CI dependency installs are pinned by hash.** The Node binding now installs
   with `npm ci` (strict `package-lock.json`), and the Python CI/bench tooling is

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://wickra.org"><img src="https://wickra.org/og-banner.webp" alt="Wickra — streaming-first technical indicators" width="100%"></a>
+  <a href="https://wickra.org"><img src="https://raw.githubusercontent.com/wickra-lib/.github/main/profile/wickra-banner.webp?v=227" alt="Wickra — streaming-first technical indicators" width="100%"></a>
 </p>
 
 [![CI](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml/badge.svg)](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml)


### PR DESCRIPTION
## What

- **Fix the webpage count sync.** `sync-about.yml`'s webpage step sed'd a `public/hero.svg` that was removed from wickra-lib/webpage, so under `bash -e` it exited 2 before the commit/push — the marketing site's indicator count (and its OG banner) silently stayed stale, masked green by `continue-on-error`. Drops `public/hero.svg`; `index.md` and `.vitepress/config.ts` (both still carry the count) remain.
- **Self-updating README banner.** Repoints the top README banner from `wickra.org/og-banner.webp` (baked at webpage deploy time, behind the broken sync chain) to the org profile image that `.github/banner.yml` regenerates from the count on every sync.
- **Cache-bust automation.** A `?v=<count>` query on the banner URL busts GitHub's Camo image cache; `sync-about.yml` now bumps it together with the indicator count in the existing PR-head patch — no extra commit on main.

## Why

The org profile banner is already self-updating (its `banner.yml` regenerates and commits the image whenever the count syncs), so reusing it makes the README banner current without depending on the webpage deploy + the now-fixed sync chain. The `?v=` bump removes the Camo lag.

Pure CI/docs change — no library code touched.