### PR TITLE
sync-about: propagate published version into Java install snippets

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -341,13 +341,19 @@ jobs:
           # are never matched.
           sed -i -E "s/^(\| \[?(crates\.io|PyPI|npm|NuGet|Maven Central|Go|r-universe)\]?.*\| )[0-9]+\.[0-9]+\.[0-9]+/\1${version}/" overview.md
           sed -i -E "s/(published crate is at version .)[0-9]+\.[0-9]+\.[0-9]+/\1${version}/" Quickstart-Rust.md
+          # Quickstart-Java is the only quickstart whose install block pins a
+          # version (the Maven `<version>` tag and the `org.wickra:wickra:<v>`
+          # Gradle coordinate). Java publishes on every release, so it tracks the
+          # same ${version}.
+          sed -i -E "s|<version>[0-9]+\.[0-9]+\.[0-9]+</version>|<version>${version}</version>|" Quickstart-Java.md
+          sed -i -E "s|(org\.wickra:wickra:)[0-9]+\.[0-9]+\.[0-9]+|\1${version}|" Quickstart-Java.md
           if git diff --quiet; then
             echo "Docs version already at ${version}."
             exit 0
           fi
           git config user.name "wickra-bot"
           git config user.email "wickra-bot@users.noreply.github.com"
-          git add overview.md Quickstart-Rust.md
+          git add overview.md Quickstart-Rust.md Quickstart-Java.md
           git commit -m "chore: sync published version to ${version}"
           if ! git push 2>/dev/null; then
             echo "::warning::push to wickra-lib/wickra-docs failed — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a)."
@@ -433,6 +439,14 @@ jobs:
           sed -i -E "s/(Latest:\*\* \[.wickra(-wasm)? )[0-9]+\.[0-9]+\.[0-9]+/\1${version}/" api/*.md
           sed -i -E "s/(text: .v)[0-9]+\.[0-9]+\.[0-9]+/\1${version}/" .vitepress/config.ts
           sed -i -E "s/(.wickra-wasm.: .\^)[0-9]+\.[0-9]+\.[0-9]+/\1${version}/" package.json
+          # Java is the only target whose install snippet pins a version: the
+          # Maven `<version>` tag in the api/java.md dependency block and the
+          # home-page install tab in index.md, plus any `org.wickra:wickra:<v>`
+          # Gradle coordinate. Java publishes on every release, so it tracks the
+          # same ${version} as the rest. (Other languages' api/*.md carry a
+          # "Latest:" line handled above; Java uses the XML snippet instead.)
+          sed -i -E "s|<version>[0-9]+\.[0-9]+\.[0-9]+</version>|<version>${version}</version>|" api/java.md index.md
+          sed -i -E "s|(org\.wickra:wickra:)[0-9]+\.[0-9]+\.[0-9]+|\1${version}|" api/java.md index.md
           # Keep package-lock.json in sync with the package.json bump. The site's
           # Cloudflare build runs `npm clean-install` (npm ci), which hard-fails
           # with EUSAGE if the lockfile still pins the previous wickra-wasm —
@@ -451,7 +465,7 @@ jobs:
           fi
           git config user.name "wickra-bot"
           git config user.email "wickra-bot@users.noreply.github.com"
-          git add api/*.md .vitepress/config.ts package.json package-lock.json
+          git add api/*.md index.md .vitepress/config.ts package.json package-lock.json
           git commit -m "chore: sync published version to ${version}"
           if ! git push 2>/dev/null; then
             echo "::warning::push to wickra-lib/webpage failed — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a)."


### PR DESCRIPTION
## Problem

Java is the only target whose install snippet pins a version (the Maven coordinate). Every other language exposes its version through an api/*.md `Latest:` line or the docs published-versions table, both of which `sync-about.yml` already rewrites on each `v*` tag. The Java `<version>` tag and the `org.wickra:wickra:<v>` Gradle coordinate were never wired in, so they drifted:

- `webpage/index.md` install tab → stuck on `0.8.0`
- `webpage/api/java.md` → stuck on `0.7.9`
- `wickra-docs/Quickstart-Java.md` (Maven `<version>` + Gradle coord) → stuck on `0.7.9`

while the published version is already `0.8.3`.

## Fix

Extend the webpage and docs version-sync steps to rewrite the Maven `<version>` tag and the Gradle coordinate to the released `${version}`, and add `index.md` / `Quickstart-Java.md` to the respective commits. Java publishes on every release, so it tracks the same version as the rest — future releases self-heal these snippets.

Patterns dry-run-verified against the live files (all three resolve to `0.8.3`). The current drift is corrected directly in companion PRs on the webpage and wickra-docs repos.