### PR TITLE
release: bump 0.8.9 -> 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-13
+
+Maintenance release: Java build-dependency updates and CI/Dependabot
+housekeeping only. No library code or public API changes.
+
+### Changed
+- Java binding: upgraded the test framework to JUnit Jupiter 6.1.0 (from
+  5.10.2) and bumped the Maven build plugins — `maven-compiler-plugin`
+  3.13.0 → 3.15.0, `maven-surefire-plugin` 3.2.5 → 3.5.6, `maven-jar-plugin`
+  3.4.1 → 3.5.0, `maven-source-plugin` 3.3.1 → 3.4.0, `maven-javadoc-plugin`
+  3.7.0 → 3.12.0, and `maven-gpg-plugin` 3.2.4 → 3.2.8.
+- Java benchmarks and examples: bumped `maven-compiler-plugin` to 3.15.0 and
+  `exec-maven-plugin` to 3.6.3; examples bumped `jackson-databind` 2.17.1 →
+  2.22.0.
+- Grouped Dependabot updates per ecosystem into a single pull request and
+  extended tracking to the NuGet (C#) binding and the Node/Go examples.
+
+
 ## [0.8.9] - 2026-06-12
 
 Maintenance release: supply-chain and CI housekeeping only. No library code or
@@ -1597,7 +1615,8 @@ public API changes.
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.8.9...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/wickra-lib/wickra/compare/v0.8.9...v0.9.0
 [0.8.9]: https://github.com/wickra-lib/wickra/compare/v0.8.8...v0.8.9
 [0.8.8]: https://github.com/wickra-lib/wickra/compare/v0.8.7...v0.8.8
 [0.8.7]: https://github.com/wickra-lib/wickra/compare/v0.8.6...v0.8.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "approx",
  "criterion",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-bench"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "kand",
@@ -1967,14 +1967,14 @@ dependencies = [
 
 [[package]]
 name = "wickra-c"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "wickra-core",
 ]
 
 [[package]]
 name = "wickra-core"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "approx",
  "proptest",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "approx",
  "csv",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-examples"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "serde_json",
  "tokio",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "numpy",
  "pyo3",
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.8.9"
+version = "0.9.0"
 authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
@@ -26,7 +26,7 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.8.9" }
+wickra-core = { path = "crates/wickra-core", version = "0.9.0" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported versions
 
-Wickra is pre-1.0. Security fixes are applied to the latest released `0.8.9`
+Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.0`
 version only; please upgrade to the newest release before reporting an issue.
 
 | Version | Supported |
 | --- | --- |
-| 0.8.9 (latest) | :white_check_mark: |
-| < 0.8.9 | :x: |
+| 0.9.0 (latest) | :white_check_mark: |
+| < 0.9.0 | :x: |
 
 ## Reporting a vulnerability
 

--- a/bindings/csharp/Wickra/Wickra.csproj
+++ b/bindings/csharp/Wickra/Wickra.csproj
@@ -11,7 +11,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>Wickra</PackageId>
-    <Version>0.8.9</Version>
+    <Version>0.9.0</Version>
     <Authors>kingchenc</Authors>
     <Description>High-performance streaming technical-analysis indicators (514 indicators) for .NET, backed by the native Rust core via the Wickra C ABI.</Description>
     <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -30,14 +30,14 @@ Maven:
 <dependency>
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.8.9</version>
+  <version>0.9.0</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.wickra:wickra:0.8.9")
+implementation("org.wickra:wickra:0.9.0")
 ```
 
 The native library ships prebuilt per platform (Linux, macOS, Windows — x64 and

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.8.9</version>
+  <version>0.9.0</version>
   <packaging>jar</packaging>
 
   <name>Wickra</name>

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wickra",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wickra",
-      "version": "0.8.9",
+      "version": "0.9.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -15,12 +15,12 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.8.9",
-        "wickra-darwin-x64": "0.8.9",
-        "wickra-linux-arm64-gnu": "0.8.9",
-        "wickra-linux-x64-gnu": "0.8.9",
-        "wickra-win32-arm64-msvc": "0.8.9",
-        "wickra-win32-x64-msvc": "0.8.9"
+        "wickra-darwin-arm64": "0.9.0",
+        "wickra-darwin-x64": "0.9.0",
+        "wickra-linux-arm64-gnu": "0.9.0",
+        "wickra-linux-x64-gnu": "0.9.0",
+        "wickra-win32-arm64-msvc": "0.9.0",
+        "wickra-win32-x64-msvc": "0.9.0"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -41,8 +41,8 @@
       }
     },
     "node_modules/wickra-darwin-arm64": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.8.9.tgz",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.0.tgz",
       "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
       "cpu": [
         "arm64"
@@ -57,8 +57,8 @@
       }
     },
     "node_modules/wickra-darwin-x64": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.8.9.tgz",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.0.tgz",
       "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
       "cpu": [
         "x64"
@@ -73,8 +73,8 @@
       }
     },
     "node_modules/wickra-linux-arm64-gnu": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.8.9.tgz",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.0.tgz",
       "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
       "cpu": [
         "arm64"
@@ -89,8 +89,8 @@
       }
     },
     "node_modules/wickra-linux-x64-gnu": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.8.9.tgz",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.0.tgz",
       "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
       "cpu": [
         "x64"
@@ -105,8 +105,8 @@
       }
     },
     "node_modules/wickra-win32-arm64-msvc": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.8.9.tgz",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.0.tgz",
       "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
       "cpu": [
         "arm64"
@@ -121,8 +121,8 @@
       }
     },
     "node_modules/wickra-win32-x64-msvc": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.8.9.tgz",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.0.tgz",
       "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
       "cpu": [
         "x64"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
@@ -47,12 +47,12 @@
     "node": ">= 18"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.8.9",
-    "wickra-linux-arm64-gnu": "0.8.9",
-    "wickra-darwin-x64": "0.8.9",
-    "wickra-darwin-arm64": "0.8.9",
-    "wickra-win32-x64-msvc": "0.8.9",
-    "wickra-win32-arm64-msvc": "0.8.9"
+    "wickra-linux-x64-gnu": "0.9.0",
+    "wickra-linux-arm64-gnu": "0.9.0",
+    "wickra-darwin-x64": "0.9.0",
+    "wickra-darwin-arm64": "0.9.0",
+    "wickra-win32-x64-msvc": "0.9.0",
+    "wickra-win32-arm64-msvc": "0.9.0"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.8.9"
+version = "0.9.0"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: wickra
 Type: Package
 Title: Streaming-First Technical Indicators
-Version: 0.8.9
+Version: 0.9.0
 Authors@R: person("Wickra contributors", role = c("aut", "cre"), email = "support@wickra.org")
 Description: R bindings for the Wickra technical-analysis library over its C ABI
     hub. Exposes 514 indicators, each an O(1) streaming state machine shared with

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra.examples</groupId>
   <artifactId>wickra-examples</artifactId>
-  <version>0.8.9</version>
+  <version>0.9.0</version>
   <packaging>jar</packaging>
 
   <name>Wickra Java examples</name>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.wickra</groupId>
       <artifactId>wickra</artifactId>
-      <version>0.8.9</version>
+      <version>0.9.0</version>
     </dependency>
     <!-- Only the network examples (fetch_btcusdt) parse JSON. -->
     <dependency>

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../../bindings/node": {
       "name": "wickra",
-      "version": "0.8.9",
+      "version": "0.9.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -26,12 +26,12 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.8.9",
-        "wickra-darwin-x64": "0.8.9",
-        "wickra-linux-arm64-gnu": "0.8.9",
-        "wickra-linux-x64-gnu": "0.8.9",
-        "wickra-win32-arm64-msvc": "0.8.9",
-        "wickra-win32-x64-msvc": "0.8.9"
+        "wickra-darwin-arm64": "0.9.0",
+        "wickra-darwin-x64": "0.9.0",
+        "wickra-linux-arm64-gnu": "0.9.0",
+        "wickra-linux-x64-gnu": "0.9.0",
+        "wickra-win32-arm64-msvc": "0.9.0",
+        "wickra-win32-x64-msvc": "0.9.0"
       }
     },
     "node_modules/wickra": {


### PR DESCRIPTION
Maintenance release. Bumps the workspace version 0.8.9 -> 0.9.0 across all manual touchpoints and rolls the merged Java Maven dependency updates (#273-#284) and the Dependabot/CI housekeeping (#286-#288) into a tagged release.

No library code or public API changes.

See CHANGELOG `[0.9.0]` for the full list. Do not merge until release is approved.