### PR TITLE
release: bump 0.9.3 -> 0.9.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,14 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --strip --out dist
           manylinux: ${{ matrix.manylinux }}
+          # The live-binance data layer links native-tls -> openssl-sys, which
+          # needs the system OpenSSL headers at build time. The manylinux and
+          # musllinux build containers do not ship them, so install them inside
+          # the container before maturin compiles the wheel (no-op on the native
+          # macOS/Windows runners, where this hook does not run).
+          before-script-linux: |
+            if command -v yum >/dev/null 2>&1; then yum install -y openssl-devel; fi
+            if command -v apk >/dev/null 2>&1; then apk add --no-cache openssl-dev pkgconfig; fi
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Include manylinux in the name so the glibc and musl x86_64/aarch64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-06-17
+
+Packaging fix for the `0.9.3` data layer. No library code changed; `0.9.4` is
+identical to `0.9.3` on every platform that already published. The Linux Python
+wheels are released for the first time here, because `0.9.3` could not build them.
+
+### Fixed
+- **Linux Python wheels (`manylinux` / `musllinux`) now build.** The `live-binance`
+  data layer links `native-tls`, which pulls in `openssl-sys`, and the wheel build
+  containers do not ship the system OpenSSL headers. The release workflow now
+  installs them inside the container before compiling (`openssl-devel` on
+  `manylinux`, `openssl-dev` on `musllinux`). The native macOS and Windows wheels
+  were unaffected. As a result `0.9.3` shipped to crates.io, Maven Central, NuGet,
+  and npm but not to PyPI; PyPI publishes starting with `0.9.4`.
+
+
 ## [0.9.3] - 2026-06-17
 
 ### Changed
@@ -1810,7 +1826,8 @@ public API changes.
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.3...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.4...HEAD
+[0.9.4]: https://github.com/wickra-lib/wickra/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/wickra-lib/wickra/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/wickra-lib/wickra/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/wickra-lib/wickra/compare/v0.9.0...v0.9.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "approx",
  "criterion",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-bench"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "criterion",
  "kand",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-c"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "tokio",
  "wickra-core",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "approx",
  "proptest",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "approx",
  "csv",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-examples"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "serde_json",
  "tokio",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "napi",
  "napi-build",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bytemuck",
  "pyo3",
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.3"
+version = "0.9.4"
 authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
