### PR TITLE
ci: add external link check (lychee, hybrid non-blocking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1146,3 +1146,22 @@ jobs:
   # (.github/workflows/bench.yml) — see audit finding R10. It runs nightly
   # at 03:00 UTC and on-demand via `workflow_dispatch`, and is no longer on
   # the every-push / every-PR critical path.
+
+  # Non-blocking external-link heads-up on PRs. The authoritative check is the
+  # scheduled links.yml; here it only surfaces link rot early without ever
+  # gating a PR — external sites flake (rate limits, transient outages, moves),
+  # so `continue-on-error` keeps a third-party hiccup from blocking the merge.
+  # Redirects are reported as warnings (lychee only fails on hard errors).
+  links:
+    name: External links (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        with:
+          args: --config lychee.toml --no-progress --root-dir "${{ github.workspace }}" "*.md" "bindings/*/README.md"
+          fail: true

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,28 @@
+name: Link check
+
+# External link rot is non-deterministic (third-party sites go down, rate-limit,
+# or move), so the authoritative check runs on a weekly schedule and on demand
+# rather than gating PRs or releases. ci.yml additionally runs a non-blocking
+# lychee job on PRs for an early heads-up (continue-on-error), and release.yml is
+# deliberately NOT gated on it — a transient external outage must never block an
+# irreversible publish.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    name: External links (lychee)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        with:
+          args: --config lychee.toml --no-progress --root-dir "${{ github.workspace }}" "*.md" "bindings/*/README.md"
+          fail: true

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -11,7 +11,7 @@ Most questions are answered in the documentation:
   data layer, and an FAQ.
 - **README:** <https://github.com/wickra-lib/wickra#readme> — installation and a
   quick overview.
-- **API docs (Rust):** <https://docs.rs/wickra>.
+- **API docs (Rust):** <https://docs.rs/wickra/latest/wickra/>.
 
 ## Questions and help
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,23 @@
+# lychee external-link checker config (see .github/workflows/links.yml).
+# Only http(s) URLs are checked; relative/internal links are skipped via the
+# scheme filter and --root-dir resolution. Loopback and private addresses are
+# skipped too.
+
+max_retries = 3
+retry_wait_time = 2
+timeout = 20
+
+# Treat these as success: OK, partial content, and rate-limited (transient).
+accept = [200, 206, 429]
+
+scheme = ["https", "http"]
+exclude_all_private = true
+
+# Known false positives (the URLs are valid; lychee just can't verify them as a
+# non-browser client):
+# - crates.io and npmjs.com return 403/404 to non-browser requests
+#   (anti-scraping); the package pages are live in a browser.
+exclude = [
+  'crates\.io/crates/',
+  'www\.npmjs\.com/package/',
+]


### PR DESCRIPTION
Adds external link-rot checking to the wickra repo, mirroring wickra-docs but in a **hybrid, non-blocking** shape so a flaky third-party site can never gate a PR or an irreversible release.

## What
- **`.github/workflows/links.yml`** — authoritative lychee run on a weekly schedule (Mondays) + `workflow_dispatch`. Off the PR/release path.
- **`ci.yml`** — a `links` job that runs on PRs as an early heads-up, `continue-on-error: true` so it never blocks the merge.
- **`release.yml`** — deliberately **not** touched: a transient external outage must never block publishing to crates.io/PyPI/npm/etc.
- **`lychee.toml`** — `accept = [200, 206, 429]`, excludes the known anti-bot registries (crates.io, npmjs) that 403/404 non-browser clients.
- **SUPPORT.md** — fixes the one redirecting link (`docs.rs/wickra` → `docs.rs/wickra/latest/wickra/`).

## Verification (lychee 0.23.0 run locally against the same args)
`315 total · 252 OK · 0 errors · 54 excluded · 9 redirects` → **exit 0 (green)**. The 9 redirects are all intentional/benign (Apache license-text constant, shields.io badge redirects, `releases/latest` always-latest link, auth-gated `security/advisories/new`, bestpractices.dev localization) and are reported as warnings only — lychee fails on hard errors, of which there are none.

Scope checked: `*.md` + `bindings/*/README.md`.