### PR TITLE
chore(release): use shared org secret GO_MIRROR_TOKEN for the Go mirror

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -827,7 +827,7 @@ jobs:
   # mirror commits them per platform under lib/<goos>_<goarch>/ alongside the
   # vendored header. Independent of the GitHub-release job so a Go hiccup never
   # blocks the C/C++ asset release. The push uses a fine-grained PAT
-  # (WICKRA_GO_MIRROR_TOKEN, contents:write on wickra-go); the mirror is a
+  # (GO_MIRROR_TOKEN, contents:write on wickra-go); the mirror is a
   # derived artifact, so its bot commit is intentionally unsigned.
   go-mirror:
     name: Mirror the Go module to wickra-go
@@ -890,7 +890,7 @@ jobs:
       - name: Push to wickra-go and tag the release
         shell: bash
         env:
-          MIRROR_TOKEN: ${{ secrets.WICKRA_GO_MIRROR_TOKEN }}
+          MIRROR_TOKEN: ${{ secrets.GO_MIRROR_TOKEN }}
         run: |
           set -e
           version="${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
Unifies the Go mirror push token onto a single organization secret `GO_MIRROR_TOKEN` in place of the per-repo `WICKRA_<PRODUCT>_GO_MIRROR_TOKEN`.

## Why
Every wickra-lib product repo currently references its own `WICKRA_<PRODUCT>_GO_MIRROR_TOKEN`. Consolidating onto one org-level secret means a single fine-grained PAT (contents:write on all `wickra-*-go` mirror repos) backs every release, and a new product repo needs no per-repo publishing token.

## Change
- `.github/workflows/release.yml`: `secrets.WICKRA_<PRODUCT>_GO_MIRROR_TOKEN` -> `secrets.GO_MIRROR_TOKEN` (job env + comment).

No behavioural change beyond the secret name; the mirror still pushes to the same `wickra-<product>-go` repository. Requires the org secret `GO_MIRROR_TOKEN` to be set before the next release (release is USER-GO gated).