### PR TITLE
chore(examples): rename live_trading examples to live_binance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -227,7 +227,7 @@ A handful of indicators need care beyond naive accumulation:
 A typical full-stack call sequence for a Python live-trading example:
 
 ```
-[ Python: live_trading.py ]
+[ Python: live_binance.py ]
         │
         ▼
 [ binance.AsyncClient WebSocket ] ──── wickra_data live feed ───┐

--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ while let Some(event) = stream.next_event().await? {
 }
 ```
 
-A Python live-trading example using the public `websockets` package lives at
-`examples/python/live_trading.py`.
+A Python live Binance feed example using the public `websockets` package lives at
+`examples/python/live_binance.py`.
 
 ## Project layout
 
@@ -294,8 +294,8 @@ wickra/
 ├── examples/                examples/README.md indexes every language
 │   ├── data/                real BTCUSDT OHLCV datasets, one per timeframe
 │   ├── rust/                Rust workspace member (`wickra-examples`)
-│   ├── python/              backtest, live trading, parallel assets, multi-tf
-│   ├── node/                streaming, backtest, live trading (load `wickra`)
+│   ├── python/              backtest, live Binance feed, parallel assets, multi-tf
+│   ├── node/                streaming, backtest, live Binance feed (load `wickra`)
 │   ├── wasm/                browser demo for `wickra-wasm`
 │   ├── c/                   C smoke + streaming, C++ RAII wrapper
 │   ├── csharp/              streaming, backtest, strategies (load `Wickra`)

--- a/examples/README.md
+++ b/examples/README.md
@@ -142,7 +142,7 @@ build-checked but not run in CI.
 | --- | --- | --- |
 | `streaming.py` | Feed a synthetic price series through SMA / EMA / RSI / MACD tick by tick. | `python -m examples.python.streaming` |
 | `backtest.py` | Basket of indicators over an OHLCV CSV. | `python -m examples.python.backtest <ohlcv.csv>` |
-| `live_trading.py` | Live Binance feed → RSI / MACD / Bollinger → signals. | `python -m examples.python.live_trading --symbol BTCUSDT --interval 1m` |
+| `live_binance.py` | Live Binance feed → RSI / MACD / Bollinger → signals. | `python -m examples.python.live_binance --symbol BTCUSDT --interval 1m` |
 | `multi_timeframe.py` | Resample a 1-minute CSV to coarser timeframes and compare. | `python -m examples.python.multi_timeframe <1m.csv>` |
 | `parallel_assets.py` | Process many symbols in parallel — the Rust extension releases the GIL during batch computation. | `python -m examples.python.parallel_assets --assets 200 --bars 5000` |
 | `fetch_btcusdt.py` | Download real BTCUSDT klines from the Binance REST API into `examples/data/` (urllib + stdlib only). | `python -m examples.python.fetch_btcusdt` |
@@ -150,7 +150,7 @@ build-checked but not run in CI.
 | `strategy_macd_adx.py` | Hourly BTCUSDT trend-follower: MACD crossover entries gated by ADX(14) > 20. | `python -m examples.python.strategy_macd_adx` |
 | `strategy_bollinger_squeeze.py` | Daily BTCUSDT Bollinger-squeeze breakout with ATR(14) trailing stop. | `python -m examples.python.strategy_bollinger_squeeze` |
 
-`live_trading.py` additionally needs `pip install websockets`.
+`live_binance.py` additionally needs `pip install websockets`.
 
 ## Node.js — `examples/node/`
 
@@ -167,7 +167,7 @@ cd ../../examples/node && npm install        # links wickra + installs `ws`
 | `backtest.js` | Basket of indicators over an OHLCV CSV; defaults to the bundled BTCUSDT daily dataset. | `node backtest.js [ohlcv.csv]` |
 | `multi_timeframe.js` | Roll a 1-minute CSV up to 5m / 15m / 1h / 4h / 1d and print indicators per timeframe. | `node multi_timeframe.js [path/to/1m.csv]` |
 | `parallel_assets.js` | Serial vs `worker_threads` pool over a synthetic panel, with speedup. | `node parallel_assets.js --assets 200 --bars 5000` |
