### PR TITLE
ci: add zizmor GitHub Actions security scanning

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,40 @@
+name: zizmor
+
+# Static analysis of the GitHub Actions workflows themselves — the surface the
+# CodeQL pass does not cover. zizmor flags template injection, overly broad
+# GITHUB_TOKEN permissions, unpinned actions, cache poisoning, and dangerous
+# triggers. Findings appear under Security -> Code scanning alongside CodeQL.
+#
+# Report-only: with `advanced-security: true` the action runs zizmor in SARIF
+# mode, which exits 0 regardless of findings, so this job never blocks CI —
+# triage happens in the Security tab. Switch to gating later (e.g. a
+# `min-severity` input) once the existing findings are triaged.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 4 * * 1' # Mondays 04:17 UTC
+
+# Least-privilege default for the auto-injected GITHUB_TOKEN; the job raises
+# exactly the scopes it needs below (matches codeql.yml's pattern).
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Audit workflows
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to code-scanning
+      contents: read # checkout
+      actions: read # online audits resolve referenced actions
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
## What

New workflow `.github/workflows/zizmor.yml` — static security analysis of the **GitHub Actions workflows themselves**, the surface CodeQL does not cover: template injection, overly broad `GITHUB_TOKEN` permissions, unpinned actions, cache poisoning, dangerous triggers. Findings surface under **Security → Code scanning** alongside CodeQL.

## Report-only (does not block CI)

`zizmorcore/zizmor-action` runs with `advanced-security: true` → SARIF mode → **exits 0 regardless of findings**. The job uploads results but never blocks PRs. Triage happens in the Security tab; can be switched to gating later (e.g. a `min-severity` input) once the existing findings are triaged.

## Correctness

- Actions **pinned to SHA** (`checkout` = the SHA already used across the repo; `zizmor-action` = v0.5.6) → satisfies Scorecard PinnedDependencies and zizmor's own self-audit.
- **Least privilege**: top-level `contents: read`; the job raises only `security-events: write` + `contents: read` + `actions: read`.
- `persist-credentials: false` on checkout (zizmor pushes nothing).
- zizmor self-check of the new workflow: **0 active findings**.

## First-run expectation

zizmor will report ~46 pre-existing findings to the Security tab (12 high / 22 medium / 12 info) — mostly known trade-offs / false positives (e.g. `template-injection` on an internal grep count, low-confidence `artipacked`). These are triaged separately and block nothing thanks to report-only mode.