### PR TITLE
ci(links): exclude GitHub stargazers/network-members from link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -17,6 +17,9 @@ exclude_all_private = true
 # check time):
 # - crates.io and npmjs.com return 403/404 to non-browser requests
 #   (anti-scraping); the package pages are live in a browser.
+# - GitHub serves 404 for /stargazers and /network/members to anonymous clients
+#   (anti-scraping). The README social-footer badges link there; the pages are
+#   live in a browser.
 # - the CHANGELOG version-compare links point at the release tag that is created
 #   *after* the bump is merged. ci.yml runs on push/PR (never on the tag), so the
 #   tag never exists when lychee runs and the compare URL 404s. One pattern
@@ -25,4 +28,6 @@ exclude = [
   'crates\.io/crates/',
   'www\.npmjs\.com/package/',
   'github\.com/wickra-lib/wickra/compare/',
+  'github\.com/wickra-lib/wickra/stargazers',
+  'github\.com/wickra-lib/wickra/network/members',
 ]


### PR DESCRIPTION
The `External links (non-blocking)` job (and the standalone `links.yml`) flagged `https://github.com/wickra-lib/wickra/stargazers` as `[404]`. GitHub serves a 404 for `/stargazers` and `/network/members` to anonymous clients (anti-scraping) — the README social-footer badges link there, and the pages are live in a browser. Excluded both in `lychee.toml` (same rationale as the existing crates.io / npm anti-scraping excludes). Keeps the social footer.