### PR TITLE
ci: Dependabot cooldown + accept residual zizmor notes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "deps(cargo)"
 
@@ -15,6 +17,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "deps(npm)"
 
@@ -24,6 +28,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "deps(pip)"
 
@@ -37,6 +43,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "deps(ci-pip)"
 
@@ -47,5 +55,7 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "deps(actions)"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -15,6 +15,22 @@
 #   pushes the indicator-count fix-up back to the PR head branch (git commit +
 #   git push), which needs the token in the runner's git config. It uploads no
 #   artifacts, so the persisted token is never packaged or leaked; accept it.
+#
+# template-injection (sync-about.yml):
+#   False positive. Every flagged expansion is steps.count.outputs.count, the
+#   indicator count produced by an internal `grep -c` over lib.rs. It is not
+#   attacker-controllable, so there is nothing to inject.
+#
+# use-trusted-publishing (release.yml):
+#   Informational suggestion to use OIDC trusted publishing for PyPI / npm
+#   instead of long-lived tokens. A worthwhile migration, but it reconfigures
+#   the live publish pipeline on the registry side; tracked separately rather
+#   than blocking on it here.
+#
+# superfluous-actions (release.yml):
+#   The GitHub release step uses softprops/action-gh-release. The runner ships
+#   `gh`, so this is replaceable by a script step, but the action is stable and
+#   battle-tested; we keep it deliberately.
 rules:
   cache-poisoning:
     ignore:
@@ -22,3 +38,12 @@ rules:
   artipacked:
     ignore:
       - sync-about.yml
+  template-injection:
+    ignore:
+      - sync-about.yml
+  use-trusted-publishing:
+    ignore:
+      - release.yml
+  superfluous-actions:
+    ignore:
+      - release.yml


### PR DESCRIPTION
Clears the remaining zizmor code-scanning findings on this repo.

**Fixed**
- `dependabot-cooldown` (5): a 7-day cooldown on every update ecosystem
  (cargo, npm, pip, ci-pip, github-actions) so Dependabot waits a week after a
  release before opening the bump PR.

**Accepted via `.github/zizmor.yml`** (no workflow code changed)
- `template-injection` (sync-about.yml): false positive — every expansion is the
  internal `grep -c` indicator count, not attacker-controllable.
- `use-trusted-publishing` (release.yml): OIDC migration tracked separately.
- `superfluous-actions` (release.yml): `softprops/action-gh-release` kept deliberately.

Verified with zizmor 1.25.2: 0 findings.