### PR TITLE
fix(r): build the Windows import library without objdump

### DIFF
--- a/bindings/r/configure.win
+++ b/bindings/r/configure.win
@@ -1,9 +1,8 @@
 #!/bin/sh
 # Windows build: the package compiles to wickra.dll, which would collide with the
 # C ABI's own wickra.dll (the loader would resolve the import to the package
-# itself). Stage a renamed copy, wickra_abi.dll, into src/ and build a mingw
-# import library that references it by that name (objdump + dlltool, both shipped
-# with Rtools — no gendef/pexports needed). install.libs.R then bundles the DLL.
+# itself). Stage a renamed copy, wickra_abi.dll, into src/ and build an import
+# library that references it by that name. install.libs.R then bundles the DLL.
 #
 # Self-contained by default: download the prebuilt wickra-c-<triple>.tar.gz
 # release asset matching this package's version. Set WICKRA_INCLUDE_DIR +
@@ -30,22 +29,33 @@ wickra_download() {
   return 1
 }
 
+# Detect the R architecture, not the shell's. On the Windows/arm64 runner
+# `uname -m` reports x86_64 (the shell runs under emulation), so the x64 C ABI
+# would be pulled into an arm64 R and fail to load ("%1 is not a valid Win32
+# application"). R.version$arch reflects the R build that loads the DLL, and it
+# also selects the import library's target machine below.
+arch=$("${R_HOME}/bin/Rscript" -e 'cat(R.version$arch)')
+case "${arch}" in
+  x86_64)
+    triple="x86_64-pc-windows-msvc"
+    dll_machine="i386:x86-64"
+    ;;
+  aarch64 | arm64)
+    triple="aarch64-pc-windows-msvc"
+    dll_machine="arm64"
+    ;;
+  *)
+    echo "wickra: unsupported Windows arch '${arch}' — set WICKRA_INCLUDE_DIR/WICKRA_LIB_DIR"
+    exit 1
+    ;;
+esac
+
 if [ -n "${WICKRA_INCLUDE_DIR}" ] && [ -n "${WICKRA_LIB_DIR}" ]; then
   echo "wickra: using C ABI from WICKRA_INCLUDE_DIR / WICKRA_LIB_DIR (dev override)"
   inc="${WICKRA_INCLUDE_DIR}"
   lib="${WICKRA_LIB_DIR}"
 else
   version=$(sed -n 's/^Version:[[:space:]]*//p' DESCRIPTION)
-  # Detect the R architecture, not the shell's. On the Windows/arm64 runner
-  # `uname -m` reports x86_64 (the shell runs under emulation), so the x64 C
-  # ABI would be pulled into an arm64 R and fail to load ("%1 is not a valid
-  # Win32 application"). R.version$arch reflects the R build that loads the DLL.
-  arch=$("${R_HOME}/bin/Rscript" -e 'cat(R.version$arch)')
-  case "${arch}" in
-    x86_64) triple="x86_64-pc-windows-msvc" ;;
-    aarch64 | arm64) triple="aarch64-pc-windows-msvc" ;;
-    *) echo "wickra: unsupported Windows arch '${arch}' — set WICKRA_INCLUDE_DIR/WICKRA_LIB_DIR"; exit 1 ;;
-  esac
   url="https://github.com/wickra-lib/wickra/releases/download/v${version}/wickra-c-${triple}.tar.gz"
   echo "wickra: downloading C ABI ${triple} for v${version}"
   wickra_download "${url}" "src/wickra-c.tar.gz" || exit 1
@@ -56,20 +66,72 @@ fi
 
 cp "${inc}/wickra.h" src/wickra.h
 cp "${lib}/wickra.dll" src/wickra_abi.dll
