### PR TITLE
release: bump 0.7.0 -> 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.7.1] - 2026-06-08
 - **Open-Interest Momentum** — rate-of-change of open interest over a rolling window (`OpenInterestMomentum`).
 - **Funding-Implied APR** — annualised funding rate (per-interval funding times intervals per year) (`FundingImpliedApr`).
 - **Perpetual Premium Index** — relative premium of the mark price over the index price (`PerpetualPremiumIndex`).
@@ -1387,7 +1389,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/wickra-lib/wickra/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/wickra-lib/wickra/compare/v0.6.9...v0.7.0
 [0.6.9]: https://github.com/wickra-lib/wickra/compare/v0.6.8...v0.6.9
 [0.6.8]: https://github.com/wickra-lib/wickra/compare/v0.6.7...v0.6.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "approx",
  "criterion",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-bench"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "kand",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "approx",
  "proptest",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "approx",
  "csv",
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-examples"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde_json",
  "tokio",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "napi",
  "napi-build",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "numpy",
  "pyo3",
@@ -2023,7 +2023,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
@@ -25,7 +25,7 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.7.0" }
+wickra-core = { path = "crates/wickra-core", version = "0.7.1" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wickra",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wickra",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -15,12 +15,12 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.7.0",
-        "wickra-darwin-x64": "0.7.0",
-        "wickra-linux-arm64-gnu": "0.7.0",
-        "wickra-linux-x64-gnu": "0.7.0",
-        "wickra-win32-arm64-msvc": "0.7.0",
-        "wickra-win32-x64-msvc": "0.7.0"
+        "wickra-darwin-arm64": "0.7.1",
+        "wickra-darwin-x64": "0.7.1",
+        "wickra-linux-arm64-gnu": "0.7.1",
+        "wickra-linux-x64-gnu": "0.7.1",
+        "wickra-win32-arm64-msvc": "0.7.1",
+        "wickra-win32-x64-msvc": "0.7.1"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -41,8 +41,8 @@
       }
     },
     "node_modules/wickra-darwin-arm64": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.7.0.tgz",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.7.1.tgz",
       "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
       "cpu": [
         "arm64"
@@ -57,8 +57,8 @@
       }
     },
     "node_modules/wickra-darwin-x64": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.7.0.tgz",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.7.1.tgz",
       "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
       "cpu": [
         "x64"
@@ -73,8 +73,8 @@
       }
     },
     "node_modules/wickra-linux-arm64-gnu": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.7.0.tgz",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.7.1.tgz",
       "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
       "cpu": [
         "arm64"
@@ -89,8 +89,8 @@
       }
     },
     "node_modules/wickra-linux-x64-gnu": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.7.0.tgz",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.7.1.tgz",
       "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
       "cpu": [
         "x64"
@@ -105,8 +105,8 @@
       }
     },
     "node_modules/wickra-win32-arm64-msvc": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.7.0.tgz",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.7.1.tgz",
       "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
       "cpu": [
         "arm64"
@@ -121,8 +121,8 @@
       }
     },
     "node_modules/wickra-win32-x64-msvc": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.7.0.tgz",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.7.1.tgz",
       "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
       "cpu": [
         "x64"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
@@ -47,12 +47,12 @@
     "node": ">= 18"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.7.0",
-    "wickra-linux-arm64-gnu": "0.7.0",
-    "wickra-darwin-x64": "0.7.0",
-    "wickra-darwin-arm64": "0.7.0",
-    "wickra-win32-x64-msvc": "0.7.0",
-    "wickra-win32-arm64-msvc": "0.7.0"
+    "wickra-linux-x64-gnu": "0.7.1",
+    "wickra-linux-arm64-gnu": "0.7.1",
+    "wickra-darwin-x64": "0.7.1",
+    "wickra-darwin-arm64": "0.7.1",
+    "wickra-win32-x64-msvc": "0.7.1",
+    "wickra-win32-arm64-msvc": "0.7.1"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.7.0"
+version = "0.7.1"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../../bindings/node": {
       "name": "wickra",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -26,12 +26,12 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.7.0",
-        "wickra-darwin-x64": "0.7.0",
-        "wickra-linux-arm64-gnu": "0.7.0",
-        "wickra-linux-x64-gnu": "0.7.0",
-        "wickra-win32-arm64-msvc": "0.7.0",
-        "wickra-win32-x64-msvc": "0.7.0"
+        "wickra-darwin-arm64": "0.7.1",
+        "wickra-darwin-x64": "0.7.1",
+        "wickra-linux-arm64-gnu": "0.7.1",
+        "wickra-linux-x64-gnu": "0.7.1",
+        "wickra-win32-arm64-msvc": "0.7.1",
+        "wickra-win32-x64-msvc": "0.7.1"
       }
     },
     "node_modules/wickra": {


### PR DESCRIPTION
Version bump 0.7.0 → 0.7.1 for the B16 Derivatives batch (493 indicators): `EstimatedLeverageRatio`, `OiToVolumeRatio`, `PerpetualPremiumIndex`, `FundingImpliedApr`, `OpenInterestMomentum`. Only version strings + CHANGELOG; no code changes.