### PR TITLE
ci(dependabot): track NuGet (C#) and the Node/Go examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -76,3 +76,41 @@ updates:
       default-days: 7
     commit-message:
       prefix: "deps(maven)"
+
+  # C# binding (NuGet). The published Wickra.csproj is a thin C-ABI wrapper with
+  # no external packages, but the test and benchmark projects pull xunit,
+  # Microsoft.NET.Test.Sdk and BenchmarkDotNet.
+  - package-ecosystem: nuget
+    directories:
+      - "/bindings/csharp/Wickra.Tests"
+      - "/bindings/csharp/benchmarks"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "deps(nuget)"
+
+  # Node examples (npm) — separate from the binding's own package.json.
+  - package-ecosystem: npm
+    directory: "/examples/node"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "deps(npm)"
+
+  # Go examples (Go modules). The binding's own go.mod has no external deps;
+  # the examples pull coder/websocket.
+  - package-ecosystem: gomod
+    directory: "/examples/go"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "deps(gomod)"


### PR DESCRIPTION
Closes the remaining Dependabot coverage gaps after the Maven ecosystem was
added. Audited every binding for external dependency manifests:

| Language | External deps | Coverage |
|----------|---------------|----------|
| Rust (core/wasm) | yes | already `cargo` |
| Python | yes | already `pip` |
| Node (binding) | yes | already `npm` |
| Java | yes | already `maven` |
| **C# / .NET** | **yes** (xunit, Microsoft.NET.Test.Sdk, BenchmarkDotNet) | **added `nuget`** |
| **examples/node** | **yes** (`ws`) | **added `npm`** |
| **examples/go** | **yes** (`coder/websocket`) | **added `gomod`** |
| C (C ABI) | no | nothing to track |
| Go (binding) | no (empty go.mod) | nothing to track |
| R | only `Depends: R` | Dependabot has no R/CRAN ecosystem |

The published `Wickra.csproj` itself has no external NuGet packages (thin C-ABI
wrapper), so only the test and benchmark projects are tracked.