-# Use the binutils that match R's compiler (and thus the target arch). Bare
-# `objdump`/`dlltool` resolve via PATH to the x64 mingw copies, which cannot read
-# an arm64 wickra_abi.dll ("file format not recognized"). -print-prog-name asks
-# the compiler for the matching GNU tool; fall back to the bare name otherwise.
-CC=$("${R_HOME}/bin/R" CMD config CC | awk '{print $1}')
-OBJDUMP=$("${CC}" -print-prog-name=objdump 2>/dev/null)
-DLLTOOL=$("${CC}" -print-prog-name=dlltool 2>/dev/null)
-case "${OBJDUMP}" in ""|objdump) OBJDUMP=objdump ;; esac
-case "${DLLTOOL}" in ""|dlltool) DLLTOOL=dlltool ;; esac
+
+# Take the export list from the staged header rather than by dumping the DLL.
+# cbindgen declares exactly the exported symbols, so header and PE export table
+# agree entry for entry, and reading the header needs no binutils at all: the
+# objdump that resolves on Windows/arm64 is the runner image's x86_64 mingw copy,
+# which carries no aarch64 PE backend and rejects an arm64 wickra_abi.dll with
+# "file format not recognized".
 {
   echo 'LIBRARY wickra_abi.dll'
   echo 'EXPORTS'
-  "${OBJDUMP}" -p src/wickra_abi.dll | awk '/\[ *[0-9]+\]/ {print $NF}' | grep '^wickra_'
+  awk '
+    # Strip block and line comments first so a symbol mentioned in the generated
+    # documentation is never mistaken for a declaration.
+    BEGIN { inblock = 0 }
+    {
+      out = ""
+      i = 1
+      n = length($0)
+      while (i <= n) {
+        two = substr($0, i, 2)
+        if (inblock) {
+          if (two == "*/") { inblock = 0; i += 2 } else { i++ }
+        } else if (two == "/*") {
+          inblock = 1
+          i += 2
+        } else if (two == "//") {
+          break
+        } else {
+          out = out substr($0, i, 1)
+          i++
+        }
+      }
+      print out
+    }
+  ' src/wickra.h \
+    | grep -oE '\bwickra_[A-Za-z0-9_]*[[:space:]]*\(' \
+    | sed 's/[[:space:]]*($//' \
+    | LC_ALL=C sort -u
 } > src/wickra_abi.def
-"${DLLTOOL}" --input-def src/wickra_abi.def --dllname wickra_abi.dll \
-  --output-lib src/libwickra_abi.dll.a
+
+# The import library has to target R's architecture. A binutils build only
+# carries the PE backends it was configured with, so the x86_64 mingw dlltool
+# that resolves on PATH cannot emit an arm64 library — asked for one via -m it
+# fails outright ("invalid bfd target") instead of quietly producing the wrong
+# thing. That loud failure is what makes trying candidates in order safe: the
+# first that succeeds is by construction one that can target this architecture.
+# BINPREF is R's own pointer at the matching Rtools toolchain, and llvm-dlltool
+# (shipped with the clang-based aarch64 Rtools) carries every backend.
+BINPREF=$("${R_HOME}/bin/R" CMD config BINPREF 2>/dev/null | tr -d '\r') || BINPREF=""
+dlltool_log="src/dlltool.log"
+: > "${dlltool_log}"
+DLLTOOL=""
+for cand in "${WICKRA_DLLTOOL}" "${BINPREF}llvm-dlltool" "${BINPREF}dlltool" llvm-dlltool dlltool; do
+  [ -n "${cand}" ] || continue
+  echo "wickra: trying ${cand} -m ${dll_machine}" >> "${dlltool_log}"
+  if "${cand}" -m "${dll_machine}" --input-def src/wickra_abi.def \
+      --dllname wickra_abi.dll --output-lib src/libwickra_abi.dll.a >> "${dlltool_log}" 2>&1; then
+    DLLTOOL="${cand}"
+    break
+  fi
+done
+if [ -z "${DLLTOOL}" ]; then
+  echo "wickra: no dlltool could build a ${dll_machine} import library; attempts:"
+  cat "${dlltool_log}"
+  exit 1
+fi
+rm -f "${dlltool_log}"
+echo "wickra: import library built by ${DLLTOOL} (-m ${dll_machine})"
 exit 0

--- a/bindings/r/src/.gitignore
+++ b/bindings/r/src/.gitignore
@@ -6,6 +6,7 @@
 *.dylib
 wickra.h
 wickra_abi.def
+dlltool.log
 symbols.rds
 wickra-c.tar.gz
 wickra-c/


### PR DESCRIPTION
## Problem

`r-universe/wickra-lib/wickra/deploy` has been failing on `main` since 2026-08-01. The R-devel and R-release jobs **for Windows arm64** fail in `configure.win`; every other platform (Linux x86_64/arm64, macOS x86_64/arm64, Windows x86_64, Wasm) passes.

```
wickra: downloading C ABI aarch64-pc-windows-msvc for v0.9.9
C:\mingw64\bin\objdump.exe: src/wickra_abi.dll: file format not recognized
ERROR: configuration failed for package 'wickra'
```

`configure.win` dumped the export list out of the staged `wickra_abi.dll` with `objdump`. The `objdump` that resolves on that runner is the image's x86_64 mingw copy at `C:\mingw64` — not Rtools45-aarch64 — and it carries no aarch64 PE backend, so it cannot read an arm64 DLL. Resolving the tool through `${CC} -print-prog-name=objdump` returned the same x64 copy, which is why the previous attempt did not fix it.

## Change

**Derive the `.def` from the staged header instead of dumping the DLL.** The cbindgen header declares exactly the exported symbols, so no binutils is involved in building the export list at all. Verified against the v0.9.9 release artifacts by parsing the PE export tables directly:

| source | symbols |
|---|---|
| `wickra.h` (header-derived) | 3951 |
| `wickra-c-x86_64-pc-windows-msvc/lib/wickra.dll` export table | 3951 |
| `wickra-c-aarch64-pc-windows-msvc/lib/wickra.dll` export table | 3951 |
| previous `objdump`-generated `.def` | 3951 |

All four sets are identical — no symbol in one and not the others, in either direction.

**Pass the target machine to `dlltool` explicitly and try the tools R can point at first.** `dlltool` is still needed for the import library and has the same blind spot. A binutils build without the requested PE backend fails outright rather than silently emitting a wrong-architecture archive:

```
$ dlltool -m arm64 --input-def wickra_abi.def ...
dlltool.exe: Can't create .lib file: invalid bfd target
```

That loud failure is what makes an ordered candidate list safe: the first candidate that succeeds is by construction one that can target this architecture. The list is `$WICKRA_DLLTOOL`, `${BINPREF}llvm-dlltool`, `${BINPREF}dlltool`, `llvm-dlltool`, `dlltool` — `BINPREF` is R's own pointer at the matching Rtools toolchain, and the clang-based aarch64 Rtools ships `llvm-dlltool`, which carries every backend. If no candidate works the build stops and prints every attempt with its error, instead of failing later at link time.

Architecture detection moved above the dev-override branch, since the target machine is now needed on both paths.

## Verification

Exercised locally on x86_64 against the real header and the released DLLs:

- Header-derived export list == PE export table == previous `objdump` output (3951/3951, both directions).
- New pipeline → `dlltool` → import library: same size, same 3951 symbols, same referenced DLL (`wickra_abi.dll`) as the one the old script produced. Only the archive member timestamps differ.
- arm64 path on a host without an arm64-capable `dlltool`: every candidate fails, the diagnostic lists all attempts, `configure.win` exits 1.
- `sh -n` / `bash -n` clean; no bashisms.

The repo's own CI cannot cover this — it has no Windows arm64 R job, which is why `1444a379` went green on all 98 checks while r-universe stayed red. The r-universe rebuild triggered by merging this is the real check.