### PR TITLE
release: 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-26
+
 ### Security
 - **The `rust-cache` action pin claimed a version it no longer points at.** All
   19 uses across `ci.yml`, `release.yml` and `bench.yml` pinned commit
@@ -2995,7 +2997,8 @@ public API changes.
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/wickra-lib/wickra/compare/v0.9.9...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/wickra-lib/wickra/compare/v0.9.9...v1.0.0
 [0.9.9]: https://github.com/wickra-lib/wickra/compare/v0.9.8...v0.9.9
 [0.9.8]: https://github.com/wickra-lib/wickra/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/wickra-lib/wickra/compare/v0.9.6...v0.9.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wrapper against both headers. A symbol absent from the header in the tree means
   the wrapper is stale, which is a defect and fails; a symbol absent from the
   released ABI means main is ahead of the last release and r-universe stays red
-  until the next one, which is a release-readiness signal and warns.
+  until the next one, which is a release-readiness signal and warns. A version
+  with no release at all is a release in flight, where the tag publishes wrapper
+  and ABI together, and passes.
 - **Nothing compared the bindings to each other.** Each is generated or written
   separately and tested separately, so a method that went missing in one of them
   failed nowhere — which is how the WASM binding shipped 73 classes without

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "0.9.9"
+version = "1.0.0"
 dependencies = [
  "approx",
  "criterion",
@@ -1905,7 +1905,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-bench"
-version = "0.9.9"
+version = "1.0.0"
 dependencies = [
  "criterion",
  "kand",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-c"
-version = "0.9.9"
+version = "1.0.0"
 dependencies = [
  "tokio",
  "wickra-core",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "0.9.9"
+version = "1.0.0"
 dependencies = [
  "approx",
  "proptest",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "0.9.9"
+version = "1.0.0"
 dependencies = [
  "approx",
  "csv",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-examples"
-version = "0.9.9"
+version = "1.0.0"
 dependencies = [
  "serde_json",
  "tokio",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "0.9.9"
+version = "1.0.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "0.9.9"
+version = "1.0.0"
 dependencies = [
  "bytemuck",
  "pyo3",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "0.9.9"
+version = "1.0.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.9"
+version = "1.0.0"
 authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
@@ -26,8 +26,8 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "0.9.9" }
-wickra-data = { path = "crates/wickra-data", version = "0.9.9" }
+wickra-core = { path = "crates/wickra-core", version = "1.0.0" }
+wickra-data = { path = "crates/wickra-data", version = "1.0.0" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported versions
 
-Wickra is pre-1.0. Security fixes are applied to the latest released `0.9.9`
+Wickra is pre-1.0. Security fixes are applied to the latest released `1.0.0`
 version only; please upgrade to the newest release before reporting an issue.
 
 | Version | Supported |
 | --- | --- |
-| 0.9.9 (latest) | :white_check_mark: |
-| < 0.9.9 | :x: |
+| 1.0.0 (latest) | :white_check_mark: |
+| < 1.0.0 | :x: |
 
 ## Reporting a vulnerability
 

--- a/bindings/csharp/Wickra/Wickra.csproj
+++ b/bindings/csharp/Wickra/Wickra.csproj
@@ -11,7 +11,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>Wickra</PackageId>
-    <Version>0.9.9</Version>
+    <Version>1.0.0</Version>
     <Authors>kingchenc</Authors>
     <Description>High-performance streaming technical-analysis indicators (514 indicators) for .NET, backed by the native Rust core via the Wickra C ABI.</Description>
     <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -38,14 +38,14 @@ Maven:
 <dependency>
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.9</version>
+  <version>1.0.0</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.wickra:wickra:0.9.9")
+implementation("org.wickra:wickra:1.0.0")
 ```
 
 The native library ships prebuilt per platform (Linux, macOS, Windows — x64 and

--- a/bindings/java/benchmarks/pom.xml
+++ b/bindings/java/benchmarks/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.wickra</groupId>
       <artifactId>wickra</artifactId>
-      <version>0.9.9</version>
+      <version>1.0.0</version>
     </dependency>
   </dependencies>
 

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>0.9.9</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <name>Wickra</name>

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('wickra-android-arm64')
         const bindingPackageVersion = require('wickra-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('wickra-android-arm-eabi')
         const bindingPackageVersion = require('wickra-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('wickra-win32-x64-gnu')
         const bindingPackageVersion = require('wickra-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('wickra-win32-x64-msvc')
         const bindingPackageVersion = require('wickra-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('wickra-win32-ia32-msvc')
         const bindingPackageVersion = require('wickra-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('wickra-win32-arm64-msvc')
         const bindingPackageVersion = require('wickra-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('wickra-darwin-universal')
       const bindingPackageVersion = require('wickra-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('wickra-darwin-x64')
         const bindingPackageVersion = require('wickra-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('wickra-darwin-arm64')
         const bindingPackageVersion = require('wickra-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('wickra-freebsd-x64')
         const bindingPackageVersion = require('wickra-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('wickra-freebsd-arm64')
         const bindingPackageVersion = require('wickra-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-x64-musl')
           const bindingPackageVersion = require('wickra-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-x64-gnu')
           const bindingPackageVersion = require('wickra-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-arm64-musl')
           const bindingPackageVersion = require('wickra-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-arm64-gnu')
           const bindingPackageVersion = require('wickra-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-arm-musleabihf')
           const bindingPackageVersion = require('wickra-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-arm-gnueabihf')
           const bindingPackageVersion = require('wickra-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-loong64-musl')
           const bindingPackageVersion = require('wickra-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-loong64-gnu')
           const bindingPackageVersion = require('wickra-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-riscv64-musl')
           const bindingPackageVersion = require('wickra-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-riscv64-gnu')
           const bindingPackageVersion = require('wickra-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('wickra-linux-ppc64-gnu')
         const bindingPackageVersion = require('wickra-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('wickra-linux-s390x-gnu')
         const bindingPackageVersion = require('wickra-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('wickra-openharmony-arm64')
         const bindingPackageVersion = require('wickra-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('wickra-openharmony-x64')
         const bindingPackageVersion = require('wickra-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('wickra-openharmony-arm')
         const bindingPackageVersion = require('wickra-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.9.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.9.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wickra",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wickra",
-      "version": "0.9.9",
+      "version": "1.0.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.7.2"
@@ -15,12 +15,12 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.9",
-        "wickra-darwin-x64": "0.9.9",
-        "wickra-linux-arm64-gnu": "0.9.9",
-        "wickra-linux-x64-gnu": "0.9.9",
-        "wickra-win32-arm64-msvc": "0.9.9",
-        "wickra-win32-x64-msvc": "0.9.9"
+        "wickra-darwin-arm64": "1.0.0",
+        "wickra-darwin-x64": "1.0.0",
+        "wickra-linux-arm64-gnu": "1.0.0",
+        "wickra-linux-x64-gnu": "1.0.0",
+        "wickra-win32-arm64-msvc": "1.0.0",
+        "wickra-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1846,8 +1846,8 @@
       "license": "ISC"
     },
     "node_modules/wickra-darwin-arm64": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-0.9.9.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-1.0.0.tgz",
       "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
       "cpu": [
         "arm64"
@@ -1862,8 +1862,8 @@
       }
     },
     "node_modules/wickra-darwin-x64": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-0.9.9.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-1.0.0.tgz",
       "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
       "cpu": [
         "x64"
@@ -1878,8 +1878,8 @@
       }
     },
     "node_modules/wickra-linux-arm64-gnu": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-0.9.9.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-1.0.0.tgz",
       "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
       "cpu": [
         "arm64"
@@ -1894,8 +1894,8 @@
       }
     },
     "node_modules/wickra-linux-x64-gnu": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-0.9.9.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-1.0.0.tgz",
       "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
       "cpu": [
         "x64"
@@ -1910,8 +1910,8 @@
       }
     },
     "node_modules/wickra-win32-arm64-msvc": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-0.9.9.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-1.0.0.tgz",
       "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
       "cpu": [
         "arm64"
@@ -1926,8 +1926,8 @@
       }
     },
     "node_modules/wickra-win32-x64-msvc": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-0.9.9.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-1.0.0.tgz",
       "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
       "cpu": [
         "x64"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
@@ -45,12 +45,12 @@
     "node": ">= 22"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "0.9.9",
-    "wickra-linux-arm64-gnu": "0.9.9",
-    "wickra-darwin-x64": "0.9.9",
-    "wickra-darwin-arm64": "0.9.9",
-    "wickra-win32-x64-msvc": "0.9.9",
-    "wickra-win32-arm64-msvc": "0.9.9"
+    "wickra-linux-x64-gnu": "1.0.0",
+    "wickra-linux-arm64-gnu": "1.0.0",
+    "wickra-darwin-x64": "1.0.0",
+    "wickra-darwin-arm64": "1.0.0",
+    "wickra-win32-x64-msvc": "1.0.0",
+    "wickra-win32-arm64-msvc": "1.0.0"
   },
   "scripts": {
     "build": "napi build --platform --release && node scripts/prune-type-only-exports.mjs",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "0.9.9"
+version = "1.0.0"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: wickra
 Type: Package
 Title: Streaming-First Technical Indicators
-Version: 0.9.9
+Version: 1.0.0
 Authors@R: person("kingchenc", role = c("aut", "cre"), email = "support@wickra.org")
 Description: R bindings for the Wickra technical-analysis library over its C ABI
     hub. Exposes 514 indicators, each an incremental streaming state machine

--- a/crates/wickra-data/Cargo.toml
+++ b/crates/wickra-data/Cargo.toml
@@ -27,7 +27,7 @@ workspace = true
 # (rayon) feature on — the WASM binding needs a rayon-free build and the data
 # layer never uses the parallel batch path. Native bindings re-enable `parallel`
 # through their own wickra-core dependency (cargo unifies the features).
-wickra-core = { path = "../wickra-core", version = "0.9.9", default-features = false }
+wickra-core = { path = "../wickra-core", version = "1.0.0", default-features = false }
 thiserror = { workspace = true }
 csv = "1.3"
 serde = { version = "1", features = ["derive"] }

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra.examples</groupId>
   <artifactId>wickra-examples</artifactId>
-  <version>0.9.9</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <name>Wickra Java examples</name>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.wickra</groupId>
       <artifactId>wickra</artifactId>
-      <version>0.9.9</version>
+      <version>1.0.0</version>
     </dependency>
   </dependencies>
 

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -14,7 +14,7 @@
     },
     "../../bindings/node": {
       "name": "wickra",
-      "version": "0.9.9",
+      "version": "1.0.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -23,12 +23,12 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "0.9.9",
-        "wickra-darwin-x64": "0.9.9",
-        "wickra-linux-arm64-gnu": "0.9.9",
-        "wickra-linux-x64-gnu": "0.9.9",
-        "wickra-win32-arm64-msvc": "0.9.9",
-        "wickra-win32-x64-msvc": "0.9.9"
+        "wickra-darwin-arm64": "1.0.0",
+        "wickra-darwin-x64": "1.0.0",
+        "wickra-linux-arm64-gnu": "1.0.0",
+        "wickra-linux-x64-gnu": "1.0.0",
+        "wickra-win32-arm64-msvc": "1.0.0",
+        "wickra-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/wickra": {

--- a/scripts/check_r_abi_skew.py
+++ b/scripts/check_r_abi_skew.py
@@ -39,6 +39,7 @@ import re
 import subprocess
 import sys
 import time
+import urllib.error
 import urllib.request
 
 ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
@@ -60,8 +61,12 @@ def released_version() -> str:
     raise SystemExit(f"no Version: field in {DESCRIPTION}")
 
 
-def released_header(tag: str) -> str:
-    """The header as of `tag`, from the local clone if it has the tag, else raw."""
+def released_header(tag: str) -> str | None:
+    """The header as of `tag`, from the local clone if it has the tag, else raw.
+
+    None when no release carries that tag yet, which is what a release branch
+    looks like: DESCRIPTION already names the version the tag will publish.
+    """
     try:
         return subprocess.run(
             ["git", "show", f"{tag}:bindings/c/include/wickra.h"],
@@ -77,6 +82,14 @@ def released_header(tag: str) -> str:
         try:
             with urllib.request.urlopen(url, timeout=60) as response:
                 return response.read().decode("utf-8")
+        except urllib.error.HTTPError as err:
+            # A 404 is an answer, not a flake: that tag does not exist.
+            if err.code == 404:
+                return None
+            reason = err
+            if attempt < 3:
+                print(f"  attempt {attempt}/3 failed ({err}); retrying in {attempt * 5}s")
+                time.sleep(attempt * 5)
         except OSError as err:
             reason = err
             if attempt < 3:
@@ -164,7 +177,12 @@ def main() -> int:
 
     version = released_version()
     tag = f"v{version}"
-    released = declarations(released_header(tag))
+    header = released_header(tag)
+    if header is None:
+        print(f"\nNo release carries {tag} yet, so there is no released ABI to"
+              " compare against: the tag publishes the wrapper and the ABI together.")
+        return 0
+    released = declarations(header)
     skew = compare(used, released, tree)
     print(f"\nDESCRIPTION names version {version}, whose ABI declares {len(released)} exports.")
     if not skew:


### PR DESCRIPTION
Cuts **1.0.0**. Version strings and release tooling only — no behaviour change to
any indicator, binding or fixture.

## Commits

1. **`release: bump 0.9.9 -> 1.0.0`** — `Cargo.toml` + the `wickra-core`
   path-dep, `Cargo.lock`'s `wickra*` entries (via `cargo build`), the Python /
   Node / Java / C# / R manifests, the six Node platform stubs and both
   lockfiles, `SECURITY.md`'s supported-versions table, and the `[1.0.0]`
   CHANGELOG section with its two compare links. The docs and webpage version
   strings are deliberately untouched — `sync-about.yml` rewrites those on the
   tag push.

2. **`fix(ci): pass the R ABI check while a release is in flight`** — the check
   merged in #395 compares `bindings/r/src/wickra.c` against the header at the
   tag `DESCRIPTION` names. On a release branch that tag does not exist yet, so
   the read 404s and the job failed. Without this, every release PR from now on
   would have failed. A 404 is an answer, not a flake: it means the tag will
   publish the wrapper and the ABI together, so it reports that and passes. Any
   other network error stays fatal, so a DNS failure cannot masquerade as an
   unreleased version.

3. **`release: bump the two version touchpoints the tool did not own`** — a
   `git grep` for the old version after the bump reported clean turned up two
   files that had drifted:

   | file | was | stale since |
   |---|---|---|
   | `bindings/java/benchmarks/pom.xml` | `0.9.6` | v0.9.7 |
   | `bindings/node/index.js` | `0.9.7` in the v0.9.9 tag | whenever someone last ran `napi build` |

   Both are now covered by the release-bump tooling, so the next bump carries
   them without anyone remembering. The `index.js` diff is 52 occurrences of the
   same two generated lines and nothing else; the check they guard is gated on
   `NAPI_RS_ENFORCE_VERSION_CHECK`, which is why a stale literal never surfaced.

## Verification

- `cargo fmt --all` clean, `cargo check --workspace --all-features` clean.
- The R ABI check was exercised in all four states before committing: an
  unreleased tag passes with the note, a released tag still reports the
  178-export skew against v0.9.9, a wrapper calling an export this tree does not
  declare still exits 1, and an unreachable host still exits non-zero.
- `git grep` for `0.9.9` in tracked files is empty outside CHANGELOG history and
  one narrative reference in `scripts/check_r_abi_skew.py`.
