### PR TITLE
fix(data): add missing 3d and 1M Binance kline intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Binance kline feed: add the missing `3d` and `1M` intervals.** The
+  `live-binance` `Interval` enum was missing three-day (`3d`) and one-month (`1M`)
+  candles, two of Binance's 16 supported kline intervals. Both are now selectable
+  and map to the correct wire-format strings.
+
 ### Added
 - **CSV candle reading in all 10 languages (data layer).** The `CandleReader`
   parses a `timestamp,open,high,low,close,volume` CSV buffer (a leading UTF-8 BOM

--- a/crates/wickra-data/src/live/binance.rs
+++ b/crates/wickra-data/src/live/binance.rs
@@ -92,7 +92,9 @@ pub enum Interval {
     EightHours,
     TwelveHours,
     OneDay,
+    ThreeDays,
     OneWeek,
+    OneMonth,
 }
 
 impl Interval {
@@ -112,7 +114,9 @@ impl Interval {
             Self::EightHours => "8h",
             Self::TwelveHours => "12h",
             Self::OneDay => "1d",
+            Self::ThreeDays => "3d",
             Self::OneWeek => "1w",
+            Self::OneMonth => "1M",
         }
     }
 }
@@ -413,7 +417,9 @@ mod tests {
             (Interval::EightHours, "8h"),
             (Interval::TwelveHours, "12h"),
             (Interval::OneDay, "1d"),
+            (Interval::ThreeDays, "3d"),
             (Interval::OneWeek, "1w"),
+            (Interval::OneMonth, "1M"),
         ];
         for (iv, expected) in pairs {
             assert_eq!(iv.as_str(), *expected);


### PR DESCRIPTION
## Summary

The `live-binance` `Interval` enum was missing two of Binance's 16 supported kline intervals: **three-day (`3d`)** and **one-month (`1M`)**. A user spotted the gap. Both are now selectable and map to the correct wire-format strings used in the combined-stream name.

## Changes
- `Interval` enum: add `ThreeDays` (after `OneDay`) and `OneMonth` (after `OneWeek`), in Binance's documented order (`1d, 3d, 1w, 1M`).
- `Interval::as_str`: `ThreeDays -> "3d"`, `OneMonth -> "1M"`.
- Extend the exhaustive `interval_as_str_covers_every_variant` test to all 16.

## Verification
Local: `cargo fmt --all`, `cargo clippy -p wickra-data --features live-binance --all-targets -- -D warnings` (0), `cargo test -p wickra-data --features live-binance` (51+4 pass). CI runs the same `live-binance` feature test (ci.yml).

Prep for the upcoming native Binance feed binding (F4) so every binding exposes the full interval set.