### PR TITLE
ci(dependabot): group updates per ecosystem into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       default-days: 7
     commit-message:
       prefix: "deps(cargo)"
+    groups:
+      cargo:
+        patterns: ["*"]
 
   # Node binding npm dependencies.
   - package-ecosystem: npm
@@ -21,6 +24,9 @@ updates:
       default-days: 7
     commit-message:
       prefix: "deps(npm)"
+    groups:
+      node-binding:
+        patterns: ["*"]
 
   # Python binding pip dependencies.
   - package-ecosystem: pip
@@ -32,6 +38,9 @@ updates:
       default-days: 7
     commit-message:
       prefix: "deps(pip)"
+    groups:
+      python-binding:
+        patterns: ["*"]
 
   # Hash-pinned CI/bench Python tooling under .github/requirements/. Each
   # <name>.in is the loose source; the matching hash-locked <name>.txt is the
@@ -47,6 +56,9 @@ updates:
       default-days: 7
     commit-message:
       prefix: "deps(ci-pip)"
+    groups:
+      ci-pip:
+        patterns: ["*"]
 
   # GitHub Actions — keeps the SHA-pinned actions current (Dependabot reads
   # the version comment after each pinned SHA and bumps both together).
@@ -59,6 +71,9 @@ updates:
       default-days: 7
     commit-message:
       prefix: "deps(actions)"
+    groups:
+      github-actions:
+        patterns: ["*"]
 
   # Java binding + examples (Maven). Tracks the C-ABI binding's build plugins
   # (e.g. central-publishing-maven-plugin) and the examples' jackson dependency,
@@ -76,6 +91,9 @@ updates:
       default-days: 7
     commit-message:
       prefix: "deps(maven)"
+    groups:
+      maven:
+        patterns: ["*"]
 
   # C# binding (NuGet). The published Wickra.csproj is a thin C-ABI wrapper with
   # no external packages, but the test and benchmark projects pull xunit,
@@ -91,6 +109,9 @@ updates:
       default-days: 7
     commit-message:
       prefix: "deps(nuget)"
+    groups:
+      nuget:
+        patterns: ["*"]
 
   # Node examples (npm) — separate from the binding's own package.json.
   - package-ecosystem: npm
@@ -102,6 +123,9 @@ updates:
       default-days: 7
     commit-message:
       prefix: "deps(npm)"
+    groups:
+      node-examples:
+        patterns: ["*"]
 
   # Go examples (Go modules). The binding's own go.mod has no external deps;
   # the examples pull coder/websocket.
@@ -114,3 +138,6 @@ updates:
       default-days: 7
     commit-message:
       prefix: "deps(gomod)"
+    groups:
+      go-examples:
+        patterns: ["*"]


### PR DESCRIPTION
All nine Dependabot ecosystems now batch their updates into one grouped PR each
(`groups: { <name>: { patterns: ["*"] } }`) instead of one PR per dependency.

A routine refresh previously fanned out into a dozen-plus PRs (the Maven batch
alone opened 12), each running the full nine-language CI matrix (~55 checks) and
clogging the runner queue ahead of release and feature runs. Grouping collapses
that to one PR per ecosystem.

Trade-off: a single broken update blocks its whole group until excluded — fine
for routine maintenance bumps. Security updates are unaffected (they are not
grouped and continue to arrive individually).