### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
`cargo-deny` started failing on `RUSTSEC-2026-0204` — an invalid pointer dereference in crossbeam-epoch's `fmt::Pointer` impl for `Atomic`/`Shared`, reaching us transitively through `crossbeam-deque`. The advisory was published after the last green run, so it reddens the supply-chain check on every PR (and the next main push) org-wide, not just here.

Official fix: upgrade to `>=0.9.20`. This is a **lock-only** patch bump (`cargo update -p crossbeam-epoch`, `0.9.18 -> 0.9.20`) — no `Cargo.toml` or code change. Restores `cargo-deny` (advisories) to green.