### PR TITLE
release: bump 0.7.9 -> 0.8.0 + Go module mirror

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -775,6 +775,95 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: mvn -B -f bindings/java -Prelease deploy -DskipTests
 
+  # Mirror the in-repo Go module (bindings/go) to the standalone wickra-go
+  # repository so `go get github.com/wickra-lib/wickra-go` builds with no extra
+  # steps. The in-repo module keeps the prebuilt libraries git-ignored; the
+  # mirror commits them per platform under lib/<goos>_<goarch>/ alongside the
+  # vendored header. Independent of the GitHub-release job so a Go hiccup never
+  # blocks the C/C++ asset release. The push uses a fine-grained PAT
+  # (WICKRA_GO_MIRROR_TOKEN, contents:write on wickra-go); the mirror is a
+  # derived artifact, so its bot commit is intentionally unsigned.
+  go-mirror:
+    name: Mirror the Go module to wickra-go
+    needs: c-abi-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download the C ABI native libraries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: c-abi-*
+          path: c-abi-artifacts
+
+      - name: Assemble the wickra-go module tree
+        shell: bash
+        run: |
+          set -e
+          out=wickra-go-module
+          mkdir -p "$out/include" "$out/lib"
+          # Single-package Go source + vendored C ABI header.
+          cp bindings/go/*.go "$out/"
+          cp bindings/go/include/wickra.h "$out/include/"
+          cp bindings/go/README.md "$out/"
+          # Standalone module path (the in-repo go.mod points at the subdir).
+          printf 'module github.com/wickra-lib/wickra-go\n\ngo 1.23\n' > "$out/go.mod"
+          # Point install instructions at the standalone module path.
+          sed -i 's#github.com/wickra-lib/wickra/bindings/go#github.com/wickra-lib/wickra-go#g' \
+            "$out/README.md" "$out"/*.go
+          # Stage each prebuilt library under lib/<goos>_<goarch>/ (committed in
+          # the mirror, unlike the in-repo lib/.gitignore). "<dir> <libfile>".
+          declare -A GO=(
+            [x86_64-unknown-linux-gnu]="linux_amd64 libwickra.so"
+            [aarch64-unknown-linux-gnu]="linux_arm64 libwickra.so"
+            [x86_64-apple-darwin]="darwin_amd64 libwickra.dylib"
+            [aarch64-apple-darwin]="darwin_arm64 libwickra.dylib"
+            [x86_64-pc-windows-msvc]="windows_amd64 wickra.dll"
+            [aarch64-pc-windows-msvc]="windows_arm64 wickra.dll"
+          )
+          for target in "${!GO[@]}"; do
+            read -r dir libfile <<< "${GO[$target]}"
+            archive=$(find c-abi-artifacts -name "wickra-c-$target.tar.gz" | head -1)
+            if [ -z "$archive" ]; then
+              echo "::error::missing native artifact for $target"; exit 1
+            fi
+            tmp=$(mktemp -d); tar -xzf "$archive" -C "$tmp"
+            src=$(find "$tmp" -name "$libfile" | head -1)
+            if [ -z "$src" ]; then
+              echo "::error::missing $libfile for $target"; exit 1
+            fi
+            mkdir -p "$out/lib/$dir"; cp "$src" "$out/lib/$dir/"
+          done
+          echo "assembled module:"; find "$out" -type f | sort
+
+      - name: Push to wickra-go and tag the release
+        shell: bash
+        env:
+          MIRROR_TOKEN: ${{ secrets.WICKRA_GO_MIRROR_TOKEN }}
+        run: |
+          set -e
+          version="${GITHUB_REF_NAME#v}"
+          remote="https://x-access-token:${MIRROR_TOKEN}@github.com/wickra-lib/wickra-go.git"
+          git clone -q "$remote" mirror-repo
+          cd mirror-repo
+          git config user.name "wickra-bot"
+          git config user.email "support@wickra.org"
+          git symbolic-ref HEAD refs/heads/main
+          # Replace all tracked content with the freshly assembled tree.
+          find . -mindepth 1 -maxdepth 1 -not -name .git -exec rm -rf {} +
+          cp -r ../wickra-go-module/. .
+          git add -A
+          if git diff --cached --quiet; then
+            echo "wickra-go already up to date; tagging only"
+          else
+            git -c commit.gpgsign=false commit -q -m "Release v$version"
+          fi
+          git push origin HEAD:refs/heads/main
+          git tag "v$version"
+          git push origin "v$version"
+
   github-release:
     name: Attach assets to the draft GitHub Release
     needs: [cargo-publish, python-publish, node-publish, wasm-publish, c-abi-build]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to Wickra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-06-09
+### Added
+- **Standalone `wickra-go` module** — the Go binding is now mirrored to a
+  dedicated `github.com/wickra-lib/wickra-go` repository on every release, with
+  the prebuilt C ABI libraries committed per platform under
+  `lib/<goos>_<goarch>/` and the C ABI header vendored alongside the source, so
+  `go get github.com/wickra-lib/wickra-go` builds with no extra steps. The
+  in-repo `bindings/go` module is unchanged for repo-clone workflows.
+
+### Changed
+- **Go binding (`bindings/go`) is self-contained** — the C ABI header is now
+  vendored inside the module (`bindings/go/include/wickra.h`) instead of being
+  referenced from the parent `bindings/c` directory, and the cgo link flags
+  resolve the prebuilt library per `GOOS`/`GOARCH` under `lib/<goos>_<goarch>/`.
+  This removes the dependency on a full repository checkout for building the
+  module.
+
 ## [0.7.9] - 2026-06-09
 ### Added
 - **Java binding (`bindings/java`)** — a Java binding reaching the C ABI hub
@@ -1461,7 +1478,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.7.9...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/wickra-lib/wickra/compare/v0.7.9...v0.8.0
 [0.7.9]: https://github.com/wickra-lib/wickra/compare/v0.7.8...v0.7.9
 [0.7.8]: https://github.com/wickra-lib/wickra/compare/v0.7.7...v0.7.8
 [0.7.7]: https://github.com/wickra-lib/wickra/compare/v0.7.6...v0.7.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.7.9"
+version = "0.8.0"
 dependencies = [
  "approx",
  "criterion",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-bench"
-version = "0.7.9"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "kand",
@@ -1967,14 +1967,14 @@ dependencies = [
 
 [[package]]
 name = "wickra-c"
-version = "0.7.9"
+version = "0.8.0"
 dependencies = [
  "wickra-core",
 ]
 
 [[package]]
 name = "wickra-core"
-version = "0.7.9"
+version = "0.8.0"
 dependencies = [
  "approx",
  "proptest",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.7.9"
+version = "0.8.0"
 dependencies = [
  "approx",
  "csv",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-examples"
-version = "0.7.9"
+version = "0.8.0"
 dependencies = [
  "serde_json",
  "tokio",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.7.9"
+version = "0.8.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.7.9"
+version = "0.8.0"
 dependencies = [
  "numpy",
  "pyo3",
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.7.9"
+version = "0.8.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.7.9"
+version = "0.8.0"
 authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
@@ -26,7 +26,7 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.7.9" }
+wickra-core = { path = "crates/wickra-core", version = "0.8.0" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -30,14 +30,14 @@ Maven:
 <dependency>
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.7.9</version>
+  <version>0.8.0</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.wickra:wickra:0.7.9")
+implementation("org.wickra:wickra:0.8.0")
 ```
 
 The native library ships prebuilt per platform (Linux, macOS, Windows — x64 and

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.7.9</version>
+  <version>0.8.0</version>
   <packaging>jar</packaging>
 
   <name>Wickra</name>

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wickra",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wickra",
-      "version": "0.7.9",
+      "version": "0.8.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -15,12 +15,12 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.7.9",
-        "wickra-darwin-x64": "0.7.9",
-        "wickra-linux-arm64-gnu": "0.7.9",
-        "wickra-linux-x64-gnu": "0.7.9",
-        "wickra-win32-arm64-msvc": "0.7.9",
-        "wickra-win32-x64-msvc": "0.7.9"
+        "wickra-darwin-arm64": "0.8.0",
+        "wickra-darwin-x64": "0.8.0",
+        "wickra-linux-arm64-gnu": "0.8.0",
+        "wickra-linux-x64-gnu": "0.8.0",
+        "wickra-win32-arm64-msvc": "0.8.0",
+        "wickra-win32-x64-msvc": "0.8.0"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -41,8 +41,8 @@
       }
     },
     "node_modules/wickra-darwin-arm64": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.7.9.tgz",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.8.0.tgz",
       "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
       "cpu": [
         "arm64"
@@ -57,8 +57,8 @@
       }
     },
     "node_modules/wickra-darwin-x64": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.7.9.tgz",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.8.0.tgz",
       "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
       "cpu": [
         "x64"
@@ -73,8 +73,8 @@
       }
     },
     "node_modules/wickra-linux-arm64-gnu": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.7.9.tgz",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.8.0.tgz",
       "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
       "cpu": [
         "arm64"
@@ -89,8 +89,8 @@
       }
     },
     "node_modules/wickra-linux-x64-gnu": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.7.9.tgz",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.8.0.tgz",
       "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
       "cpu": [
         "x64"
@@ -105,8 +105,8 @@
       }
     },
     "node_modules/wickra-win32-arm64-msvc": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.7.9.tgz",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.8.0.tgz",
       "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
       "cpu": [
         "arm64"
@@ -121,8 +121,8 @@
       }
     },
     "node_modules/wickra-win32-x64-msvc": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.7.9.tgz",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.8.0.tgz",
       "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
       "cpu": [
         "x64"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
@@ -47,12 +47,12 @@
     "node": ">= 18"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.7.9",
-    "wickra-linux-arm64-gnu": "0.7.9",
-    "wickra-darwin-x64": "0.7.9",
-    "wickra-darwin-arm64": "0.7.9",
-    "wickra-win32-x64-msvc": "0.7.9",
-    "wickra-win32-arm64-msvc": "0.7.9"
+    "wickra-linux-x64-gnu": "0.8.0",
+    "wickra-linux-arm64-gnu": "0.8.0",
+    "wickra-darwin-x64": "0.8.0",
+    "wickra-darwin-arm64": "0.8.0",
+    "wickra-win32-x64-msvc": "0.8.0",
+    "wickra-win32-arm64-msvc": "0.8.0"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.7.9"
+version = "0.8.0"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra.examples</groupId>
   <artifactId>wickra-examples</artifactId>
-  <version>0.7.9</version>
+  <version>0.8.0</version>
   <packaging>jar</packaging>
 
   <name>Wickra Java examples</name>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.wickra</groupId>
       <artifactId>wickra</artifactId>
-      <version>0.7.9</version>
+      <version>0.8.0</version>
     </dependency>
     <!-- Only the network examples (fetch_btcusdt) parse JSON. -->
     <dependency>

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../../bindings/node": {
       "name": "wickra",
-      "version": "0.7.9",
+      "version": "0.8.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -26,12 +26,12 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.7.9",
-        "wickra-darwin-x64": "0.7.9",
-        "wickra-linux-arm64-gnu": "0.7.9",
-        "wickra-linux-x64-gnu": "0.7.9",
-        "wickra-win32-arm64-msvc": "0.7.9",
-        "wickra-win32-x64-msvc": "0.7.9"
+        "wickra-darwin-arm64": "0.8.0",
+        "wickra-darwin-x64": "0.8.0",
+        "wickra-linux-arm64-gnu": "0.8.0",
+        "wickra-linux-x64-gnu": "0.8.0",
+        "wickra-win32-arm64-msvc": "0.8.0",
+        "wickra-win32-x64-msvc": "0.8.0"
       }
     },
     "node_modules/wickra": {


### PR DESCRIPTION
Bumps the workspace from 0.7.9 to 0.8.0 and adds the release-time mirror of the Go module to a standalone `wickra-go` repository.

## release.yml: `go-mirror` job
Adds a `go-mirror` job (independent of `github-release`, `needs: c-abi-build`) that on every `v*` tag:
- assembles the standalone Go module from `bindings/go` (single-package source + the vendored `include/wickra.h`),
- stages the six prebuilt C ABI libraries from the `c-abi-build` artifacts under `lib/<goos>_<goarch>/` (committed in the mirror, unlike the in-repo `lib/.gitignore`),
- rewrites `go.mod` to `module github.com/wickra-lib/wickra-go`,
- commits and tags the result in `wickra-lib/wickra-go` using the `WICKRA_GO_MIRROR_TOKEN` fine-grained PAT.

This makes `go get github.com/wickra-lib/wickra-go` build with no extra steps, closing the gap where the in-repo `bindings/go` module only built inside a full repository checkout. The mirror is a derived artifact, so its bot commit is intentionally unsigned.

## Version bump 0.7.9 -> 0.8.0
Patch never reaches double digits (`0.7.9` -> `0.8.0`). Touchpoints: `Cargo.toml` (+ `Cargo.lock` via build), `bindings/python/pyproject.toml`, `bindings/node/package.json` + 6 platform `npm/*/package.json` + both `package-lock.json` files, `bindings/java/pom.xml` + `examples/java/pom.xml` + Maven/Gradle snippets in `bindings/java/README.md`, and `CHANGELOG.md`. The C# `Wickra.csproj` (version set per tag) and `bindings/c` (inherits the workspace version) are intentionally untouched.

Tagging `v0.8.0` (which triggers the publish + the new mirror) stays gated on explicit confirmation.