### PR TITLE
ci(dependabot): freeze hypothesis to keep the Python 3.9 dev lockfile installable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,6 +87,12 @@ updates:
       # CI tooling only needs a working numpy, not the newest.
       - dependency-name: "numpy"
         update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      # hypothesis >=6.142 requires Python >=3.10, but ci-dev-py39.txt targets
+      # 3.9. A bump to 6.157 broke every 3.9 matrix row (pip "Ignored the
+      # following versions that require a different python version"). Freeze
+      # hypothesis so the 3.9 dev-tooling lockfile stays installable.
+      - dependency-name: "hypothesis"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
 
   # GitHub Actions — keeps the SHA-pinned actions current (Dependabot reads
   # the version comment after each pinned SHA and bumps both together).


### PR DESCRIPTION
hypothesis `>=6.142` requires Python `>=3.10`, but `.github/requirements/ci-dev-py39.txt` targets the 3.9 matrix rows. The ci-pip group bump (#377) pushed hypothesis to 6.157.0, which pip refused to install on every Python 3.9 job. Freeze hypothesis minor/major in the CI requirements ecosystem, mirroring the existing numpy pin. (#377 also dropped the Windows-conditional `colorama` from the hash lockfile, breaking `--require-hashes` on Windows — a separate dependabot lockfile-gen quirk; #377 is being closed as a broken bump and will re-propose cleanly next cycle.)