### PR TITLE
release: bump 0.9.5 -> 0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-06-18
+
+Documentation release for the R binding. The library API and every indicator
+are unchanged from `0.9.5`; only the R package's help pages change.
+
+### Fixed
+- **R package: document the data-layer exports and refresh the man pages.**
+  r-universe's `R CMD check` reported two warnings against the `0.9.3` data layer
+  it built for the first time in `0.9.5`: twelve undocumented exported objects
+  (`BinanceFeed`, `CandleReader`, `Resampler`, `TickAggregator`,
+  `fetch_binance_klines` and the `name` / `is_ready` / `warmup_period` / `push` /
+  `read` generics) and a codoc mismatch on `AwesomeOscillatorHistogram` (its help
+  page still listed `sma_period` after the argument was renamed to `lookback`).
+  The roxygen sources existed but the `man/*.Rd` had never been regenerated; they
+  are now complete, and a `push()` example that constructed a `TickAggregator`
+  without its required `gap_fill` argument is fixed. CI now runs `R CMD check` so
+  documentation drift fails the pull request instead of surfacing on r-universe.
+
+
 ## [0.9.5] - 2026-06-17
 
 Maintenance release. The library API and every indicator are unchanged from
@@ -1853,7 +1872,8 @@ public API changes.
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.5...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.6...HEAD
+[0.9.6]: https://github.com/wickra-lib/wickra/compare/v0.9.5...v0.9.6
 [0.9.5]: https://github.com/wickra-lib/wickra/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/wickra-lib/wickra/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/wickra-lib/wickra/compare/v0.9.2...v0.9.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "approx",
  "criterion",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-bench"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "criterion",
  "kand",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-c"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "tokio",
  "wickra-core",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "approx",
  "proptest",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "approx",
  "csv",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-examples"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "serde_json",
  "tokio",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "napi",
  "napi-build",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "bytemuck",
  "pyo3",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.5"
+version = "0.9.6"
 authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
