### PR TITLE
release: bump 0.9.7 -> 0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.8] - 2026-06-28
+
+Maintenance release. The library API and every indicator are unchanged from
+`0.9.7`; this release migrates the Node.js binding's build to napi-rs 3 and
+carries routine dependency and CI tooling updates.
+
+### Changed
+- **Node binding built with napi-rs 3.** Migrate `napi` 2.16 → 3.9, `napi-derive`
+  2.16 → 3.5 (Rust) and `@napi-rs/cli` 2.18 → 3.7 (npm). The published API and
+  every computed value are unchanged — the generated TypeScript surface is
+  identical (626 symbols), only the code-generation format differs. napi 3's
+  derive macros emit `#[allow(unsafe_code)]`, so the Node crate's `unsafe_code`
+  lint is relaxed from the workspace `forbid` to `deny` for that crate only;
+  `forbid` stays in force for every other crate. The `engines.node` floor is
+  raised to `>= 22` (matching the CI test matrix). `ureq` is intentionally held
+  at 2.x — ureq 3 unconditionally pulls `webpki-root-certs` (CDLA-Permissive-2.0),
+  which the native-tls / OS-trust-store setup deliberately avoids.
+- **Dependency and CI housekeeping.** Bump the Maven
+  `central-publishing-maven-plugin` and the GitHub Actions used by CI
+  (`actions/checkout`, `taiki-e/install-action`, `actions/setup-java`,
+  `softprops/action-gh-release`). No runtime code changes.
+
 ## [0.9.7] - 2026-06-21
 
 Maintenance release. The library API and every indicator are unchanged from
@@ -1893,7 +1915,8 @@ public API changes.
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.7...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.8...HEAD
+[0.9.8]: https://github.com/wickra-lib/wickra/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/wickra-lib/wickra/compare/v0.9.6...v0.9.7
 [0.9.6]: https://github.com/wickra-lib/wickra/compare/v0.9.5...v0.9.6
 [0.9.5]: https://github.com/wickra-lib/wickra/compare/v0.9.4...v0.9.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "approx",
  "criterion",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-bench"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "criterion",
  "kand",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-c"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "tokio",
  "wickra-core",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "approx",
  "proptest",
@@ -1880,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "approx",
  "csv",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-examples"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "serde_json",
  "tokio",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "napi",
  "napi-build",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "bytemuck",
  "pyo3",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.7"
+version = "0.9.8"
 authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
