### PR TITLE
ci: retry-harden the Rust toolchain install across all jobs

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,46 @@
+name: Setup Rust toolchain (with retry)
+description: >
+  Install a Rust toolchain via dtolnay/rust-toolchain, retrying once after a
+  short pause on the transient rustup CDN failure (a corrupt channel manifest /
+  checksum mismatch on `channel-rust-<channel>.toml`) that rustup itself does
+  not retry — the same hardening already applied to setup-node / setup-go.
+
+inputs:
+  toolchain:
+    description: Rust toolchain (channel or version) to install.
+    required: false
+    default: stable
+  components:
+    description: Comma-separated list of rustup components (e.g. "rustfmt, clippy").
+    required: false
+    default: ""
+  targets:
+    description: Comma-separated list of rustup targets (e.g. "wasm32-unknown-unknown").
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - id: first
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+      continue-on-error: true
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}
+        targets: ${{ inputs.targets }}
+
+    - name: Wait before retrying the toolchain install
+      if: steps.first.outcome == 'failure'
+      shell: bash
+      run: |
+        echo "::warning::rustup toolchain install failed (likely a CDN flake / corrupt channel manifest); retrying in 30s"
+        sleep 30
+
+    - name: Retry the Rust toolchain install
+      if: steps.first.outcome == 'failure'
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}
+        targets: ${{ inputs.targets }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+      - uses: ./.github/actions/setup-rust
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
@@ -126,7 +126,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+      - uses: ./.github/actions/setup-rust
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+        uses: ./.github/actions/setup-rust
         with:
           components: rustfmt, clippy
 
@@ -202,7 +202,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+        uses: ./.github/actions/setup-rust
         with:
           components: clippy
 
@@ -296,7 +296,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust ${{ matrix.toolchain }}
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+        uses: ./.github/actions/setup-rust
         with:
           toolchain: ${{ matrix.toolchain }}
 
@@ -335,7 +335,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+        uses: ./.github/actions/setup-rust
         with:
           components: llvm-tools-preview
 
@@ -396,7 +396,7 @@ jobs:
           persist-credentials: false
 
       - name: Install nightly Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+        uses: ./.github/actions/setup-rust
         with:
           toolchain: nightly
 
@@ -455,7 +455,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+        uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -532,7 +532,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain (with wasm target)
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+        uses: ./.github/actions/setup-rust
         with:
           targets: wasm32-unknown-unknown
 
@@ -587,7 +587,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+        uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -660,7 +660,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+        uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -716,7 +716,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+        uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -792,7 +792,7 @@ jobs:
           cache: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+        uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -893,7 +893,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+        uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -972,7 +972,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+        uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+      - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
@@ -273,7 +273,7 @@ jobs:
         with:
           node-version: "22"
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+      - uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.target }}
 
@@ -505,7 +505,7 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+      - uses: ./.github/actions/setup-rust
         with:
           targets: wasm32-unknown-unknown
 
@@ -592,7 +592,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch, 2026-03-27
+      - uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.target }}
 


### PR DESCRIPTION
A v0.9.2 CI run failed in the Fuzz job because `rustup toolchain install nightly` hit a corrupt `channel-rust-nightly.toml` from the CDN (checksum mismatch). That download is not covered by `CARGO_NET_RETRY` (cargo only) or the rustup bootstrap's `curl --retry` — so a single bad fetch failed the job hard, exactly the class of CDN flake `setup-node` and `setup-go` are already guarded against.

This adds a small composite action `./.github/actions/setup-rust` that wraps `dtolnay/rust-toolchain` with a one-shot retry (continue-on-error + 30s pause + re-run), forwarding the `toolchain` / `components` / `targets` inputs, and routes every Rust toolchain install in `ci.yml` (13), `bench.yml` (2) and `release.yml` (4) through it. No behavioural change on the happy path; transient rustup CDN failures now retry once instead of failing the job.