### PR TITLE
Check out the PR head by SHA in the count-sync workflow

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -86,10 +86,17 @@ jobs:
       # merge ref) so the counter check validates exactly what will land. On
       # push events we check out the default ref. No push is made, so a shallow
       # checkout is enough.
+      #
+      # Check out by head SHA, not head ref (branch name): a fast `gh pr merge
+      # --squash --delete-branch` deletes the head branch the moment the PR
+      # merges, often before this queued read-only check reaches its checkout.
+      # Fetching the now-gone `refs/heads/<branch>` then fails the run (exit 1).
+      # The head SHA stays reachable via `refs/pull/N/head` after the branch is
+      # gone, so the checkout — and the run — survives an instant merge.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Count indicators


### PR DESCRIPTION
## Problem
The **Sync indicator count** check has failed on every release-bump PR since 0.7.5 (`release/0.7.6`, `release/0.7.7`, …). It is a race, not a counter mismatch.

The checkout step used the PR head **branch name**:
\`\`\`yaml
ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
\`\`\`
Release PRs are merged with \`gh pr merge --squash --delete-branch\`, which deletes the head branch the instant the PR merges — usually before this queued read-only check reaches its checkout. Fetching the now-gone \`refs/heads/release/X.Y.Z\` then fails with exit 1 (3 retries, then error). Push-to-main, tag and slower feature PRs stayed green because their head branch still existed when the check ran.

## Fix
Check out \`github.event.pull_request.head.sha\` instead. The head SHA stays reachable via \`refs/pull/N/head\` after the branch is deleted, so an instant merge no longer red-Xes the run. It is still the author's head commit (not the merge ref), so the counter validates exactly what will land — the existing design intent is preserved.

Because \`pull_request\` runs the workflow definition from the merge commit, the fix already applies to this PR itself.