### PR TITLE
docs+ci: star-history chart, drop token-pool badges, sync docs config count

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -180,14 +180,14 @@ jobs:
             exit 0
           fi
           cd docs-count
-          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" index.md overview.md Indicators-Overview.md
+          sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" index.md overview.md Indicators-Overview.md .vitepress/config.ts
           if git diff --quiet; then
             echo "Docs indicator count unchanged."
             exit 0
           fi
           git config user.name "wickra-bot"
           git config user.email "wickra-bot@users.noreply.github.com"
-          git add index.md overview.md Indicators-Overview.md
+          git add index.md overview.md Indicators-Overview.md .vitepress/config.ts
           git commit -m "chore: sync indicator count to ${n}"
           if ! git push 2>/dev/null; then
             echo "::warning::push to wickra-lib/wickra-docs failed — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a)."

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml/badge.svg)](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/wickra-lib/wickra/actions/workflows/codeql.yml/badge.svg)](https://github.com/wickra-lib/wickra/actions/workflows/codeql.yml)
 [![codecov](https://codecov.io/gh/wickra-lib/wickra/branch/main/graph/badge.svg)](https://codecov.io/gh/wickra-lib/wickra)
+[![GitHub release](https://img.shields.io/github/v/release/wickra-lib/wickra?logo=github&color=green)](https://github.com/wickra-lib/wickra/releases/latest)
 [![crates.io](https://img.shields.io/crates/v/wickra.svg?logo=rust&color=orange)](https://crates.io/crates/wickra)
 [![PyPI](https://img.shields.io/pypi/v/wickra.svg?logo=pypi&color=blue)](https://pypi.org/project/wickra/)
 [![npm](https://img.shields.io/npm/v/wickra.svg?logo=npm&color=red)](https://www.npmjs.com/package/wickra)
@@ -411,12 +412,24 @@ The library is provided **as is**, without warranty of any kind; see
 ---
 
 <p align="center">
-  <a href="https://star-history.com/#wickra-lib/wickra&Date">
-    <img alt="Wickra star history" width="640"
-         src="https://api.star-history.com/svg?repos=wickra-lib/wickra&type=Date&theme=dark">
+  <a href="https://github.com/wickra-lib/wickra/stargazers">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=ffd866">
+  </a>
+  <a href="https://github.com/wickra-lib/wickra/network/members">
+    <img alt="GitHub forks" src="https://img.shields.io/github/forks/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=78dce8">
+  </a>
+  <a href="https://github.com/wickra-lib/wickra/issues">
+    <img alt="GitHub issues" src="https://img.shields.io/github/issues/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=ff6188">
   </a>
 </p>
 
 <p align="center">
   If Wickra saved you time, the cheapest way to say thanks is to ⭐ the repo.
+</p>
+
+<p align="center">
+  <a href="https://star-history.com/#wickra-lib/wickra&Date">
+    <img alt="Wickra star history" width="640"
+         src="https://api.star-history.com/svg?repos=wickra-lib/wickra&type=Date&theme=dark">
+  </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![CI](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml/badge.svg)](https://github.com/wickra-lib/wickra/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/wickra-lib/wickra/actions/workflows/codeql.yml/badge.svg)](https://github.com/wickra-lib/wickra/actions/workflows/codeql.yml)
 [![codecov](https://codecov.io/gh/wickra-lib/wickra/branch/main/graph/badge.svg)](https://codecov.io/gh/wickra-lib/wickra)
-[![GitHub release](https://img.shields.io/github/v/release/wickra-lib/wickra?logo=github&color=green)](https://github.com/wickra-lib/wickra/releases/latest)
 [![crates.io](https://img.shields.io/crates/v/wickra.svg?logo=rust&color=orange)](https://crates.io/crates/wickra)
 [![PyPI](https://img.shields.io/pypi/v/wickra.svg?logo=pypi&color=blue)](https://pypi.org/project/wickra/)
 [![npm](https://img.shields.io/npm/v/wickra.svg?logo=npm&color=red)](https://www.npmjs.com/package/wickra)
@@ -412,24 +411,12 @@ The library is provided **as is**, without warranty of any kind; see
 ---
 
 <p align="center">
-  <a href="https://github.com/wickra-lib/wickra/stargazers">
-    <img alt="GitHub stars" src="https://img.shields.io/github/stars/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=ffd866">
-  </a>
-  <a href="https://github.com/wickra-lib/wickra/network/members">
-    <img alt="GitHub forks" src="https://img.shields.io/github/forks/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=78dce8">
-  </a>
-  <a href="https://github.com/wickra-lib/wickra/issues">
-    <img alt="GitHub issues" src="https://img.shields.io/github/issues/wickra-lib/wickra?style=for-the-badge&logo=github&logoColor=white&color=ff6188">
+  <a href="https://star-history.com/#wickra-lib/wickra&Date">
+    <img alt="Wickra star history" width="640"
+         src="https://api.star-history.com/svg?repos=wickra-lib/wickra&type=Date&theme=dark">
   </a>
 </p>
 
 <p align="center">
   If Wickra saved you time, the cheapest way to say thanks is to ⭐ the repo.
-</p>
-
-<p align="center">
-  <a href="https://github.com/wickra-lib/wickra">
-    <img alt="Star Wickra on GitHub"
-         src="https://img.shields.io/badge/%E2%AD%90%20Star%20Wickra%20on%20GitHub-1f2328?style=for-the-badge&logo=github&logoColor=ffd866&labelColor=1f2328">
-  </a>
 </p>


### PR DESCRIPTION
Two robustness fixes: (1) the wickra README's footer social badges and top GitHub-release badge hot-link shields.io github/* endpoints that error with 'unable to select next github token from pool' during token-pool exhaustion — replaced with a dark-mode star-history chart and dropped the redundant release badge (crates/PyPI/npm cover the version via non-token-pool APIs). (2) sync-about now also syncs the indicator count into wickra-docs .vitepress/config.ts, which had drifted to 214.