### PR TITLE
release: bump 0.9.8 -> 0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.9] - 2026-06-28
+
+Maintenance release. No library or binding code changes from `0.9.8`; this
+re-release simply runs through the corrected release workflow (the `0.9.8` npm
+publish required a hotfix to the napi-rs 3 `napi artifacts` invocation, now in
+place), so the published `0.9.9` artifacts are byte-identical to `0.9.8`.
+
 ## [0.9.8] - 2026-06-28
 
 Maintenance release. The library API and every indicator are unchanged from
@@ -1915,7 +1922,8 @@ public API changes.
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.8...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.9...HEAD
+[0.9.9]: https://github.com/wickra-lib/wickra/compare/v0.9.8...v0.9.9
 [0.9.8]: https://github.com/wickra-lib/wickra/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/wickra-lib/wickra/compare/v0.9.6...v0.9.7
 [0.9.6]: https://github.com/wickra-lib/wickra/compare/v0.9.5...v0.9.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "approx",
  "criterion",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-bench"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "criterion",
  "kand",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-c"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "tokio",
  "wickra-core",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "approx",
  "proptest",
@@ -1880,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "approx",
  "csv",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-examples"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "serde_json",
  "tokio",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "napi",
  "napi-build",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "bytemuck",
  "pyo3",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.8"
+version = "0.9.9"
 authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
