### PR TITLE
release: bump 0.5.2 -> 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.3] - 2026-06-04
 - **Fibonacci Time Zones** — vertical markers at Fibonacci bar-distances (1/2/3/5/8/...) from the latest swing pivot (`FIB_TIME_ZONES`).
 - **Fibonacci Channel** — a sloped base trendline plus parallel lines at Fibonacci multiples of the channel width (`FIB_CHANNEL`).
 - **Fibonacci Arcs** — semicircular retracement levels centred on the swing end, normalised by leg bar-width (`FIB_ARCS`).
@@ -1215,7 +1217,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.5.3...HEAD
+[0.5.3]: https://github.com/wickra-lib/wickra/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/wickra-lib/wickra/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/wickra-lib/wickra/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/wickra-lib/wickra/compare/v0.4.7...v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "approx",
  "criterion",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "approx",
  "proptest",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "approx",
  "csv",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "napi",
  "napi-build",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "numpy",
  "pyo3",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
@@ -24,7 +24,7 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.5.2" }
+wickra-core = { path = "crates/wickra-core", version = "0.5.3" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wickra",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wickra",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -15,12 +15,12 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.5.2",
-        "wickra-darwin-x64": "0.5.2",
-        "wickra-linux-arm64-gnu": "0.5.2",
-        "wickra-linux-x64-gnu": "0.5.2",
-        "wickra-win32-arm64-msvc": "0.5.2",
-        "wickra-win32-x64-msvc": "0.5.2"
+        "wickra-darwin-arm64": "0.5.3",
+        "wickra-darwin-x64": "0.5.3",
+        "wickra-linux-arm64-gnu": "0.5.3",
+        "wickra-linux-x64-gnu": "0.5.3",
+        "wickra-win32-arm64-msvc": "0.5.3",
+        "wickra-win32-x64-msvc": "0.5.3"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -41,8 +41,8 @@
       }
     },
     "node_modules/wickra-darwin-arm64": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.5.2.tgz",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.5.3.tgz",
       "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
       "cpu": [
         "arm64"
@@ -57,8 +57,8 @@
       }
     },
     "node_modules/wickra-darwin-x64": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.5.2.tgz",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.5.3.tgz",
       "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
       "cpu": [
         "x64"
@@ -73,8 +73,8 @@
       }
     },
     "node_modules/wickra-linux-arm64-gnu": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.5.2.tgz",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.5.3.tgz",
       "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
       "cpu": [
         "arm64"
@@ -89,8 +89,8 @@
       }
     },
     "node_modules/wickra-linux-x64-gnu": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.5.2.tgz",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.5.3.tgz",
       "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
       "cpu": [
         "x64"
@@ -105,8 +105,8 @@
       }
     },
     "node_modules/wickra-win32-arm64-msvc": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.5.2.tgz",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.5.3.tgz",
       "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
       "cpu": [
         "arm64"
@@ -121,8 +121,8 @@
       }
     },
     "node_modules/wickra-win32-x64-msvc": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.5.2.tgz",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.5.3.tgz",
       "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
       "cpu": [
         "x64"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
@@ -47,12 +47,12 @@
     "node": ">= 18"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.5.2",
-    "wickra-linux-arm64-gnu": "0.5.2",
-    "wickra-darwin-x64": "0.5.2",
-    "wickra-darwin-arm64": "0.5.2",
-    "wickra-win32-x64-msvc": "0.5.2",
-    "wickra-win32-arm64-msvc": "0.5.2"
+    "wickra-linux-x64-gnu": "0.5.3",
+    "wickra-linux-arm64-gnu": "0.5.3",
+    "wickra-darwin-x64": "0.5.3",
+    "wickra-darwin-arm64": "0.5.3",
+    "wickra-win32-x64-msvc": "0.5.3",
+    "wickra-win32-arm64-msvc": "0.5.3"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.5.2"
+version = "0.5.3"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../../bindings/node": {
       "name": "wickra",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -26,12 +26,12 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.5.2",
-        "wickra-darwin-x64": "0.5.2",
-        "wickra-linux-arm64-gnu": "0.5.2",
-        "wickra-linux-x64-gnu": "0.5.2",
-        "wickra-win32-arm64-msvc": "0.5.2",
-        "wickra-win32-x64-msvc": "0.5.2"
+        "wickra-darwin-arm64": "0.5.3",
+        "wickra-darwin-x64": "0.5.3",
+        "wickra-linux-arm64-gnu": "0.5.3",
+        "wickra-linux-x64-gnu": "0.5.3",
+        "wickra-win32-arm64-msvc": "0.5.3",
+        "wickra-win32-x64-msvc": "0.5.3"
       }
     },
     "node_modules/wickra": {


### PR DESCRIPTION
Version bump publishing the **Fibonacci** family (10 tools across A5a + A5b, catalogue 377 indicators / twenty-four families):

`FibRetracement`, `FibExtension`, `FibProjection`, `AutoFib`, `GoldenPocket`, `FibConfluence`, `FibFan`, `FibArcs`, `FibChannel`, `FibTimeZones`.

Version strings + lockfiles only (Cargo.toml, pyproject.toml, package.json + 6 npm platform manifests, both package-lock.json, Cargo.lock); CHANGELOG `[0.5.3]` section + compare URLs.