### PR TITLE
ci(fuzz): pin the fuzz-smoke nightly toolchain (ICE workaround)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,10 @@ jobs:
       - name: Install nightly Rust
         uses: ./.github/actions/setup-rust
         with:
-          toolchain: nightly
+          # Pinned to a fixed nightly: a rolling `nightly` regressed with a
+          # codegen ICE (rustc_codegen_ssa operand.rs) building tokio, which is
+          # unrelated to our code. Bump this date deliberately when needed.
+          toolchain: nightly-2026-07-01
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2


### PR DESCRIPTION
The `Fuzz (smoke)` job started failing with a rustc **codegen ICE** (`rustc_codegen_ssa/src/mir/operand.rs`) while building tokio on the rolling `nightly` — an upstream compiler bug, not our code. Pin the fuzz toolchain to a fixed nightly (`nightly-2026-07-01`, pre-ICE and compatible with the pinned cargo-fuzz) so CI is deterministic. Bump the date deliberately when a newer nightly is needed. Config-only; no code change.