@@ -26,8 +26,8 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.9.8" }
-wickra-data = { path = "crates/wickra-data", version = "0.9.8" }
+wickra-core = { path = "crates/wickra-core", version = "0.9.9" }
+wickra-data = { path = "crates/wickra-data", version = "0.9.9" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported versions
 
-Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.8`
+Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.9`
 version only; please upgrade to the newest release before reporting an issue.
 
 | Version | Supported |
 | --- | --- |
-| 0.9.8 (latest) | :white_check_mark: |
-| < 0.9.8 | :x: |
+| 0.9.9 (latest) | :white_check_mark: |
+| < 0.9.9 | :x: |
 
 ## Reporting a vulnerability
 

--- a/bindings/csharp/Wickra/Wickra.csproj
+++ b/bindings/csharp/Wickra/Wickra.csproj
@@ -11,7 +11,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>Wickra</PackageId>
-    <Version>0.9.8</Version>
+    <Version>0.9.9</Version>
     <Authors>kingchenc</Authors>
     <Description>High-performance streaming technical-analysis indicators (514 indicators) for .NET, backed by the native Rust core via the Wickra C ABI.</Description>
     <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -38,14 +38,14 @@ Maven:
 <dependency>
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.8</version>
+  <version>0.9.9</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.wickra:wickra:0.9.8")
+implementation("org.wickra:wickra:0.9.9")
 ```
 
 The native library ships prebuilt per platform (Linux, macOS, Windows — x64 and

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.8</version>
+  <version>0.9.9</version>
   <packaging>jar</packaging>
 
   <name>Wickra</name>

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wickra",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wickra",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.7.2"
@@ -15,12 +15,12 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.8",
-        "wickra-darwin-x64": "0.9.8",
-        "wickra-linux-arm64-gnu": "0.9.8",
-        "wickra-linux-x64-gnu": "0.9.8",
-        "wickra-win32-arm64-msvc": "0.9.8",
-        "wickra-win32-x64-msvc": "0.9.8"
+        "wickra-darwin-arm64": "0.9.9",
+        "wickra-darwin-x64": "0.9.9",
+        "wickra-linux-arm64-gnu": "0.9.9",
+        "wickra-linux-x64-gnu": "0.9.9",
+        "wickra-win32-arm64-msvc": "0.9.9",
+        "wickra-win32-x64-msvc": "0.9.9"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1846,8 +1846,8 @@
       "license": "ISC"
     },
     "node_modules/wickra-darwin-arm64": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.8.tgz",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.9.tgz",
       "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
       "cpu": [
         "arm64"
@@ -1862,8 +1862,8 @@
       }
     },
     "node_modules/wickra-darwin-x64": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.8.tgz",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.9.tgz",
       "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
       "cpu": [
         "x64"
@@ -1878,8 +1878,8 @@
       }
     },
     "node_modules/wickra-linux-arm64-gnu": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.8.tgz",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.9.tgz",
       "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
       "cpu": [
         "arm64"
@@ -1894,8 +1894,8 @@
       }
     },
     "node_modules/wickra-linux-x64-gnu": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.8.tgz",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.9.tgz",
       "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
       "cpu": [
         "x64"
@@ -1910,8 +1910,8 @@
       }
     },
     "node_modules/wickra-win32-arm64-msvc": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.8.tgz",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.9.tgz",
       "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
       "cpu": [
         "arm64"
@@ -1926,8 +1926,8 @@
       }
     },
     "node_modules/wickra-win32-x64-msvc": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.8.tgz",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.9.tgz",
       "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
       "cpu": [
         "x64"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
@@ -47,12 +47,12 @@
     "node": ">= 22"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.9.8",
-    "wickra-linux-arm64-gnu": "0.9.8",
-    "wickra-darwin-x64": "0.9.8",
-    "wickra-darwin-arm64": "0.9.8",
-    "wickra-win32-x64-msvc": "0.9.8",
-    "wickra-win32-arm64-msvc": "0.9.8"
+    "wickra-linux-x64-gnu": "0.9.9",
+    "wickra-linux-arm64-gnu": "0.9.9",
+    "wickra-darwin-x64": "0.9.9",
+    "wickra-darwin-arm64": "0.9.9",
+    "wickra-win32-x64-msvc": "0.9.9",
+    "wickra-win32-arm64-msvc": "0.9.9"
   },
   "scripts": {
     "build": "napi build --platform --release",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.9.8"
+version = "0.9.9"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: wickra
 Type: Package
 Title: Streaming-First Technical Indicators
-Version: 0.9.8
+Version: 0.9.9
 Authors@R: person("kingchenc", role = c("aut", "cre"), email = "support@wickra.org")
 Description: R bindings for the Wickra technical-analysis library over its C ABI
     hub. Exposes 514 indicators, each an O(1) streaming state machine shared with

--- a/crates/wickra-data/Cargo.toml
+++ b/crates/wickra-data/Cargo.toml
@@ -27,7 +27,7 @@ workspace = true
 # (rayon) feature on — the WASM binding needs a rayon-free build and the data
 # layer never uses the parallel batch path. Native bindings re-enable `parallel`
 # through their own wickra-core dependency (cargo unifies the features).
-wickra-core = { path = "../wickra-core", version = "0.9.8", default-features = false }
+wickra-core = { path = "../wickra-core", version = "0.9.9", default-features = false }
 thiserror = { workspace = true }
 csv = "1.3"
 serde = { version = "1", features = ["derive"] }

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra.examples</groupId>
   <artifactId>wickra-examples</artifactId>
-  <version>0.9.8</version>
+  <version>0.9.9</version>
   <packaging>jar</packaging>
 
   <name>Wickra Java examples</name>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.wickra</groupId>
       <artifactId>wickra</artifactId>
-      <version>0.9.8</version>
+      <version>0.9.9</version>
     </dependency>
   </dependencies>
 

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -14,7 +14,7 @@
     },
     "../../bindings/node": {
       "name": "wickra",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -23,12 +23,12 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.8",
-        "wickra-darwin-x64": "0.9.8",
-        "wickra-linux-arm64-gnu": "0.9.8",
-        "wickra-linux-x64-gnu": "0.9.8",
-        "wickra-win32-arm64-msvc": "0.9.8",
-        "wickra-win32-x64-msvc": "0.9.8"
+        "wickra-darwin-arm64": "0.9.9",
+        "wickra-darwin-x64": "0.9.9",
+        "wickra-linux-arm64-gnu": "0.9.9",
+        "wickra-linux-x64-gnu": "0.9.9",
+        "wickra-win32-arm64-msvc": "0.9.9",
+        "wickra-win32-x64-msvc": "0.9.9"
       }
     },
     "node_modules/wickra": {

--- a/lychee.toml
+++ b/lychee.toml
@@ -13,11 +13,16 @@ accept = [200, 206, 429]
 scheme = ["https", "http"]
 exclude_all_private = true
 
-# Known false positives (the URLs are valid; lychee just can't verify them as a
-# non-browser client):
+# Known false positives (the URLs are valid; lychee just can't verify them at
+# check time):
 # - crates.io and npmjs.com return 403/404 to non-browser requests
 #   (anti-scraping); the package pages are live in a browser.
+# - the CHANGELOG version-compare links point at the release tag that is created
+#   *after* the bump is merged. ci.yml runs on push/PR (never on the tag), so the
+#   tag never exists when lychee runs and the compare URL 404s. One pattern
+#   covers every future version — no per-release exclude needed.
 exclude = [
   'crates\.io/crates/',
   'www\.npmjs\.com/package/',
+  'github\.com/wickra-lib/wickra/compare/',
 ]


### PR DESCRIPTION
Version bump **0.9.8 → 0.9.9** across the manual release touchpoints (generated
by `bump_version.py`). docs/webpage strings are left to `sync-about.yml` on the
tag.

## What's in 0.9.9
Maintenance release — **no library or binding code changes from 0.9.8**. This is
a clean re-release through the **corrected release workflow**: the 0.9.8 npm
publish needed a hotfix (napi-rs 3 renamed `napi artifacts --dir` → `--output-dir`),
which is now in place, so 0.9.9 publishes cleanly through the whole pipeline. The
published 0.9.9 artifacts are byte-identical to 0.9.8.

See [CHANGELOG.md](CHANGELOG.md) for the entry. Merging this PR and pushing the
`v0.9.9` tag (the irreversible publish) is left to you — not auto-merged.