### PR TITLE
ci: bump actions/checkout to v6.0.2 (codeql & scorecard)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,7 +24,7 @@ jobs:
       id-token: write # OIDC token to publish results to the OpenSSF API
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Brings the two remaining `actions/checkout` pins up to the v6.0.2 SHA already used by the other 23 call sites across CI/release/sync. `codeql.yml` and `scorecard.yml` were still SHA-pinned at v4.3.1; this removes the v4 (Node 20) deprecation warning and unifies the version. Drop-in — checkout v6 only changes the bundled Node runtime (24), which GitHub-hosted runners already provide. SHA pins preserved for the Scorecard PinnedDependencies check.