### PR TITLE
release: bump 0.9.2 -> 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-06-17
+
 ### Changed
 - **Python: zero third-party dependencies — NumPy is no longer required**
   (breaking). `pip install wickra` now pulls nothing else. Batch inputs accept any
@@ -17,7 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   arrays. Both expose the buffer protocol, so `numpy.asarray(result)` still wraps a
   1-D result zero-copy when NumPy is installed — it is now an optional extra
   (`pip install wickra[numpy]`). Streaming `update(...)` is unchanged, and results
-  are numerically identical. The other nine languages were already dependency-free.
+  are numerically identical. Single-output `batch(...)` is slower than the previous
+  NumPy path — a stdlib `array.array` cannot take ownership of the Rust result, so
+  it is copied rather than moved — though absolute batch latency stays in the
+  low-millisecond range. The other nine languages were already dependency-free.
 
 ### Removed
 - **Python: `numpy` runtime dependency** (see *Changed*). NumPy moves to the
@@ -1805,7 +1810,8 @@ public API changes.
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/wickra-lib/wickra/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/wickra-lib/wickra/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/wickra-lib/wickra/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/wickra-lib/wickra/compare/v0.8.9...v0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "approx",
  "criterion",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-bench"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "criterion",
  "kand",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-c"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "tokio",
  "wickra-core",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "approx",
  "proptest",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "approx",
  "csv",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-examples"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "serde_json",
  "tokio",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "napi",
  "napi-build",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bytemuck",
  "pyo3",
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.3"
 authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
