### PR TITLE
docs(examples): drop stale third-party install hints

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -150,7 +150,8 @@ build-checked but not run in CI.
 | `strategy_macd_adx.py` | Hourly BTCUSDT trend-follower: MACD crossover entries gated by ADX(14) > 20. | `python -m examples.python.strategy_macd_adx` |
 | `strategy_bollinger_squeeze.py` | Daily BTCUSDT Bollinger-squeeze breakout with ATR(14) trailing stop. | `python -m examples.python.strategy_bollinger_squeeze` |
 
-`live_binance.py` additionally needs `pip install websockets`.
+Every Python example runs on Wickra alone — no third-party packages.
+`live_binance.py` uses the native `BinanceFeed` and `fetch_btcusdt.py` the stdlib `urllib`.
 
 ## Node.js — `examples/node/`
 
@@ -158,7 +159,7 @@ Build the native binding once, then link it into the examples directory:
 
 ```bash
 cd bindings/node && npm install && npx napi build --platform --release
-cd ../../examples/node && npm install        # links wickra + installs `ws`
+cd ../../examples/node && npm install        # links wickra (no third-party packages)
 ```
 
 | Example | What it does | Run |


### PR DESCRIPTION
The examples README still told readers `live_binance.py` needs `pip install websockets` and that the node `npm install` pulls `ws` — both stale since the data-layer cleanup migrated those examples to the native `BinanceFeed`.

- Python section: note that every example runs on Wickra alone (`live_binance.py` → native `BinanceFeed`, `fetch_btcusdt.py` → stdlib `urllib`).
- Node section: `npm install` comment now reads "links wickra (no third-party packages)".

Scanned all four repos (wickra / wickra-docs / webpage / .github): the quickstart/API pages and selling-point prose were already clean (Task 7); this was the last stale third-party install hint.