### PR TITLE
release: bump 0.9.0 -> 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-14
+
 ### Added
 - C ABI hub: every indicator now exposes `wickra_<ind>_warmup_period` and
   `wickra_<ind>_is_ready`, closing the gap with the native bindings (which
@@ -15,8 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `int warmupPeriod()` / `boolean isReady()`, and R `warmup_period()` /
   `is_ready()` generics. The alt-chart bar builders are excluded by design (a
   candle can complete 0..n bars, so they have no warmup).
+- Runnable rustdoc examples for 23 indicators that previously lacked one.
+- A Requirements reference documenting the minimum supported version per
+  language — a new page in the documentation site plus README, marketing-site
+  and organization-profile sections.
 
 ### Changed
+- Raised the minimum Node.js version to 20 — Node 18 reached end-of-life. The
+  prebuilt N-API addon is now tested on the active LTS lines (22 and 24).
+- The Java binding now builds on the JDK 25 LTS in CI (JDK 22 reached
+  end-of-life); the published bytecode still targets Java 22, so the runtime
+  requirement is unchanged.
 - Standardised programming-language naming and ordering across all docs, READMEs,
   the documentation site, marketing site, organization profile and GitHub
   repository descriptions. Canonical list:
@@ -1652,7 +1663,8 @@ public API changes.
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/wickra-lib/wickra/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/wickra-lib/wickra/compare/v0.8.9...v0.9.0
 [0.8.9]: https://github.com/wickra-lib/wickra/compare/v0.8.8...v0.8.9
 [0.8.8]: https://github.com/wickra-lib/wickra/compare/v0.8.7...v0.8.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "approx",
  "criterion",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-bench"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "criterion",
  "kand",
@@ -1966,14 +1966,14 @@ dependencies = [
 
 [[package]]
 name = "wickra-c"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "wickra-core",
 ]
 
 [[package]]
 name = "wickra-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "approx",
  "proptest",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "approx",
  "csv",
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-examples"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde_json",
  "tokio",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "napi",
  "napi-build",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "numpy",
  "pyo3",
@@ -2029,7 +2029,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
@@ -26,7 +26,7 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.9.0" }
+wickra-core = { path = "crates/wickra-core", version = "0.9.1" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported versions
 
-Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.0`
+Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.1`
 version only; please upgrade to the newest release before reporting an issue.
 
 | Version | Supported |
 | --- | --- |
-| 0.9.0 (latest) | :white_check_mark: |
-| < 0.9.0 | :x: |
+| 0.9.1 (latest) | :white_check_mark: |
+| < 0.9.1 | :x: |
 
 ## Reporting a vulnerability
 

--- a/bindings/csharp/Wickra/Wickra.csproj
+++ b/bindings/csharp/Wickra/Wickra.csproj
@@ -11,7 +11,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>Wickra</PackageId>
-    <Version>0.9.0</Version>
+    <Version>0.9.1</Version>
     <Authors>kingchenc</Authors>
     <Description>High-performance streaming technical-analysis indicators (514 indicators) for .NET, backed by the native Rust core via the Wickra C ABI.</Description>
     <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -30,14 +30,14 @@ Maven:
 <dependency>
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.0</version>
+  <version>0.9.1</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.wickra:wickra:0.9.0")
+implementation("org.wickra:wickra:0.9.1")
 ```
 
 The native library ships prebuilt per platform (Linux, macOS, Windows — x64 and

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.0</version>
+  <version>0.9.1</version>
   <packaging>jar</packaging>
 
   <name>Wickra</name>

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wickra",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wickra",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -15,12 +15,12 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.0",
-        "wickra-darwin-x64": "0.9.0",
-        "wickra-linux-arm64-gnu": "0.9.0",
-        "wickra-linux-x64-gnu": "0.9.0",
-        "wickra-win32-arm64-msvc": "0.9.0",
-        "wickra-win32-x64-msvc": "0.9.0"
+        "wickra-darwin-arm64": "0.9.1",
+        "wickra-darwin-x64": "0.9.1",
+        "wickra-linux-arm64-gnu": "0.9.1",
+        "wickra-linux-x64-gnu": "0.9.1",
+        "wickra-win32-arm64-msvc": "0.9.1",
+        "wickra-win32-x64-msvc": "0.9.1"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -41,8 +41,8 @@
       }
     },
     "node_modules/wickra-darwin-arm64": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.0.tgz",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.1.tgz",
       "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
       "cpu": [
         "arm64"
@@ -57,8 +57,8 @@
       }
     },
     "node_modules/wickra-darwin-x64": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.0.tgz",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.1.tgz",
       "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
       "cpu": [
         "x64"
@@ -73,8 +73,8 @@
       }
     },
     "node_modules/wickra-linux-arm64-gnu": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.0.tgz",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.1.tgz",
       "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
       "cpu": [
         "arm64"
@@ -89,8 +89,8 @@
       }
     },
     "node_modules/wickra-linux-x64-gnu": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.0.tgz",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.1.tgz",
       "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
       "cpu": [
         "x64"
@@ -105,8 +105,8 @@
       }
     },
     "node_modules/wickra-win32-arm64-msvc": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.0.tgz",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.1.tgz",
       "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
       "cpu": [
         "arm64"
@@ -121,8 +121,8 @@
       }
     },
     "node_modules/wickra-win32-x64-msvc": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.0.tgz",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.1.tgz",
       "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
       "cpu": [
         "x64"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
@@ -47,12 +47,12 @@
     "node": ">= 20"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.9.0",
-    "wickra-linux-arm64-gnu": "0.9.0",
-    "wickra-darwin-x64": "0.9.0",
-    "wickra-darwin-arm64": "0.9.0",
-    "wickra-win32-x64-msvc": "0.9.0",
-    "wickra-win32-arm64-msvc": "0.9.0"
+    "wickra-linux-x64-gnu": "0.9.1",
+    "wickra-linux-arm64-gnu": "0.9.1",
+    "wickra-darwin-x64": "0.9.1",
+    "wickra-darwin-arm64": "0.9.1",
+    "wickra-win32-x64-msvc": "0.9.1",
+    "wickra-win32-arm64-msvc": "0.9.1"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.9.0"
+version = "0.9.1"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: wickra
 Type: Package
 Title: Streaming-First Technical Indicators
-Version: 0.9.0
+Version: 0.9.1
 Authors@R: person("Wickra contributors", role = c("aut", "cre"), email = "support@wickra.org")
 Description: R bindings for the Wickra technical-analysis library over its C ABI
     hub. Exposes 514 indicators, each an O(1) streaming state machine shared with

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra.examples</groupId>
   <artifactId>wickra-examples</artifactId>
-  <version>0.9.0</version>
+  <version>0.9.1</version>
   <packaging>jar</packaging>
 
   <name>Wickra Java examples</name>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.wickra</groupId>
       <artifactId>wickra</artifactId>
-      <version>0.9.0</version>
+      <version>0.9.1</version>
     </dependency>
     <!-- Only the network examples (fetch_btcusdt) parse JSON. -->
     <dependency>

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../../bindings/node": {
       "name": "wickra",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -26,12 +26,12 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.0",
-        "wickra-darwin-x64": "0.9.0",
-        "wickra-linux-arm64-gnu": "0.9.0",
-        "wickra-linux-x64-gnu": "0.9.0",
-        "wickra-win32-arm64-msvc": "0.9.0",
-        "wickra-win32-x64-msvc": "0.9.0"
+        "wickra-darwin-arm64": "0.9.1",
+        "wickra-darwin-x64": "0.9.1",
+        "wickra-linux-arm64-gnu": "0.9.1",
+        "wickra-linux-x64-gnu": "0.9.1",
+        "wickra-win32-arm64-msvc": "0.9.1",
+        "wickra-win32-x64-msvc": "0.9.1"
       }
     },
     "node_modules/wickra": {


### PR DESCRIPTION
Release prep for **0.9.1** — bumped via the ScriptHelpers `bump_version.py` tool (19 files: Cargo.toml/lock, pyproject, node package.json + 6 platform stubs + both lockfiles, java pom + examples + README, C# csproj, R DESCRIPTION, SECURITY.md, CHANGELOG section + compare URLs).

### Highlights (from `CHANGELOG.md`)
- **Added:** C ABI `warmup_period` / `is_ready` across C, C#, Go, Java, R; runnable rustdoc examples for 23 indicators; a Requirements reference.
- **Changed:** min Node.js 20 (18 EOL); Java builds on JDK 25 LTS (22 EOL, target still 22); language-naming standardization; pyo3 + rust-numpy 0.29.
- **Fixed:** `RelativeStrengthAB` wrapper casing.
- **Security:** cleared the two pyo3 advisories (RUSTSEC-2026-0176/0177) via pyo3 0.29.

`cargo build` (Cargo.lock refresh) + `cargo fmt --all` clean; tool reported 19 ok / 0 warn / 0 fail.

> No tag is pushed — tagging `v0.9.1` (the irreversible crates.io/PyPI/npm publish) waits for explicit go after this merges.