### PR TITLE
chore(supply-chain): suppress jackson false positive in the Maven sub-scans

### DIFF
--- a/bindings/java/osv-scanner.toml
+++ b/bindings/java/osv-scanner.toml
@@ -1,0 +1,12 @@
+# OSV-Scanner suppression for this Maven manifest. OSV-Scanner looks for an
+# osv-scanner.toml next to each manifest it scans, and the repo-root config does
+# not cover Maven sub-directory scans — so the jackson finding is suppressed
+# here as well. See the root osv-scanner.toml and the SECURITY.md VEX section.
+#
+# tools.jackson.core:jackson-core 3.x is NOT a dependency of this project. Full
+# Maven resolution (the publishing plugin tree and the project dependency tree)
+# resolves only jackson 2.16.1 / 2.17.1; tools.jackson 3.x appears nowhere.
+# OSV-Scanner's own resolver flags it as a false positive.
+[[IgnoredVulns]]
+id = "GHSA-72hv-8253-57qq"
+reason = "tools.jackson.core:jackson-core 3.x is not a dependency; only jackson 2.x resolves. Not affected."

--- a/examples/java/osv-scanner.toml
+++ b/examples/java/osv-scanner.toml
@@ -1,0 +1,12 @@
+# OSV-Scanner suppression for this Maven manifest. OSV-Scanner looks for an
+# osv-scanner.toml next to each manifest it scans, and the repo-root config does
+# not cover Maven sub-directory scans — so the jackson finding is suppressed
+# here as well. See the root osv-scanner.toml and the SECURITY.md VEX section.
+#
+# tools.jackson.core:jackson-core 3.x is NOT a dependency of this project. This
+# example resolves only com.fasterxml.jackson.core:jackson-databind 2.17.1 (and
+# its 2.x jackson-core); tools.jackson 3.x appears nowhere. OSV-Scanner's own
+# resolver flags it as a false positive.
+[[IgnoredVulns]]
+id = "GHSA-72hv-8253-57qq"
+reason = "tools.jackson.core:jackson-core 3.x is not a dependency; only jackson 2.x resolves. Not affected."


### PR DESCRIPTION
Follow-up to #272. The root `osv-scanner.toml` cleared the OpenSSF Scorecard
Vulnerabilities check from score 5 to 9 (the two pyo3 advisories, which live in
`Cargo.lock` at the root). One finding remained — `GHSA-72hv-8253-57qq`
(jackson-core 3.x async-parser DoS) — because OSV-Scanner resolves its config
relative to each manifest, and the repo-root config does not cover the Maven
sub-directory scans.

This adds the same not-affected suppression next to the two Maven manifests
(`bindings/java`, `examples/java`).

`tools.jackson.core:jackson-core` 3.x is not a dependency of this project: full
Maven resolution (publishing-plugin tree + project trees) resolves only jackson
`2.16.1` / `2.17.1`; tools.jackson 3.x appears nowhere. OSV-Scanner's own
resolver flags it as a false positive.