### PR TITLE
fix(r): declare Depends: R (>= 2.10) for the bundled dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- R binding: declare `Depends: R (>= 2.10)`, clearing the `R CMD check` warning
+  ("package needs dependence on R (>= 2.10)") that the bundled, lazy-loaded
+  `sample_ohlcv` dataset triggers on r-universe / CRAN.
 
 ## [0.8.7] - 2026-06-11
 ### Added

--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -21,6 +21,7 @@ SystemRequirements: the Wickra C ABI shared library, downloaded automatically at
     Set WICKRA_INCLUDE_DIR and WICKRA_LIB_DIR to build against a locally built C
     ABI instead (e.g. after `cargo build -p wickra-c --release`).
 Roxygen: list(markdown = TRUE)
+Depends: R (>= 2.10)
 Suggests: testthat (>= 3.0.0), knitr, rmarkdown
 VignetteBuilder: knitr
 LazyData: true


### PR DESCRIPTION
The `sample_ohlcv` dataset added in #262 is lazy-loaded (`LazyData: true`), which makes `R CMD check` on r-universe / CRAN warn:

```
* checking data for ASCII and uncompressed saves ... WARNING
  Warning: package needs dependence on R (>= 2.10)
```

Lazy-loading of package data requires R ≥ 2.10, so the package must declare it. This adds `Depends: R (>= 2.10)` to `bindings/r/DESCRIPTION`.

**Verified locally** (R 4.6.0, `R CMD build` + `R CMD check`): the `checking data for ASCII and uncompressed saves` step now reports **OK**. (The repo CI only runs `R CMD INSTALL` + testthat, not full `R CMD check`, so this surfaces only on r-universe — same asymmetry as the golden-test skip.)