@@ -26,8 +26,8 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.9.7" }
-wickra-data = { path = "crates/wickra-data", version = "0.9.7" }
+wickra-core = { path = "crates/wickra-core", version = "0.9.8" }
+wickra-data = { path = "crates/wickra-data", version = "0.9.8" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported versions
 
-Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.7`
+Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.8`
 version only; please upgrade to the newest release before reporting an issue.
 
 | Version | Supported |
 | --- | --- |
-| 0.9.7 (latest) | :white_check_mark: |
-| < 0.9.7 | :x: |
+| 0.9.8 (latest) | :white_check_mark: |
+| < 0.9.8 | :x: |
 
 ## Reporting a vulnerability
 

--- a/bindings/csharp/Wickra/Wickra.csproj
+++ b/bindings/csharp/Wickra/Wickra.csproj
@@ -11,7 +11,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>Wickra</PackageId>
-    <Version>0.9.7</Version>
+    <Version>0.9.8</Version>
     <Authors>kingchenc</Authors>
     <Description>High-performance streaming technical-analysis indicators (514 indicators) for .NET, backed by the native Rust core via the Wickra C ABI.</Description>
     <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -38,14 +38,14 @@ Maven:
 <dependency>
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.7</version>
+  <version>0.9.8</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.wickra:wickra:0.9.7")
+implementation("org.wickra:wickra:0.9.8")
 ```
 
 The native library ships prebuilt per platform (Linux, macOS, Windows — x64 and

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.7</version>
+  <version>0.9.8</version>
   <packaging>jar</packaging>
 
   <name>Wickra</name>

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wickra",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wickra",
-      "version": "0.9.7",
+      "version": "0.9.8",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.7.2"
@@ -15,12 +15,12 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.7",
-        "wickra-darwin-x64": "0.9.7",
-        "wickra-linux-arm64-gnu": "0.9.7",
-        "wickra-linux-x64-gnu": "0.9.7",
-        "wickra-win32-arm64-msvc": "0.9.7",
-        "wickra-win32-x64-msvc": "0.9.7"
+        "wickra-darwin-arm64": "0.9.8",
+        "wickra-darwin-x64": "0.9.8",
+        "wickra-linux-arm64-gnu": "0.9.8",
+        "wickra-linux-x64-gnu": "0.9.8",
+        "wickra-win32-arm64-msvc": "0.9.8",
+        "wickra-win32-x64-msvc": "0.9.8"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1846,8 +1846,8 @@
       "license": "ISC"
     },
     "node_modules/wickra-darwin-arm64": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.7.tgz",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.8.tgz",
       "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
       "cpu": [
         "arm64"
@@ -1862,8 +1862,8 @@
       }
     },
     "node_modules/wickra-darwin-x64": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.7.tgz",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.8.tgz",
       "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
       "cpu": [
         "x64"
@@ -1878,8 +1878,8 @@
       }
     },
     "node_modules/wickra-linux-arm64-gnu": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.7.tgz",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.8.tgz",
       "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
       "cpu": [
         "arm64"
@@ -1894,8 +1894,8 @@
       }
     },
     "node_modules/wickra-linux-x64-gnu": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.7.tgz",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.8.tgz",
       "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
       "cpu": [
         "x64"
@@ -1910,8 +1910,8 @@
       }
     },
     "node_modules/wickra-win32-arm64-msvc": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.7.tgz",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.8.tgz",
       "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
       "cpu": [
         "arm64"
@@ -1926,8 +1926,8 @@
       }
     },
     "node_modules/wickra-win32-x64-msvc": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.7.tgz",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.8.tgz",
       "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
       "cpu": [
         "x64"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
@@ -47,12 +47,12 @@
     "node": ">= 22"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.9.7",
-    "wickra-linux-arm64-gnu": "0.9.7",
-    "wickra-darwin-x64": "0.9.7",
-    "wickra-darwin-arm64": "0.9.7",
-    "wickra-win32-x64-msvc": "0.9.7",
-    "wickra-win32-arm64-msvc": "0.9.7"
+    "wickra-linux-x64-gnu": "0.9.8",
+    "wickra-linux-arm64-gnu": "0.9.8",
+    "wickra-darwin-x64": "0.9.8",
+    "wickra-darwin-arm64": "0.9.8",
+    "wickra-win32-x64-msvc": "0.9.8",
+    "wickra-win32-arm64-msvc": "0.9.8"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.9.7"
+version = "0.9.8"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: wickra
 Type: Package
 Title: Streaming-First Technical Indicators
-Version: 0.9.7
+Version: 0.9.8
 Authors@R: person("kingchenc", role = c("aut", "cre"), email = "support@wickra.org")
 Description: R bindings for the Wickra technical-analysis library over its C ABI
     hub. Exposes 514 indicators, each an O(1) streaming state machine shared with

--- a/crates/wickra-data/Cargo.toml
+++ b/crates/wickra-data/Cargo.toml
@@ -27,7 +27,7 @@ workspace = true
 # (rayon) feature on — the WASM binding needs a rayon-free build and the data
 # layer never uses the parallel batch path. Native bindings re-enable `parallel`
 # through their own wickra-core dependency (cargo unifies the features).
-wickra-core = { path = "../wickra-core", version = "0.9.2", default-features = false }
+wickra-core = { path = "../wickra-core", version = "0.9.8", default-features = false }
 thiserror = { workspace = true }
 csv = "1.3"
 serde = { version = "1", features = ["derive"] }

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra.examples</groupId>
   <artifactId>wickra-examples</artifactId>
-  <version>0.9.7</version>
+  <version>0.9.8</version>
   <packaging>jar</packaging>
 
   <name>Wickra Java examples</name>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.wickra</groupId>
       <artifactId>wickra</artifactId>
-      <version>0.9.7</version>
+      <version>0.9.8</version>
     </dependency>
   </dependencies>
 

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -14,7 +14,7 @@
     },
     "../../bindings/node": {
       "name": "wickra",
-      "version": "0.9.7",
+      "version": "0.9.8",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -23,12 +23,12 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.7",
-        "wickra-darwin-x64": "0.9.7",
-        "wickra-linux-arm64-gnu": "0.9.7",
-        "wickra-linux-x64-gnu": "0.9.7",
-        "wickra-win32-arm64-msvc": "0.9.7",
-        "wickra-win32-x64-msvc": "0.9.7"
+        "wickra-darwin-arm64": "0.9.8",
+        "wickra-darwin-x64": "0.9.8",
+        "wickra-linux-arm64-gnu": "0.9.8",
+        "wickra-linux-x64-gnu": "0.9.8",
+        "wickra-win32-arm64-msvc": "0.9.8",
+        "wickra-win32-x64-msvc": "0.9.8"
       }
     },
     "node_modules/wickra": {


### PR DESCRIPTION
Version bump **0.9.7 → 0.9.8** across the manual release touchpoints (workspace
`Cargo.toml` + lock, Python `pyproject.toml`, Node `package.json` + 6 platform
stubs + lockfiles, Java/examples `pom.xml` + README, C# `.csproj`, R
`DESCRIPTION`, `SECURITY.md`), generated by `bump_version.py`. The docs/webpage
version strings are left to `sync-about.yml` on the tag.

## What's in 0.9.8
Maintenance release; the library API and every indicator value are unchanged.

- **Node binding built with napi-rs 3** (`napi` 3.9 / `napi-derive` 3.5 /
  `@napi-rs/cli` 3.7). Identical published API (626-symbol TypeScript surface);
  the `unsafe_code` lint is scoped to `deny` for the Node crate only, `forbid`
  stays everywhere else. `engines.node` raised to `>= 22`. `ureq` held at 2.x
  (ureq 3 pulls webpki-root-certs / CDLA-Permissive-2.0).
- Dependency and CI housekeeping (Maven publishing plugin, GitHub Actions).

See [CHANGELOG.md](CHANGELOG.md) for the full entry. Tagging `v0.9.8` (the
irreversible publish to crates.io / PyPI / npm) is a separate step after merge.