### PR TITLE
fix(examples): satisfy clippy -D warnings in gen_golden

### DIFF
--- a/examples/rust/src/bin/gen_golden.rs
+++ b/examples/rust/src/bin/gen_golden.rs
@@ -56,8 +56,16 @@ fn main() {
 
     let candles: Vec<Candle> = (0..N)
         .map(|i| {
-            let (o, h, l, c, v) = bar(i);
-            Candle::new(o, h, l, c, v, i as i64).expect("valid candle")
+            let (open, high, low, close, volume) = bar(i);
+            Candle::new(
+                open,
+                high,
+                low,
+                close,
+                volume,
+                i64::try_from(i).expect("golden row index fits i64"),
+            )
+            .expect("valid candle")
         })
         .collect();
     let closes: Vec<f64> = candles.iter().map(|c| c.close).collect();


### PR DESCRIPTION
`cargo clippy --workspace --all-targets --all-features -- -D warnings` failed on the 1.95 toolchain at `examples/rust/src/bin/gen_golden.rs`:
- `i as i64` → `clippy::cast_possible_wrap` → use `i64::try_from(i)`.
- `let (o, h, l, c, v) = …` → `clippy::many_single_char_names` → rename to `open/high/low/close/volume`.

Dev-tool (golden-fixture generator) only — no library or public API change. Clippy now green.