### PR TITLE
ci: pin rust-cache to the commit its version comment names

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -128,7 +128,7 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -263,7 +263,7 @@ jobs:
           node-version: "22"
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -317,7 +317,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -356,7 +356,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -420,7 +420,7 @@ jobs:
           toolchain: nightly-2026-07-01
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
         with:
@@ -488,7 +488,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -583,7 +583,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -642,7 +642,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -756,7 +756,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -812,7 +812,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -910,7 +910,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -1011,7 +1011,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true
         timeout-minutes: 6
 
@@ -1122,7 +1122,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-rust
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -296,7 +296,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -541,7 +541,7 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 
@@ -633,7 +633,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true # cache is an optimisation; never block on a stuck/slow restore
         timeout-minutes: 6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **The `rust-cache` action pin claimed a version it no longer points at.** All
+  19 uses across `ci.yml`, `release.yml` and `bench.yml` pinned commit
+  `e18b497` with the comment `# v2`, but `v2` has since moved to `6323deb`
+  and no tag points at the pinned commit any more. A stale comment is worse
+  than none: it invites a reviewer to trust a version claim that no longer
+  holds. The pin is now `6323deb` with the exact release it corresponds to,
+  `# v2.9.2`. Every other pinned action was checked the same way — all 25
+  resolve to the commit their comment names.
+
 ### Changed
 - **Eight hand-written midpoints now call `f64::midpoint`.** Averaging two
   values as `0.5 * (a + b)` is the same arithmetic for any pair under


### PR DESCRIPTION
Closes the 19 open `zizmor/ref-version-mismatch` code-scanning alerts.

All 19 uses of `Swatinem/rust-cache` across `ci.yml`, `release.yml` and
`bench.yml` pinned commit `e18b497` with the comment `# v2`. The tag has since
moved to `6323deb`, and no tag points at `e18b497` any more — so the comment
asserted a version the pin does not have. That is what zizmor reports, once per
use.

A stale version comment is worse than no comment: it invites a reviewer to trust
a claim that no longer holds, while the code actually running is an unlabelled
commit. The pin now names the release it really is, `v2.9.2` — verified by
resolving the tag to `6323deb102c322ba6fcbdcafc7e3dddab59af2b6`.

Every other pinned action was checked the same way, by resolving each comment's
tag against its pinned SHA. All 25 agree, so this was the only one adrift.

## The three remaining alerts are not fixable in code

**Two Dependabot alerts, `pytest < 9.0.3` (GHSA-6w46-j5rx-g56g).** The patched
release requires Python >= 3.10, and the file it is reported against —
`.github/requirements/ci-dev-py39.txt` — exists precisely to serve the 3.9
matrix rows. #383 already froze pytest there for this reason. The 3.10+ rows use
`ci-dev-py3.txt`, which is on 9.0.3 and unaffected.

The advisory concerns pytest's handling of `/tmp/pytest-of-{user}`. This suite
never creates that directory: it uses no `tmp_path`, `tmpdir` or
`tmp_path_factory` fixture anywhere, which I confirmed by running it and
comparing the directory before and after — unchanged. The vulnerable path is
never taken, so adding a `--basetemp` guard would be a flag protecting a code
path that is not exercised.

**One Scorecard alert, `pipCommand not pinned by hash` at `ci.yml:550`.** That
line is `pip install --no-index --find-links dist … wickra`, which installs the
wheel built two steps earlier. `--no-index` means no index is consulted at all,
so the risk the rule guards against cannot occur, and a freshly built artifact
has no upstream hash to pin. Rewriting it to a glob path to satisfy the
heuristic would churn an install step that runs across twelve job instances and
three operating systems, for no security gain.

All three want dismissal with a reason rather than a code change.