-| `live_trading.js` | Live Binance feed → RSI / MACD / Bollinger → signals. | `node live_trading.js --symbol BTCUSDT --interval 1m` |
+| `live_binance.js` | Live Binance feed → RSI / MACD / Bollinger → signals. | `node live_binance.js --symbol BTCUSDT --interval 1m` |
 | `fetch_btcusdt.js` | Download real BTCUSDT klines from the Binance REST API into `examples/data/` (built-in `fetch`, Node 18+). | `node fetch_btcusdt.js` |
 | `strategy_rsi_mean_reversion.js` | Hourly BTCUSDT mean-reversion using RSI(14) thresholds, with PnL / Sharpe / max-DD summary. | `node strategy_rsi_mean_reversion.js` |
 | `strategy_macd_adx.js` | Hourly BTCUSDT trend-follower: MACD crossover entries gated by ADX(14) > 20. | `node strategy_macd_adx.js` |
@@ -188,7 +188,7 @@ Then serve the repository root (`python -m http.server`, `npx http-server`,
 | --- | --- |
 | `index.html` | Streams a synthetic price series through six indicators and draws a live `<canvas>` chart. |
 | `backtest.html` | Streams a fetched OHLCV CSV through a basket of indicators (SMA, EMA, RSI, MACD, Bollinger, ATR, ADX, OBV) and prints a per-series summary table. |
-| `live_trading.html` | Opens a browser-native `WebSocket` to Binance, runs RSI / MACD / Bollinger and flags BUY/SELL candidates. |
+| `live_binance.html` | Opens a browser-native `WebSocket` to Binance, runs RSI / MACD / Bollinger and flags BUY/SELL candidates. |
 | `multi_timeframe.html` | Fetches a 1-minute CSV, rolls it up to 5m / 15m / 1h / 4h / 1d in-page, prints RSI / MACD hist / ADX per timeframe. |
 | `parallel_assets.html` | Spawns a pool of module Workers (each loading its own copy of the WASM module) and reports the speedup over a serial baseline. |
 | `strategy_rsi_mean_reversion.html` | Hourly BTCUSDT RSI(14) mean-reversion (long &lt; 30, exit &gt; 70); prints a PnL / Sharpe / max-DD summary table. |

--- a/examples/c/live_binance.c
+++ b/examples/c/live_binance.c
@@ -1,7 +1,7 @@
 /* Live BTCUSDT indicator with the Wickra C ABI.
  *
  * The C counterpart of `examples/rust/src/bin/live_binance.rs`,
- * `examples/python/live_trading.py` and `examples/node/live_trading.js`. Those
+ * `examples/python/live_binance.py` and `examples/node/live_binance.js`. Those
  * stream Binance over a WebSocket; the C ABI ships only the indicators and no
  * socket layer, so this example polls the Binance REST klines endpoint via the
  * system `curl` once per interval and feeds each newly *closed* candle into a

--- a/examples/node/live_binance.js
+++ b/examples/node/live_binance.js
@@ -1,17 +1,17 @@
-// Live trading skeleton for the Wickra Node binding.
+// Live Binance feed example for the Wickra Node binding.
 //
 // Connects to Binance's public WebSocket feed (no API key needed) and runs
 // RSI / MACD / Bollinger Bands on the incoming close prices. When RSI crosses
 // the common overbought / oversold thresholds *and* the MACD histogram
 // confirms the direction *and* price pierces the matching Bollinger band, a
 // signal line is printed. No orders are placed. It is the Node counterpart of
-// examples/python/live_trading.py.
+// examples/python/live_binance.py.
 //
 // Run it from the repository after building the native binding:
 //
 //   cd bindings/node && npm install && npx napi build --platform --release
 //   cd ../../examples/node && npm install     # pulls `ws` for this example
-//   node live_trading.js --symbol BTCUSDT --interval 1m
+//   node live_binance.js --symbol BTCUSDT --interval 1m
 //
 // Stop it with Ctrl+C.
 

--- a/examples/python/live_binance.py
+++ b/examples/python/live_binance.py
@@ -1,4 +1,4 @@
-"""Live trading skeleton: stream Binance kline ticks → incremental indicators → signals.
+"""Live Binance feed: stream Binance kline ticks → incremental indicators → signals.
 
 This example connects to Binance's public WebSocket feed (no API key needed)
 and runs RSI / MACD / Bollinger Bands on the close prices coming in. When the
@@ -7,7 +7,7 @@ confirms the direction, a `Signal` event is printed. No orders are placed.
 
 Run with::
 
-    python -m examples.python.live_trading --symbol BTCUSDT --interval 1m
+    python -m examples.python.live_binance --symbol BTCUSDT --interval 1m
 
 Dependencies::
 

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -38,7 +38,7 @@ Then open the demo you want at `http://localhost:8000/examples/wasm/<file>`.
 | --- | --- |
 | `index.html` | The original showcase: streams a synthetic price series through six indicators and draws a live `<canvas>` chart with `SMA`, `EMA`, `RSI`, `MACD`, `BollingerBands` and `ATR` cards. |
 | `backtest.html` | Backtest: fetches an OHLCV CSV (default the bundled BTCUSDT daily dataset), streams every candle through a basket of eight indicators, prints a summary table. Mirrors `examples/python/backtest.py`. |
-| `live_trading.html` | Browser-native `WebSocket` to Binance kline streams; runs RSI / MACD / Bollinger on the incoming closes and flags BUY/SELL candidates when the three agree. Mirrors `examples/python/live_trading.py`. |
+| `live_binance.html` | Browser-native `WebSocket` to Binance kline streams; runs RSI / MACD / Bollinger on the incoming closes and flags BUY/SELL candidates when the three agree. Mirrors `examples/python/live_binance.py`. |
 | `multi_timeframe.html` | Fetches a 1-minute CSV, rolls it up in-page to 5m / 15m / 1h / 4h / 1d buckets and prints RSI / MACD-histogram / ADX per timeframe. Mirrors `examples/python/multi_timeframe.py`. |
 | `parallel_assets.html` | Synthetic `(assets, bars)` panel, serial baseline on the main thread vs. a pool of module Workers each loading its own copy of the WASM module. Mirrors `examples/python/parallel_assets.py`. |
 | `parallel_worker.js` | Module worker used by `parallel_assets.html` (not loaded directly). |

--- a/examples/wasm/live_binance.html
+++ b/examples/wasm/live_binance.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Wickra WASM — live trading</title>
+  <title>Wickra WASM — live Binance feed</title>
   <style>
     body { font-family: ui-sans-serif, system-ui, sans-serif; max-width: 980px; margin: 2rem auto; padding: 0 1rem; color: #1d1d1d; }
     h1 { margin-bottom: .25rem; }
@@ -22,14 +22,14 @@
   </style>
 </head>
 <body>
-  <h1>Wickra WASM — live trading</h1>
+  <h1>Wickra WASM — live Binance feed</h1>
   <p class="meta">
     Connects to Binance's public kline WebSocket from the browser, streams
     every tick through RSI(14), MACD(12,26,9) and Bollinger(20, 2.0) via
     the WebAssembly bindings, and flags BUY/SELL candidates when all
     three indicators agree. No orders are placed. Mirrors
-    <code>examples/python/live_trading.py</code> and
-    <code>examples/node/live_trading.js</code>.
+    <code>examples/python/live_binance.py</code> and
+    <code>examples/node/live_binance.js</code>.
   </p>
 
   <p>


### PR DESCRIPTION
## Why

The `live_trading` examples stream a live Binance feed into the indicators and print signals — **they place no orders**. The name overstated them and was inconsistent with the C / Go / R examples, which are already named `live_binance`.

## What

- Rename `examples/{python,node,wasm}/live_trading.* -> live_binance.*`.
- Update every file reference, run command, in-file header/title, and the project-tree listings in `README.md` / `ARCHITECTURE.md` / `examples/README.md` / `examples/wasm/README.md` / `examples/c/live_binance.c`.

Accurate use-case wording ("suitable for live trading bots") and the risk disclaimers ("any use in a live trading context is at your own risk") are intentionally kept — those are correct, not misnomers. Historical CHANGELOG entries that named the old files are left as-is.

Docs in wickra-docs / webpage / wickra-go that reference the old filename are updated on their own branches to land alongside this.