### PR TITLE
ci(scorecard): pass a read-only PAT for the Branch-Protection check

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,6 +33,13 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # The default GITHUB_TOKEN cannot read classic branch-protection
+          # rules, so the Branch-Protection check fails with an internal error
+          # and scores -1. A read-only fine-grained PAT (Administration: read,
+          # Contents: read, Metadata: read) supplied as SCORECARD_TOKEN lets the
+          # check read the protection settings. See
+          # https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           # Publish to the public OpenSSF endpoint that backs the README badge.
           publish_results: true
 


### PR DESCRIPTION
The OpenSSF Scorecard **Branch-Protection** check currently fails with:

```
internal error: some github tokens can't read classic branch protection rules
```

The default `GITHUB_TOKEN` cannot read classic branch-protection rules, so since branch protection was enabled on `main` the check scores **-1**, dragging the overall score down.

## Fix
Pass a read-only fine-grained PAT as `repo_token` (input `SCORECARD_TOKEN`). Per the [scorecard-action auth docs](https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md).

## Required secret (repo → Settings → Secrets and variables → Actions)
Create **`SCORECARD_TOKEN`** = a fine-grained PAT scoped to `wickra-lib/wickra` with **read-only**:
- Administration: Read-only (branch protection)
- Contents: Read-only
- Metadata: Read-only (mandatory)

Until the secret exists the input is empty and the action falls back to `GITHUB_TOKEN` (no regression). Once present, the Branch-Protection check reads the rules and scores properly.