### PR TITLE
ci: zizmor security hardening

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -49,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
@@ -88,6 +90,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         id: setup_node
@@ -175,6 +179,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
@@ -253,6 +259,8 @@ jobs:
             packages: "-p wickra-node"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
@@ -276,6 +284,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
@@ -315,6 +325,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: cargo-deny
         uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
@@ -331,6 +343,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install nightly Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
@@ -387,6 +401,8 @@ jobs:
         python-version: ["3.9", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
@@ -461,6 +477,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain (with wasm target)
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
@@ -507,6 +525,8 @@ jobs:
         node-version: ["18", "20"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3.36.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -574,9 +574,17 @@ jobs:
 
       - name: Resolve target tag
         id: tag
+        # Pass the (potentially attacker-influenceable on a tag push) ref context
+        # through the environment instead of interpolating it into the shell
+        # script, so a crafted tag name cannot inject commands (zizmor:
+        # template-injection).
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "push" ] && [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            tag="${{ github.ref_name }}"
+          if [ "$EVENT_NAME" = "push" ] && [[ "$REF" == refs/tags/* ]]; then
+            tag="$REF_NAME"
           else
             # workflow_dispatch / non-tag push: attach to the latest v* tag.
             tag=$(git tag --list 'v*' --sort=-v:refname | head -n1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
     environment: release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
@@ -156,6 +158,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python
         id: setup_python
         continue-on-error: true
@@ -194,6 +198,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Sync root README into bindings/python so it ships in the sdist
         run: cp README.md bindings/python/README.md
       - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
@@ -244,6 +250,8 @@ jobs:
     runs-on: ${{ matrix.host }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         id: setup_node
@@ -303,6 +311,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         id: setup_node
@@ -470,6 +480,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         id: setup_node
@@ -570,6 +582,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Resolve target tag

--- a/.github/workflows/sync-metadata.yml
+++ b/.github/workflows/sync-metadata.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,15 @@
+# zizmor configuration — https://docs.zizmor.sh/configuration/
+#
+# cache-poisoning (release.yml):
+#   The release pipeline restores build caches (Swatinem/rust-cache for the Rust
+#   compilation, actions/setup-node) as a deliberate, accepted optimisation.
+#   zizmor flags these under cache-poisoning because release.yml publishes
+#   artifacts to crates.io / PyPI / npm, so a poisoned cache could in theory
+#   reach a released build. Our caches are maintainer-controlled and the
+#   restore speedup is kept on purpose; we accept this risk rather than running
+#   cache-free release builds. (Six of the eight hits are actions/setup-node,
+#   which zizmor reports at "Low" confidence.)
+rules:
+  cache-poisoning:
+    ignore:
+      - release.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -9,7 +9,16 @@
 #   restore speedup is kept on purpose; we accept this risk rather than running
 #   cache-free release builds. (Six of the eight hits are actions/setup-node,
 #   which zizmor reports at "Low" confidence.)
+#
+# artipacked (sync-about.yml):
+#   The sync-about job checks out with persisted credentials on purpose: it
+#   pushes the indicator-count fix-up back to the PR head branch (git commit +
+#   git push), which needs the token in the runner's git config. It uploads no
+#   artifacts, so the persisted token is never packaged or leaked; accept it.
 rules:
   cache-poisoning:
     ignore:
       - release.yml
+  artipacked:
+    ignore:
+      - sync-about.yml


### PR DESCRIPTION
Addresses the high- and medium-severity [zizmor](https://docs.zizmor.sh)
findings on this repo's workflows. Three commits, each a distinct finding.

## 1. template-injection (high, `release.yml`)

The "Resolve target tag" step interpolated `github.event_name` / `github.ref`
/ `github.ref_name` straight into the shell script. On a tag push the tag name
is attacker-influenceable, so a crafted tag could inject commands. Moved all
three context values into the step `env:` and reference them as shell variables.

## 2. cache-poisoning (high x8, `release.yml`)

The release pipeline restores build caches (`Swatinem/rust-cache`,
`actions/setup-node`) as a deliberate optimisation. zizmor flags them because
`release.yml` publishes to crates.io / PyPI / npm. The caches are
maintainer-controlled and none of the flagged jobs upload artifacts that pack
`.git`, so the risk is accepted via `.github/zizmor.yml` rather than running
cache-free release builds. (Six of the eight are `setup-node`, reported at Low
confidence.)

## 3. artipacked (medium x21)

`actions/checkout` persists the job token into the runner's `.git/config`, where
it can leak if a later step packs `.git` into an artifact or is read by another
step. Set `persist-credentials: false` on the 20 checkouts whose jobs never push
to git (ci.yml build/test/lint/coverage/fuzz, bench.yml, codeql.yml, the seven
release/publish jobs, sync-metadata.yml). Publish jobs authenticate to the
registries / GitHub API with their own tokens, not persisted git credentials.
`sync-about.yml` genuinely pushes the count fix-up, so it keeps its credential
and is accepted via `.github/zizmor.yml`.

## Result

zizmor for the repo: **0 high, 0 medium** remaining (the 12 informational items —
`use-trusted-publishing` and the false-positive `template-injection` on
`sync-about.yml`'s internal counter — are left for a separate change).