### PR TITLE
docs: link the live in-browser demo (live.wickra.org)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@
 [![Build provenance](https://raw.githubusercontent.com/wickra-lib/.github/main/profile/badges/provenance.svg)](https://github.com/wickra-lib/wickra/attestations)
 [![Docs](https://raw.githubusercontent.com/wickra-lib/.github/main/profile/badges/docs.svg)](https://docs.wickra.org)
 [![Verified across 10 languages](https://raw.githubusercontent.com/wickra-lib/.github/main/profile/badges/verified.svg)](https://docs.wickra.org/FAQ#do-all-the-language-bindings-compute-the-same-values)
+[![Live demo](https://img.shields.io/badge/live%20demo-live.wickra.org-3b82f6)](https://live.wickra.org)
 
 **Streaming-first technical indicators. Install with `pip install wickra` — no system dependencies, zero third-party packages.**
+
+> **▶ Live demo:** all 514 indicators over real Binance market data, computed live in your browser — **[live.wickra.org](https://live.wickra.org)** · zero backend, powered by `wickra-wasm`.
 
 Wickra is a multi-language technical-analysis library with a Rust core and
 native bindings for Python, Node.js and WASM, plus a C ABI that C, C++,

--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -5,6 +5,8 @@
 [![GitHub release](https://img.shields.io/github/v/release/wickra-lib/wickra?logo=github&color=green)](https://github.com/wickra-lib/wickra/releases/latest)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT_OR_Apache--2.0-blue)](https://github.com/wickra-lib/wickra#license)
 
+> **▶ Live demo:** all 514 indicators over real Binance market data, computed live in your browser — **[live.wickra.org](https://live.wickra.org)** · zero backend, powered by `wickra-wasm`.
+
 **Streaming-first technical indicators for C and C++. A prebuilt shared/static
 library plus a generated `wickra.h` — no system dependencies.**
 

--- a/bindings/csharp/README.md
+++ b/bindings/csharp/README.md
@@ -5,6 +5,8 @@
 [![NuGet](https://img.shields.io/nuget/v/Wickra.svg?logo=nuget&color=blue)](https://www.nuget.org/packages/Wickra)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT_OR_Apache--2.0-blue)](https://github.com/wickra-lib/wickra#license)
 
+> **▶ Live demo:** all 514 indicators over real Binance market data, computed live in your browser — **[live.wickra.org](https://live.wickra.org)** · zero backend, powered by `wickra-wasm`.
+
 **Streaming-first technical indicators for C#. `dotnet add package Wickra` —
 prebuilt native library, no system dependencies.**
 

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -5,6 +5,8 @@
 [![Go module](https://raw.githubusercontent.com/wickra-lib/.github/main/profile/badges/go.svg)](https://pkg.go.dev/github.com/wickra-lib/wickra/bindings/go)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT_OR_Apache--2.0-blue)](https://github.com/wickra-lib/wickra#license)
 
+> **▶ Live demo:** all 514 indicators over real Binance market data, computed live in your browser — **[live.wickra.org](https://live.wickra.org)** · zero backend, powered by `wickra-wasm`.
+
 **Streaming-first technical indicators for Go, over the Wickra C ABI hub via cgo.**
 
 Wickra is a multi-language technical-analysis library with a Rust core and

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -5,6 +5,8 @@
 [![Maven Central](https://img.shields.io/maven-central/v/org.wickra/wickra.svg?logo=apache-maven&color=blue)](https://central.sonatype.com/artifact/org.wickra/wickra)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT_OR_Apache--2.0-blue)](https://github.com/wickra-lib/wickra#license)
 
+> **▶ Live demo:** all 514 indicators over real Binance market data, computed live in your browser — **[live.wickra.org](https://live.wickra.org)** · zero backend, powered by `wickra-wasm`.
+
 **Streaming-first technical indicators for the JVM, on the Java Foreign Function
 & Memory API — prebuilt native library, no JNI, no system dependencies.**
 

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -5,6 +5,8 @@
 [![npm](https://img.shields.io/npm/v/wickra.svg?logo=npm&color=red)](https://www.npmjs.com/package/wickra)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT_OR_Apache--2.0-blue)](https://github.com/wickra-lib/wickra#license)
 
+> **▶ Live demo:** all 514 indicators over real Binance market data, computed live in your browser — **[live.wickra.org](https://live.wickra.org)** · zero backend, powered by `wickra-wasm`.
+
 **Streaming-first technical indicators for Node.js. `npm install wickra` —
 prebuilt native binary, no system dependencies.**
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -5,6 +5,8 @@
 [![PyPI](https://img.shields.io/pypi/v/wickra.svg?logo=pypi&color=blue)](https://pypi.org/project/wickra/)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT_OR_Apache--2.0-blue)](https://github.com/wickra-lib/wickra#license)
 
+> **▶ Live demo:** all 514 indicators over real Binance market data, computed live in your browser — **[live.wickra.org](https://live.wickra.org)** · zero backend, powered by `wickra-wasm`.
+
 **Streaming-first technical indicators for Python. `pip install wickra` — zero
 third-party dependencies (not even NumPy), no system dependencies, no C build tooling.**
 

--- a/bindings/r/README.md
+++ b/bindings/r/README.md
@@ -4,6 +4,8 @@
 [![codecov](https://codecov.io/gh/wickra-lib/wickra/branch/main/graph/badge.svg)](https://codecov.io/gh/wickra-lib/wickra)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT_OR_Apache--2.0-blue)](https://github.com/wickra-lib/wickra#license)
 
+> **▶ Live demo:** all 514 indicators over real Binance market data, computed live in your browser — **[live.wickra.org](https://live.wickra.org)** · zero backend, powered by `wickra-wasm`.
+
 **Streaming-first technical indicators for R, over the Wickra C ABI hub via `.Call`.**
 
 Wickra is a multi-language technical-analysis library with a Rust core and

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -5,6 +5,8 @@
 [![npm](https://img.shields.io/npm/v/wickra-wasm.svg?logo=npm&color=red)](https://www.npmjs.com/package/wickra-wasm)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT_OR_Apache--2.0-blue)](https://github.com/wickra-lib/wickra#license)
 
+> **▶ Live demo:** all 514 indicators over real Binance market data, computed live in your browser — **[live.wickra.org](https://live.wickra.org)** · zero backend, powered by `wickra-wasm`.
+
 **Streaming-first technical indicators in the browser. `npm install
 wickra-wasm` — pure WebAssembly, runs anywhere a modern JS engine does.**
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -17,7 +17,9 @@ exclude_all_private = true
 # non-browser client):
 # - crates.io and npmjs.com return 403/404 to non-browser requests
 #   (anti-scraping); the package pages are live in a browser.
+# TODO(deploy): drop the live.wickra.org exclude once the wickra-live site is up.
 exclude = [
   'crates\.io/crates/',
   'www\.npmjs\.com/package/',
+  'live\.wickra\.org',
 ]

--- a/lychee.toml
+++ b/lychee.toml
@@ -17,9 +17,7 @@ exclude_all_private = true
 # non-browser client):
 # - crates.io and npmjs.com return 403/404 to non-browser requests
 #   (anti-scraping); the package pages are live in a browser.
-# TODO(deploy): drop the live.wickra.org exclude once the wickra-live site is up.
 exclude = [
   'crates\.io/crates/',
   'www\.npmjs\.com/package/',
-  'live\.wickra\.org',
 ]


### PR DESCRIPTION
Prepared for the wickra-live launch (handoff-19, Phase 8). Adds a *Live demo* badge + callout to the main README and a one-line callout to all eight binding READMEs (C/C++, C#, Go, Java, Node.js, Python, R, WASM), pointing at the in-browser demo of all 514 indicators at live.wickra.org.

The link resolves once Cloudflare Pages + DNS for live.wickra.org are live; until then it is excluded from the lychee link check (a TODO marks the exclude for removal post-deploy), so all checks stay green.