### PR TITLE
fix(r): credit kingchenc as R package author/maintainer

### DIFF
--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -2,7 +2,7 @@ Package: wickra
 Type: Package
 Title: Streaming-First Technical Indicators
 Version: 0.9.6
-Authors@R: person("Wickra contributors", role = c("aut", "cre"), email = "support@wickra.org")
+Authors@R: person("kingchenc", role = c("aut", "cre"), email = "support@wickra.org")
 Description: R bindings for the Wickra technical-analysis library over its C ABI
     hub. Exposes 514 indicators, each an O(1) streaming state machine shared with
     the Rust core and the other language bindings, so that live and historical

--- a/bindings/r/LICENSE
+++ b/bindings/r/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2026
-COPYRIGHT HOLDER: Wickra contributors
+COPYRIGHT HOLDER: kingchenc and the Wickra contributors

--- a/bindings/r/man/wickra-package.Rd
+++ b/bindings/r/man/wickra-package.Rd
@@ -24,11 +24,11 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Wickra contributors \email{support@wickra.org}
+\strong{Maintainer}: kingchenc \email{support@wickra.org}
 
 Authors:
 \itemize{
-  \item Wickra contributors \email{support@wickra.org}
+  \item kingchenc \email{support@wickra.org}
 }
 
 }


### PR DESCRIPTION
## Problem
The R binding's `DESCRIPTION` credited **"Wickra contributors"** as the sole `aut`/`cre` — an outlier introduced when the binding was added (#230). Every other binding credits `kingchenc`:
- Python `pyproject.toml`, Node `package.json`, Rust core `Cargo.toml` → all `kingchenc <support@wickra.org>`.

## Fix
- `DESCRIPTION` → `person("kingchenc", role = c("aut", "cre"), email = "support@wickra.org")`.
- Regenerate `man/wickra-package.Rd` (Maintainer + Authors) to match.
- Align `LICENSE` copyright holder with the root `LICENSE-MIT` (`kingchenc and the Wickra contributors`).

Metadata-only; no code or behavior change.