### PR TITLE
chore(supply-chain): osv-scanner suppressions, bump publishing plugin, track Maven in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,3 +59,20 @@ updates:
       default-days: 7
     commit-message:
       prefix: "deps(actions)"
+
+  # Java binding + examples (Maven). Tracks the C-ABI binding's build plugins
+  # (e.g. central-publishing-maven-plugin) and the examples' jackson dependency,
+  # which had no Dependabot coverage before — a stale publishing plugin slipped
+  # through unnoticed until an OSV scan flagged it.
+  - package-ecosystem: maven
+    directories:
+      - "/bindings/java"
+      - "/bindings/java/benchmarks"
+      - "/examples/java"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "deps(maven)"

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -157,7 +157,7 @@
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.5.0</version>
+            <version>0.10.0</version>
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,35 @@
+# OSV-Scanner suppressions (VEX record). Consumed by the OpenSSF Scorecard
+# Vulnerabilities check, which runs OSV-Scanner over this repository. Each entry
+# is an advisory assessed as not affecting Wickra; this mirrors the cargo-deny
+# `ignore` list in deny.toml at the OSV layer. See the "Vulnerability
+# exploitability (VEX)" section of SECURITY.md.
+
+# pyo3 — both advisories are fixed in pyo3 0.29.0, but rust-numpy 0.28 (latest
+# release) hard-pins pyo3 ^0.28.0, so the bump is upstream-blocked. Neither
+# vulnerable code path is reachable from the binding: it never calls
+# BoundListIterator nth/nth_back, the PyTuple equivalents, or
+# PyCFunction::new_closure (verified by grep over bindings/python/src). Also
+# tracked in deny.toml; remove once rust-numpy 0.29 ships and pyo3 is bumped.
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0176"
+reason = "pyo3 OOB read in PyList/PyTuple nth/nth_back; vulnerable API unused; fix blocked upstream by rust-numpy. Tracked in deny.toml."
+
+[[IgnoredVulns]]
+id = "GHSA-36hh-v3qg-5jq4"
+reason = "Alias of RUSTSEC-2026-0176."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0177"
+reason = "pyo3 missing Sync on PyCFunction::new_closure; vulnerable API unused; fix blocked upstream by rust-numpy. Tracked in deny.toml."
+
+[[IgnoredVulns]]
+id = "GHSA-chgr-c6px-7xpp"
+reason = "Alias of RUSTSEC-2026-0177."
+
+# jackson-core 3.x async-parser DoS — tools.jackson.core:jackson-core 3.x is not
+# a dependency of this project. No manifest, Maven plugin, or the GitHub
+# dependency-graph SBOM references jackson 3.x; the only jackson present is
+# com.fasterxml.jackson.core:jackson-databind 2.17.1 (examples only). Not affected.
+[[IgnoredVulns]]
+id = "GHSA-72hv-8253-57qq"
+reason = "tools.jackson.core:jackson-core 3.x is not a dependency of this project; only jackson-databind 2.17.1 is present. Not affected."


### PR DESCRIPTION
Follow-up to the Dependabot action-bump merges and the cargo-deny ignore (#271).
Three low-risk supply-chain housekeeping changes — config/docs only, no library
code, no runtime change.

## 1. `osv-scanner.toml` (new)

The OpenSSF Scorecard *Vulnerabilities* check runs OSV-Scanner over the repo and
was flagging five advisory IDs (`score is 5`). These reduce to three findings,
all assessed as not affecting Wickra:

| Advisory | Assessment |
|----------|------------|
| RUSTSEC-2026-0176 / GHSA-36hh-v3qg-5jq4 (pyo3) | Vulnerable API unused; fix is pyo3 0.29 but rust-numpy 0.28 pins pyo3 `^0.28` → upstream-blocked. Already in `deny.toml`. |
| RUSTSEC-2026-0177 / GHSA-chgr-c6px-7xpp (pyo3) | Same — `PyCFunction::new_closure` not called. Already in `deny.toml`. |
| GHSA-72hv-8253-57qq (jackson-core 3.x) | **Not a dependency of this project.** No manifest, Maven plugin, or the GitHub dependency-graph SBOM references `tools.jackson` 3.x; the only jackson present is `com.fasterxml.jackson.core:jackson-databind` 2.17.1. |

`osv-scanner.toml` records these as ignored-with-reason at the OSV layer,
mirroring `deny.toml` and the SECURITY.md VEX section. The Scorecard finding
also flip-flopped (fixed → reappeared) across unrelated release-bump commits,
confirming it is not a stable real exposure.

## 2. Bump `central-publishing-maven-plugin` 0.5.0 → 0.10.0

The Java binding pinned a publishing plugin five versions behind. Validated
locally with the JDK 22 toolchain (`mvn -Prelease validate`): the extension
loads, the existing `publishingServerId`/`autoPublish` config is compatible, and
all 14 binding tests pass. The actual `mvn deploy` upload path is only exercised
at release time (needs the Central token + GPG key), so it will be confirmed at
the next release.

## 3. Add a Maven ecosystem to Dependabot

The Java binding had no Dependabot coverage, which is why the stale 0.5.0 plugin
went unnoticed. Adds `package-ecosystem: maven` over `/bindings/java`,
`/bindings/java/benchmarks`, and `/examples/java` so plugin and dependency
updates (incl. the examples' jackson) are tracked going forward.