@@ -26,8 +26,8 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.9.2" }
-wickra-data = { path = "crates/wickra-data", version = "0.9.2" }
+wickra-core = { path = "crates/wickra-core", version = "0.9.3" }
+wickra-data = { path = "crates/wickra-data", version = "0.9.3" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported versions
 
-Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.2`
+Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.3`
 version only; please upgrade to the newest release before reporting an issue.
 
 | Version | Supported |
 | --- | --- |
-| 0.9.2 (latest) | :white_check_mark: |
-| < 0.9.2 | :x: |
+| 0.9.3 (latest) | :white_check_mark: |
+| < 0.9.3 | :x: |
 
 ## Reporting a vulnerability
 

--- a/bindings/csharp/Wickra/Wickra.csproj
+++ b/bindings/csharp/Wickra/Wickra.csproj
@@ -11,7 +11,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>Wickra</PackageId>
-    <Version>0.9.2</Version>
+    <Version>0.9.3</Version>
     <Authors>kingchenc</Authors>
     <Description>High-performance streaming technical-analysis indicators (514 indicators) for .NET, backed by the native Rust core via the Wickra C ABI.</Description>
     <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -30,14 +30,14 @@ Maven:
 <dependency>
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.2</version>
+  <version>0.9.3</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.wickra:wickra:0.9.2")
+implementation("org.wickra:wickra:0.9.3")
 ```
 
 The native library ships prebuilt per platform (Linux, macOS, Windows — x64 and

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.2</version>
+  <version>0.9.3</version>
   <packaging>jar</packaging>
 
   <name>Wickra</name>

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wickra",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wickra",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -15,12 +15,12 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.2",
-        "wickra-darwin-x64": "0.9.2",
-        "wickra-linux-arm64-gnu": "0.9.2",
-        "wickra-linux-x64-gnu": "0.9.2",
-        "wickra-win32-arm64-msvc": "0.9.2",
-        "wickra-win32-x64-msvc": "0.9.2"
+        "wickra-darwin-arm64": "0.9.3",
+        "wickra-darwin-x64": "0.9.3",
+        "wickra-linux-arm64-gnu": "0.9.3",
+        "wickra-linux-x64-gnu": "0.9.3",
+        "wickra-win32-arm64-msvc": "0.9.3",
+        "wickra-win32-x64-msvc": "0.9.3"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -41,8 +41,8 @@
       }
     },
     "node_modules/wickra-darwin-arm64": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.2.tgz",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.3.tgz",
       "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
       "cpu": [
         "arm64"
@@ -57,8 +57,8 @@
       }
     },
     "node_modules/wickra-darwin-x64": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.2.tgz",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.3.tgz",
       "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
       "cpu": [
         "x64"
@@ -73,8 +73,8 @@
       }
     },
     "node_modules/wickra-linux-arm64-gnu": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.2.tgz",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.3.tgz",
       "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
       "cpu": [
         "arm64"
@@ -89,8 +89,8 @@
       }
     },
     "node_modules/wickra-linux-x64-gnu": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.2.tgz",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.3.tgz",
       "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
       "cpu": [
         "x64"
@@ -105,8 +105,8 @@
       }
     },
     "node_modules/wickra-win32-arm64-msvc": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.2.tgz",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.3.tgz",
       "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
       "cpu": [
         "arm64"
@@ -121,8 +121,8 @@
       }
     },
     "node_modules/wickra-win32-x64-msvc": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.2.tgz",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.3.tgz",
       "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
       "cpu": [
         "x64"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
@@ -47,12 +47,12 @@
     "node": ">= 20"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.9.2",
-    "wickra-linux-arm64-gnu": "0.9.2",
-    "wickra-darwin-x64": "0.9.2",
-    "wickra-darwin-arm64": "0.9.2",
-    "wickra-win32-x64-msvc": "0.9.2",
-    "wickra-win32-arm64-msvc": "0.9.2"
+    "wickra-linux-x64-gnu": "0.9.3",
+    "wickra-linux-arm64-gnu": "0.9.3",
+    "wickra-darwin-x64": "0.9.3",
+    "wickra-darwin-arm64": "0.9.3",
+    "wickra-win32-x64-msvc": "0.9.3",
+    "wickra-win32-arm64-msvc": "0.9.3"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.9.2"
+version = "0.9.3"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: wickra
 Type: Package
 Title: Streaming-First Technical Indicators
-Version: 0.9.2
+Version: 0.9.3
 Authors@R: person("Wickra contributors", role = c("aut", "cre"), email = "support@wickra.org")
 Description: R bindings for the Wickra technical-analysis library over its C ABI
     hub. Exposes 514 indicators, each an O(1) streaming state machine shared with

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra.examples</groupId>
   <artifactId>wickra-examples</artifactId>
-  <version>0.9.2</version>
+  <version>0.9.3</version>
   <packaging>jar</packaging>
 
   <name>Wickra Java examples</name>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.wickra</groupId>
       <artifactId>wickra</artifactId>
-      <version>0.9.2</version>
+      <version>0.9.3</version>
     </dependency>
   </dependencies>
 

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -14,7 +14,7 @@
     },
     "../../bindings/node": {
       "name": "wickra",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -23,12 +23,12 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.2",
-        "wickra-darwin-x64": "0.9.2",
-        "wickra-linux-arm64-gnu": "0.9.2",
-        "wickra-linux-x64-gnu": "0.9.2",
-        "wickra-win32-arm64-msvc": "0.9.2",
-        "wickra-win32-x64-msvc": "0.9.2"
+        "wickra-darwin-arm64": "0.9.3",
+        "wickra-darwin-x64": "0.9.3",
+        "wickra-linux-arm64-gnu": "0.9.3",
+        "wickra-linux-x64-gnu": "0.9.3",
+        "wickra-win32-arm64-msvc": "0.9.3",
+        "wickra-win32-x64-msvc": "0.9.3"
       }
     },
     "node_modules/wickra": {


### PR DESCRIPTION
Release the native data-layer bundle.

`0.9.3` ships everything merged since `0.9.2`:

- **Data layer in all 10 languages** — `CandleReader` (CSV), `TickAggregator`, `Resampler`, live `BinanceFeed` (WebSocket) and the historical `fetch_binance_klines` (REST), each cross-language golden-pinned.
- **`name()` on every indicator** in all 10 languages (514 indicators, golden-pinned).
- **Python is now zero third-party deps** — NumPy is optional (`pip install wickra[numpy]`); `batch` returns a stdlib `array.array` / buffer-protocol `Matrix` (breaking; results numerically identical, batch throughput tradeoff noted in the CHANGELOG).
- **Binance feed: missing `3d` / `1M` intervals** fixed.

Pure version-string bump on top — `bump_version.py` touched 19 files (Cargo + Lock, pyproject, all node package.json/locks + 6 platform stubs, pom + csproj + DESCRIPTION, SECURITY, CHANGELOG `[0.9.3]` + compare URLs). `cargo fmt`/`clippy -D warnings`/`test --workspace --all-features` all green locally (4225+ tests, 0 failed).

The tag/publish is **not** part of this PR — it waits for explicit GO (irreversible publish to crates.io / PyPI / npm / NuGet / Maven / Go / r-universe).