### PR TITLE
docs(readme): bust Camo cache on the star-history image

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,6 @@ The library is provided **as is**, without warranty of any kind; see
 <p align="center">
   <a href="https://star-history.com/#wickra-lib/wickra&Date">
     <img alt="Wickra star history" width="640"
-         src="https://raw.githubusercontent.com/wickra-lib/.github/main/profile/badges/star-history.svg">
+         src="https://raw.githubusercontent.com/wickra-lib/.github/main/profile/badges/star-history.svg?v=2">
   </a>
 </p>


### PR DESCRIPTION
The star-history snapshot in the `.github` repo was briefly overwritten with a data-less chart (upstream token pool exhausted; fixed in wickra-lib/.github#53). GitHub's Camo image proxy then cached that blank SVG, so the README's star graph shows no line.

Appending a `?v` cache-buster to the `<img>` URL forces Camo to refetch the now-restored snapshot — the same technique the self-updating banner already uses. No content change beyond the one URL.