@@ -26,8 +26,8 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.9.5" }
-wickra-data = { path = "crates/wickra-data", version = "0.9.5" }
+wickra-core = { path = "crates/wickra-core", version = "0.9.6" }
+wickra-data = { path = "crates/wickra-data", version = "0.9.6" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported versions
 
-Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.5`
+Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.6`
 version only; please upgrade to the newest release before reporting an issue.
 
 | Version | Supported |
 | --- | --- |
-| 0.9.5 (latest) | :white_check_mark: |
-| < 0.9.5 | :x: |
+| 0.9.6 (latest) | :white_check_mark: |
+| < 0.9.6 | :x: |
 
 ## Reporting a vulnerability
 

--- a/bindings/csharp/Wickra/Wickra.csproj
+++ b/bindings/csharp/Wickra/Wickra.csproj
@@ -11,7 +11,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>Wickra</PackageId>
-    <Version>0.9.5</Version>
+    <Version>0.9.6</Version>
     <Authors>kingchenc</Authors>
     <Description>High-performance streaming technical-analysis indicators (514 indicators) for .NET, backed by the native Rust core via the Wickra C ABI.</Description>
     <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -30,14 +30,14 @@ Maven:
 <dependency>
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.5</version>
+  <version>0.9.6</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.wickra:wickra:0.9.5")
+implementation("org.wickra:wickra:0.9.6")
 ```
 
 The native library ships prebuilt per platform (Linux, macOS, Windows — x64 and

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.5</version>
+  <version>0.9.6</version>
   <packaging>jar</packaging>
 
   <name>Wickra</name>

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wickra",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wickra",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -15,12 +15,12 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.5",
-        "wickra-darwin-x64": "0.9.5",
-        "wickra-linux-arm64-gnu": "0.9.5",
-        "wickra-linux-x64-gnu": "0.9.5",
-        "wickra-win32-arm64-msvc": "0.9.5",
-        "wickra-win32-x64-msvc": "0.9.5"
+        "wickra-darwin-arm64": "0.9.6",
+        "wickra-darwin-x64": "0.9.6",
+        "wickra-linux-arm64-gnu": "0.9.6",
+        "wickra-linux-x64-gnu": "0.9.6",
+        "wickra-win32-arm64-msvc": "0.9.6",
+        "wickra-win32-x64-msvc": "0.9.6"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -41,8 +41,8 @@
       }
     },
     "node_modules/wickra-darwin-arm64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.5.tgz",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.6.tgz",
       "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
       "cpu": [
         "arm64"
@@ -57,8 +57,8 @@
       }
     },
     "node_modules/wickra-darwin-x64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.5.tgz",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.6.tgz",
       "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
       "cpu": [
         "x64"
@@ -73,8 +73,8 @@
       }
     },
     "node_modules/wickra-linux-arm64-gnu": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.5.tgz",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.6.tgz",
       "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
       "cpu": [
         "arm64"
@@ -89,8 +89,8 @@
       }
     },
     "node_modules/wickra-linux-x64-gnu": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.5.tgz",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.6.tgz",
       "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
       "cpu": [
         "x64"
@@ -105,8 +105,8 @@
       }
     },
     "node_modules/wickra-win32-arm64-msvc": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.5.tgz",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.6.tgz",
       "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
       "cpu": [
         "arm64"
@@ -121,8 +121,8 @@
       }
     },
     "node_modules/wickra-win32-x64-msvc": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.5.tgz",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.6.tgz",
       "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
       "cpu": [
         "x64"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
@@ -47,12 +47,12 @@
     "node": ">= 20"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.9.5",
-    "wickra-linux-arm64-gnu": "0.9.5",
-    "wickra-darwin-x64": "0.9.5",
-    "wickra-darwin-arm64": "0.9.5",
-    "wickra-win32-x64-msvc": "0.9.5",
-    "wickra-win32-arm64-msvc": "0.9.5"
+    "wickra-linux-x64-gnu": "0.9.6",
+    "wickra-linux-arm64-gnu": "0.9.6",
+    "wickra-darwin-x64": "0.9.6",
+    "wickra-darwin-arm64": "0.9.6",
+    "wickra-win32-x64-msvc": "0.9.6",
+    "wickra-win32-arm64-msvc": "0.9.6"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.9.5"
+version = "0.9.6"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: wickra
 Type: Package
 Title: Streaming-First Technical Indicators
-Version: 0.9.5
+Version: 0.9.6
 Authors@R: person("Wickra contributors", role = c("aut", "cre"), email = "support@wickra.org")
 Description: R bindings for the Wickra technical-analysis library over its C ABI
     hub. Exposes 514 indicators, each an O(1) streaming state machine shared with

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra.examples</groupId>
   <artifactId>wickra-examples</artifactId>
-  <version>0.9.5</version>
+  <version>0.9.6</version>
   <packaging>jar</packaging>
 
   <name>Wickra Java examples</name>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.wickra</groupId>
       <artifactId>wickra</artifactId>
-      <version>0.9.5</version>
+      <version>0.9.6</version>
     </dependency>
   </dependencies>
 

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -14,7 +14,7 @@
     },
     "../../bindings/node": {
       "name": "wickra",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -23,12 +23,12 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.5",
-        "wickra-darwin-x64": "0.9.5",
-        "wickra-linux-arm64-gnu": "0.9.5",
-        "wickra-linux-x64-gnu": "0.9.5",
-        "wickra-win32-arm64-msvc": "0.9.5",
-        "wickra-win32-x64-msvc": "0.9.5"
+        "wickra-darwin-arm64": "0.9.6",
+        "wickra-darwin-x64": "0.9.6",
+        "wickra-linux-arm64-gnu": "0.9.6",
+        "wickra-linux-x64-gnu": "0.9.6",
+        "wickra-win32-arm64-msvc": "0.9.6",
+        "wickra-win32-x64-msvc": "0.9.6"
       }
     },
     "node_modules/wickra": {


### PR DESCRIPTION
Documentation release for the R binding. The library API and every indicator are
unchanged from `0.9.5`; only the R package's help pages change.

### What's in 0.9.6
- **R package documentation** (landed in #330): the twelve undocumented data-layer
  exports now have full man pages, the stale `AwesomeOscillatorHistogram` codoc is
  fixed, and a broken `push()` example is corrected — clearing the two `R CMD check`
  warnings r-universe reported for `0.9.5`. CI now runs `R CMD check` so doc drift
  fails the PR instead of reaching r-universe.

Pure version-string bump on top — `bump_version.py` touched 19 files. `cargo fmt`
clean.

Tag/publish waits for explicit GO (irreversible publish to crates.io / PyPI / npm
/ NuGet / Maven / Go / r-universe).