### PR TITLE
chore(dependabot): move update schedule from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
@@ -31,7 +33,9 @@ updates:
   - package-ecosystem: npm
     directory: "/bindings/node"
     schedule:
-      interval: weekly
+      interval: monthly
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
@@ -45,7 +49,9 @@ updates:
   - package-ecosystem: pip
     directory: "/bindings/python"
     schedule:
-      interval: weekly
+      interval: monthly
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
@@ -63,7 +69,9 @@ updates:
   - package-ecosystem: pip
     directory: "/.github/requirements"
     schedule:
-      interval: weekly
+      interval: monthly
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
@@ -78,7 +86,9 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
@@ -98,7 +108,9 @@ updates:
       - "/bindings/java/benchmarks"
       - "/examples/java"
     schedule:
-      interval: weekly
+      interval: monthly
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
@@ -116,7 +128,9 @@ updates:
       - "/bindings/csharp/Wickra.Tests"
       - "/bindings/csharp/benchmarks"
     schedule:
-      interval: weekly
+      interval: monthly
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
@@ -130,7 +144,9 @@ updates:
   - package-ecosystem: npm
     directory: "/examples/node"
     schedule:
-      interval: weekly
+      interval: monthly
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
@@ -145,7 +161,9 @@ updates:
   - package-ecosystem: gomod
     directory: "/examples/go"
     schedule:
-      interval: weekly
+      interval: monthly
+      time: "06:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7


### PR DESCRIPTION
Reduces Dependabot PR noise across the wickra-lib org: every ecosystem in `.github/dependabot.yml` switches `weekly` → `monthly` with a pinned `time: "06:00"` / `timezone: "Etc/UTC"`. Version-update PRs now arrive as one predictable monthly batch instead of a near-daily trickle spread across the week (no `schedule.day` was pinned, so GitHub had scattered each repo's weekly run across different weekdays). Security updates are unaffected.