### PR TITLE
ci(fuzz): run cargo-fuzz with the pinned nightly, not the rolling one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,23 +424,23 @@ jobs:
           tool: cargo-fuzz
 
       - name: Fuzz csv_reader (30 s)
-        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu csv_reader -- -max_total_time=30
+        run: cargo +nightly-2026-07-01 fuzz run --target x86_64-unknown-linux-gnu csv_reader -- -max_total_time=30
         working-directory: fuzz
 
       - name: Fuzz binance_envelope (30 s)
-        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu binance_envelope -- -max_total_time=30
+        run: cargo +nightly-2026-07-01 fuzz run --target x86_64-unknown-linux-gnu binance_envelope -- -max_total_time=30
         working-directory: fuzz
 
       - name: Fuzz indicator_update (30 s)
-        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu indicator_update -- -max_total_time=30
+        run: cargo +nightly-2026-07-01 fuzz run --target x86_64-unknown-linux-gnu indicator_update -- -max_total_time=30
         working-directory: fuzz
 
       - name: Fuzz indicator_update_candle (30 s)
-        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu indicator_update_candle -- -max_total_time=30
+        run: cargo +nightly-2026-07-01 fuzz run --target x86_64-unknown-linux-gnu indicator_update_candle -- -max_total_time=30
         working-directory: fuzz
 
       - name: Fuzz tick_aggregator (30 s)
-        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu tick_aggregator -- -max_total_time=30
+        run: cargo +nightly-2026-07-01 fuzz run --target x86_64-unknown-linux-gnu tick_aggregator -- -max_total_time=30
         working-directory: fuzz
 
   python:


### PR DESCRIPTION
#378 pinned the fuzz-smoke toolchain **install** to `nightly-2026-07-01`, but the five `cargo fuzz run` commands still called `cargo +nightly` — which resolves to the **rolling** nightly and ignores the pin. The rolling nightly carries the `rustc_codegen_ssa/operand.rs` ICE building tokio, so `Fuzz (smoke)` stayed red on main. Change each command to `cargo +nightly-2026-07-01 fuzz …` so it uses the pinned, ICE-free toolchain the install step provides. (Verified in the failing log: the crashing rustc was `toolchains/nightly-…`, not `nightly-2026-07-01-…`.)