### PR TITLE
fix: classify pairwise indicators into Price Statistics family

### DIFF
--- a/crates/wickra-core/src/indicators/mod.rs
+++ b/crates/wickra-core/src/indicators/mod.rs
@@ -836,6 +836,11 @@ pub const FAMILIES: &[(&str, &[&str])] = &[
             "PearsonCorrelation",
             "Beta",
             "SpearmanCorrelation",
+            "Cointegration",
+            "LeadLagCrossCorrelation",
+            "PairSpreadZScore",
+            "PairwiseBeta",
+            "RelativeStrengthAB",
             "MidPrice",
             "MidPoint",
             "AvgPrice",
@@ -1061,6 +1066,6 @@ mod family_tests {
         // the actual indicator count is the early-warning signal that an
         // indicator was added without being assigned a family.
         let total: usize = FAMILIES.iter().map(|(_, ns)| ns.len()).sum();
-        assert_eq!(total, 309, "FAMILIES total drifted from indicator count");
+        assert_eq!(total, 314, "FAMILIES total drifted from indicator count");
     }
 }


### PR DESCRIPTION
## What

The `FAMILIES` table in `crates/wickra-core/src/indicators/mod.rs` had drifted from the indicator count: `mod`-count was **314** but the FAMILIES total asserted **309**.

The five pairwise indicators `Cointegration`, `LeadLagCrossCorrelation`, `PairSpreadZScore`, `PairwiseBeta` and `RelativeStrengthAB` were exported via `pub use` but never assigned to a `FAMILIES` group — even though the README and docs already list them under **Price Statistics**. The "−5 offset" was therefore unclassified drift, not an intentional cross-asset offset.

## Change

- Add the five indicators to the `Price Statistics` group, next to the existing pairwise cluster (`PearsonCorrelation` / `Beta` / `SpearmanCorrelation`).
- Bump the drift assert `309 → 314` so the FAMILIES total now equals the `mod`-count exactly (offset 0).

No new indicators, no binding or doc changes — purely re-classification. The `mod`-count stays 314, so no counter bump.

## Verify

- `cargo fmt --all` clean
- `cargo test -p wickra-core --lib` → 2578 passed (incl. the FAMILIES drift test)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean