### PR TITLE
docs(crates): point wickra documentation link to docs.wickra.org

### DIFF
--- a/crates/wickra/Cargo.toml
+++ b/crates/wickra/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
-documentation = "https://docs.rs/wickra"
+documentation = "https://docs.wickra.org"
 
 # Render the docs on docs.rs with every feature enabled.
 [package.metadata.docs.rs]


### PR DESCRIPTION
## What

Change the `documentation` field of the main `wickra` crate from the auto-generated rustdoc URL to the project's documentation site:

```toml
# crates/wickra/Cargo.toml
documentation = "https://docs.wickra.org"   # was: https://docs.rs/wickra
```

## Why

On crates.io the "Documentation" link defaulted to `docs.rs/wickra`. The richer landing page for someone arriving from crates.io is the prose docs site — it carries the Rust quickstart, the API guide, and the full indicator catalogue. The auto-built docs.rs API reference stays reachable at `docs.rs/wickra`; only the crates.io link target changes.

## Scope

- Only the user-facing `wickra` crate is changed.
- `wickra-core` and `wickra-data` keep their `docs.rs` links — those low-level crates have no dedicated guide page on the docs site, so docs.rs remains the correct target for them.
- Metadata only; no code, build, or runtime change. Takes effect on the next crates.io publish.