### PR TITLE
fix: keep docs/README indicator count in sync-about

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -144,19 +144,20 @@ jobs:
         id: pr_check
         run: |
           n="${{ steps.count.outputs.count }}"
-          if grep -qE "^${n} streaming-first indicators" README.md; then
+          if grep -qE "^${n} streaming-first indicators" README.md \
+            && grep -qE "\*\*${n} indicators\*\*" docs/README.md; then
             echo "matches=true" >> "$GITHUB_OUTPUT"
-            echo "README counter already at ${n}; nothing to do."
+            echo "README + docs/README counter already at ${n}; nothing to do."
           else
             echo "matches=false" >> "$GITHUB_OUTPUT"
-            echo "README counter does not match ${n}; will fix up."
+            echo "README/docs counter does not match ${n}; will fix up."
           fi
 
       - name: Fix counter on fork PR head (read-only, fail loud)
         if: github.event_name == 'pull_request' && steps.pr_check.outputs.matches == 'false' && steps.ctx.outputs.can_push == 'false'
         run: |
           n="${{ steps.count.outputs.count }}"
-          echo "::error::README.md says a different indicator count than mod.rs (${n}). This PR is from a fork, so the workflow cannot push the fix; please update README.md to '${n} streaming-first indicators' and push again."
+          echo "::error::README.md / docs/README.md say a different indicator count than lib.rs (${n}). This PR is from a fork, so the workflow cannot push the fix; please set README.md to '${n} streaming-first indicators' and docs/README.md to '**${n} indicators**', then push again."
           exit 1
 
       - name: Patch README on PR head
@@ -164,10 +165,12 @@ jobs:
         id: pr_patch
         run: |
           n="${{ steps.count.outputs.count }}"
-          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" README.md
+          # docs/README.md carries the count in its docs.wickra.org pointer prose
+          # ("**N indicators**"); keep it in sync with README's prose count.
+          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" README.md docs/README.md
           # Bump the banner cache-buster so GitHub's Camo proxy refetches the org
           # profile image (regenerated with the new count by .github/banner.yml)
-          # instead of serving a stale cached copy.
+          # instead of serving a stale cached copy. (README only — docs has no banner.)
           sed -i -E "s|(wickra-banner\.webp\?v=)[0-9]+|\1${n}|" README.md
           if git diff --quiet; then
             echo "No README changes after sed (counter regex did not match anything); skipping push."
@@ -187,7 +190,7 @@ jobs:
         run: |
           git config user.name "wickra-bot"
           git config user.email "wickra-bot@users.noreply.github.com"
-          git add README.md
+          git add README.md docs/README.md
           git commit -m "chore: sync indicator count to ${COUNT}"
           git push origin "HEAD:${HEAD_REF}"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ when proposing features or depending on Wickra elsewhere.
 | `bindings/node` | napi-rs bindings (`wickra` on npm). |
 | `bindings/wasm` | wasm-bindgen bindings (`wickra-wasm` on npm). |
 | `examples/` | Runnable examples. |
-| `docs/` | Pointer to the project Wiki, which holds all documentation. |
+| `docs/` | Pointer to the documentation site (docs.wickra.org); the docs live in the `wickra-lib/wickra-docs` repo. |
 
 ## Building and testing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ That includes:
   [Python](https://docs.wickra.org/Quickstart-Python),
   [Node](https://docs.wickra.org/Quickstart-Node), and
   [WASM](https://docs.wickra.org/Quickstart-WASM).
-- A per-indicator deep dive for every one of the **214 indicators** across
+- A per-indicator deep dive for every one of the **249 indicators** across
   the sixteen families (Moving Averages, Momentum Oscillators, Trend &
   Directional, Price Oscillators, Volatility & Bands, Bands & Channels,
   Trailing Stops, Volume, Price Statistics, Ehlers / Cycle DSP, Pivots &


### PR DESCRIPTION
## Problem

`docs/README.md` (the docs.wickra.org pointer page) names the indicator
count in prose — `**N indicators**` — but that file was never part of the
`sync-about.yml` counter pipeline. As a result it drifted to **214** while
the authoritative count from `crates/wickra-core/src/lib.rs` is **249**
(README and the GitHub About description are both already at 249).

## Fix

- Correct the stale value in `docs/README.md` (214 → 249).
- Wire `docs/README.md` into `sync-about.yml`'s PR flow so it stays in sync
  automatically on every future count change:
  - **Gate check** now also requires `**N indicators**` in `docs/README.md`.
  - **Patch `sed`** now rewrites `docs/README.md` alongside `README.md`
    (the count regex already matched the line).
  - **Fix-up commit** now `git add`s `docs/README.md`.
  - Fork fallback error message updated to mention both files.

The banner cache-buster `sed` stays README-only (docs has no banner).

## Verification

- YAML validates.
- Both gate greps match the corrected files (clean PR = no-op).
- The patch `sed` transforms the old `214 indicators` line to `249 indicators`.