### PR TITLE
release.yml: ship the dual license in the wickra-go mirror

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -808,6 +808,8 @@ jobs:
           cp bindings/go/*.go "$out/"
           cp bindings/go/include/wickra.h "$out/include/"
           cp bindings/go/README.md "$out/"
+          # Ship the dual license so pkg.go.dev detects a redistributable license.
+          cp LICENSE-MIT LICENSE-APACHE "$out/"
           # Standalone module path (the in-repo go.mod points at the subdir).
           printf 'module github.com/wickra-lib/wickra-go\n\ngo 1.23\n' > "$out/go.mod"
           # Point install instructions at the standalone module path.


### PR DESCRIPTION
The go-mirror job copied the source, header, README and libraries into wickra-go but not the license, so pkg.go.dev reports `License: None detected` (not redistributable). Copy the root `LICENSE-MIT` and `LICENSE-APACHE` into the assembled module. Takes effect on the next release; the already-published `v0.8.0` tag is immutable on the Go proxy and keeps its current state.