@@ -26,8 +26,8 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.9.3" }
-wickra-data = { path = "crates/wickra-data", version = "0.9.3" }
+wickra-core = { path = "crates/wickra-core", version = "0.9.4" }
+wickra-data = { path = "crates/wickra-data", version = "0.9.4" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported versions
 
-Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.3`
+Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.4`
 version only; please upgrade to the newest release before reporting an issue.
 
 | Version | Supported |
 | --- | --- |
-| 0.9.3 (latest) | :white_check_mark: |
-| < 0.9.3 | :x: |
+| 0.9.4 (latest) | :white_check_mark: |
+| < 0.9.4 | :x: |
 
 ## Reporting a vulnerability
 

--- a/bindings/csharp/Wickra/Wickra.csproj
+++ b/bindings/csharp/Wickra/Wickra.csproj
@@ -11,7 +11,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>Wickra</PackageId>
-    <Version>0.9.3</Version>
+    <Version>0.9.4</Version>
     <Authors>kingchenc</Authors>
     <Description>High-performance streaming technical-analysis indicators (514 indicators) for .NET, backed by the native Rust core via the Wickra C ABI.</Description>
     <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -30,14 +30,14 @@ Maven:
 <dependency>
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.3</version>
+  <version>0.9.4</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.wickra:wickra:0.9.3")
+implementation("org.wickra:wickra:0.9.4")
 ```
 
 The native library ships prebuilt per platform (Linux, macOS, Windows — x64 and

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.3</version>
+  <version>0.9.4</version>
   <packaging>jar</packaging>
 
   <name>Wickra</name>

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wickra",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wickra",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -15,12 +15,12 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.3",
-        "wickra-darwin-x64": "0.9.3",
-        "wickra-linux-arm64-gnu": "0.9.3",
-        "wickra-linux-x64-gnu": "0.9.3",
-        "wickra-win32-arm64-msvc": "0.9.3",
-        "wickra-win32-x64-msvc": "0.9.3"
+        "wickra-darwin-arm64": "0.9.4",
+        "wickra-darwin-x64": "0.9.4",
+        "wickra-linux-arm64-gnu": "0.9.4",
+        "wickra-linux-x64-gnu": "0.9.4",
+        "wickra-win32-arm64-msvc": "0.9.4",
+        "wickra-win32-x64-msvc": "0.9.4"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -41,8 +41,8 @@
       }
     },
     "node_modules/wickra-darwin-arm64": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.3.tgz",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.4.tgz",
       "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
       "cpu": [
         "arm64"
@@ -57,8 +57,8 @@
       }
     },
     "node_modules/wickra-darwin-x64": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.3.tgz",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.4.tgz",
       "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
       "cpu": [
         "x64"
@@ -73,8 +73,8 @@
       }
     },
     "node_modules/wickra-linux-arm64-gnu": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.3.tgz",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.4.tgz",
       "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
       "cpu": [
         "arm64"
@@ -89,8 +89,8 @@
       }
     },
     "node_modules/wickra-linux-x64-gnu": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.3.tgz",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.4.tgz",
       "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
       "cpu": [
         "x64"
@@ -105,8 +105,8 @@
       }
     },
     "node_modules/wickra-win32-arm64-msvc": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.3.tgz",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.4.tgz",
       "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
       "cpu": [
         "arm64"
@@ -121,8 +121,8 @@
       }
     },
     "node_modules/wickra-win32-x64-msvc": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.3.tgz",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.4.tgz",
       "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
       "cpu": [
         "x64"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
@@ -47,12 +47,12 @@
     "node": ">= 20"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.9.3",
-    "wickra-linux-arm64-gnu": "0.9.3",
-    "wickra-darwin-x64": "0.9.3",
-    "wickra-darwin-arm64": "0.9.3",
-    "wickra-win32-x64-msvc": "0.9.3",
-    "wickra-win32-arm64-msvc": "0.9.3"
+    "wickra-linux-x64-gnu": "0.9.4",
+    "wickra-linux-arm64-gnu": "0.9.4",
+    "wickra-darwin-x64": "0.9.4",
+    "wickra-darwin-arm64": "0.9.4",
+    "wickra-win32-x64-msvc": "0.9.4",
+    "wickra-win32-arm64-msvc": "0.9.4"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.9.3"
+version = "0.9.4"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: wickra
 Type: Package
 Title: Streaming-First Technical Indicators
-Version: 0.9.3
+Version: 0.9.4
 Authors@R: person("Wickra contributors", role = c("aut", "cre"), email = "support@wickra.org")
 Description: R bindings for the Wickra technical-analysis library over its C ABI
     hub. Exposes 514 indicators, each an O(1) streaming state machine shared with

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra.examples</groupId>
   <artifactId>wickra-examples</artifactId>
-  <version>0.9.3</version>
+  <version>0.9.4</version>
   <packaging>jar</packaging>
 
   <name>Wickra Java examples</name>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.wickra</groupId>
       <artifactId>wickra</artifactId>
-      <version>0.9.3</version>
+      <version>0.9.4</version>
     </dependency>
   </dependencies>
 

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -14,7 +14,7 @@
     },
     "../../bindings/node": {
       "name": "wickra",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -23,12 +23,12 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.3",
-        "wickra-darwin-x64": "0.9.3",
-        "wickra-linux-arm64-gnu": "0.9.3",
-        "wickra-linux-x64-gnu": "0.9.3",
-        "wickra-win32-arm64-msvc": "0.9.3",
-        "wickra-win32-x64-msvc": "0.9.3"
+        "wickra-darwin-arm64": "0.9.4",
+        "wickra-darwin-x64": "0.9.4",
+        "wickra-linux-arm64-gnu": "0.9.4",
+        "wickra-linux-x64-gnu": "0.9.4",
+        "wickra-win32-arm64-msvc": "0.9.4",
+        "wickra-win32-x64-msvc": "0.9.4"
       }
     },
     "node_modules/wickra": {


### PR DESCRIPTION
Packaging fix for the `0.9.3` data layer.

`0.9.3` published to crates.io, Maven Central, NuGet, npm, and the Go mirror, but
the **Linux Python wheels failed to build**, so `Publish to PyPI` was skipped and
no GitHub Release was attached. Root cause: the `live-binance` data layer links
`native-tls` -> `openssl-sys`, and the `manylinux` / `musllinux` wheel-build
containers do not ship the system OpenSSL headers. The native macOS and Windows
wheels were unaffected (system TLS), which is why CI — running Python natively on
the runners, where OpenSSL is present — stayed green.

### Changes
- **`ci`**: install the OpenSSL headers inside the wheel container via
  maturin-action's `before-script-linux` (`openssl-devel` on `manylinux`,
  `openssl-dev` on `musllinux`) before maturin compiles. No library code changed.
- **`release: bump 0.9.3 -> 0.9.4`**: version-string bump across the manual
  touchpoints + `CHANGELOG` `[0.9.4]`.

`0.9.4` is functionally identical to `0.9.3`; it exists only because the already-
published registries cannot re-release `0.9.3`. PyPI publishes for the first time
starting at `0.9.4` (it skips `0.9.3`).