### PR TITLE
ci(sync-about): fail when a sync cannot happen

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -182,9 +182,9 @@ jobs:
           GH_TOKEN: ${{ secrets.ABOUT_SYNC_TOKEN }}
         run: |
           n="${{ steps.count.outputs.count }}"
-          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/wickra-docs.git" docs-count 2>/dev/null; then
-            echo "::warning::cannot clone wickra-lib/wickra-docs — ABOUT_SYNC_TOKEN likely lacks write on that repo (findings P10.0a). Skipping docs count sync."
-            exit 0
+          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/wickra-docs.git" docs-count; then
+            echo "::error::cannot clone wickra-lib/wickra-docs; nothing was synced."
+            exit 1
           fi
           cd docs-count
           sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" index.md overview.md Indicators-Overview.md .vitepress/config.ts
@@ -196,11 +196,11 @@ jobs:
           git config user.email "wickra-bot@users.noreply.github.com"
           git add index.md overview.md Indicators-Overview.md .vitepress/config.ts
           git commit -m "chore: sync indicator count to ${n}"
-          if ! git push 2>/dev/null; then
-            echo "::warning::push to wickra-lib/wickra-docs failed — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a)."
-          else
-            echo "Docs indicator count synced to ${n}."
+          if ! git push; then
+            echo "::error::push to wickra-lib/wickra-docs failed; nothing was synced. ABOUT_SYNC_TOKEN is rotated outside this workflow -- check that it still carries write on that repository."
+            exit 1
           fi
+          echo "Docs indicator count synced to ${n}."
 
       # The GitHub wiki (wickra-lib/wickra.wiki) was collapsed to a single
       # Home.md pointer page that sends visitors to docs.wickra.org, but that
@@ -216,9 +216,9 @@ jobs:
           GH_TOKEN: ${{ secrets.ABOUT_SYNC_TOKEN }}
         run: |
           n="${{ steps.count.outputs.count }}"
-          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/wickra.wiki.git" wiki-count 2>/dev/null; then
-            echo "::warning::cannot clone wickra-lib/wickra.wiki — ABOUT_SYNC_TOKEN likely lacks write on the wiki. Skipping wiki count sync."
-            exit 0
+          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/wickra.wiki.git" wiki-count; then
+            echo "::error::cannot clone wickra-lib/wickra.wiki; nothing was synced."
+            exit 1
           fi
           cd wiki-count
           sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" Home.md
@@ -230,11 +230,11 @@ jobs:
           git config user.email "wickra-bot@users.noreply.github.com"
           git add Home.md
           git commit -m "chore: sync indicator count to ${n}"
-          if ! git push 2>/dev/null; then
-            echo "::warning::push to wickra-lib/wickra.wiki failed — ABOUT_SYNC_TOKEN likely lacks write on the wiki."
-          else
-            echo "Wiki pointer indicator count synced to ${n}."
+          if ! git push; then
+            echo "::error::push to wickra-lib/wickra.wiki failed; nothing was synced. ABOUT_SYNC_TOKEN is rotated outside this workflow -- check that it still carries write on that repository."
+            exit 1
           fi
+          echo "Wiki pointer indicator count synced to ${n}."
 
       # ----- org-profile sync (soft-skip until PAT scope lands) -------
       #
@@ -252,9 +252,9 @@ jobs:
           GH_TOKEN: ${{ secrets.ABOUT_SYNC_TOKEN }}
         run: |
           n="${{ steps.count.outputs.count }}"
-          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/.github.git" orgprofile 2>/dev/null; then
-            echo "::warning::cannot clone wickra-lib/.github — ABOUT_SYNC_TOKEN likely lacks write on that repo (findings P10.0a). Skipping org profile sync."
-            exit 0
+          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/.github.git" orgprofile; then
+            echo "::error::cannot clone wickra-lib/.github; nothing was synced."
+            exit 1
           fi
           cd orgprofile
           sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" profile/README.md
@@ -266,11 +266,11 @@ jobs:
           git config user.email "wickra-bot@users.noreply.github.com"
           git add profile/README.md
           git commit -m "chore: sync indicator count to ${n}"
-          if ! git push 2>/dev/null; then
-            echo "::warning::push to wickra-lib/.github failed — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a)."
-          else
-            echo "Org profile README synced to ${n}."
+          if ! git push; then
+            echo "::error::push to wickra-lib/.github failed; nothing was synced. ABOUT_SYNC_TOKEN is rotated outside this workflow -- check that it still carries write on that repository."
+            exit 1
           fi
+          echo "Org profile README synced to ${n}."
 
       - name: Sync org description
         if: github.event_name != 'pull_request'
@@ -322,14 +322,12 @@ jobs:
           # Clone into `docs-ver`, NOT `docs`: on a tag push this job checks out
           # the wickra repo at the workspace root, which already contains a
           # top-level `docs/` directory, so `git clone … docs` fails with
-          # "destination path 'docs' already exists" — silently, because of the
-          # 2>/dev/null below — and the version sync never runs (this is exactly
-          # why v0.4.0 did not bump the docs table). `docs-ver` mirrors the
-          # `docs-count` dir used by the count step above and collides with
-          # nothing in the repo.
-          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/wickra-docs.git" docs-ver 2>/dev/null; then
-            echo "::warning::cannot clone wickra-lib/wickra-docs — ABOUT_SYNC_TOKEN likely lacks write on that repo (findings P10.0a). Skipping docs version sync."
-            exit 0
+          # "destination path 'docs' already exists" — which is why v0.4.0 did
+          # not bump the docs table. `docs-ver` mirrors the `docs-count` dir used
+          # by the count step above and collides with nothing in the repo.
+          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/wickra-docs.git" docs-ver; then
+            echo "::error::cannot clone wickra-lib/wickra-docs; nothing was synced."
+            exit 1
           fi
           cd docs-ver
           # Published-versions table rows (all registries): replace only the
@@ -355,11 +353,11 @@ jobs:
           git config user.email "wickra-bot@users.noreply.github.com"
           git add overview.md Quickstart-Rust.md Quickstart-Java.md
           git commit -m "chore: sync published version to ${version}"
-          if ! git push 2>/dev/null; then
-            echo "::warning::push to wickra-lib/wickra-docs failed — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a)."
-          else
-            echo "Docs version synced to ${version}."
+          if ! git push; then
+            echo "::error::push to wickra-lib/wickra-docs failed; nothing was synced. ABOUT_SYNC_TOKEN is rotated outside this workflow -- check that it still carries write on that repository."
+            exit 1
           fi
+          echo "Docs version synced to ${version}."
 
       # ----- webpage (marketing site) self-update (findings P12.1) ------------
       #
@@ -376,9 +374,9 @@ jobs:
           GH_TOKEN: ${{ secrets.ABOUT_SYNC_TOKEN }}
         run: |
           n="${{ steps.count.outputs.count }}"
-          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/webpage.git" webpage-count 2>/dev/null; then
-            echo "::warning::cannot clone wickra-lib/webpage — ABOUT_SYNC_TOKEN likely lacks write on that repo (findings P10.0a). Skipping webpage count sync."
-            exit 0
+          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/webpage.git" webpage-count; then
+            echo "::error::cannot clone wickra-lib/webpage; nothing was synced."
+            exit 1
           fi
           cd webpage-count
           sed -i -E "s/[0-9]+ (streaming-first )?indicators/${n} \1indicators/g" index.md about.md .vitepress/config.ts
@@ -390,11 +388,11 @@ jobs:
           git config user.email "wickra-bot@users.noreply.github.com"
           git add index.md about.md .vitepress/config.ts
           git commit -m "chore: sync indicator count to ${n}"
-          if ! git push 2>/dev/null; then
-            echo "::warning::push to wickra-lib/webpage failed — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a)."
-          else
-            echo "Webpage indicator count synced to ${n}."
+          if ! git push; then
+            echo "::error::push to wickra-lib/webpage failed; nothing was synced. ABOUT_SYNC_TOKEN is rotated outside this workflow -- check that it still carries write on that repository."
+            exit 1
           fi
+          echo "Webpage indicator count synced to ${n}."
 
       - name: Sync webpage version (wickra-lib/webpage)
         if: startsWith(github.ref, 'refs/tags/v')
@@ -427,9 +425,9 @@ jobs:
             sleep 30
           done
           echo "wickra-wasm@${version} is live on npm; proceeding with the webpage version bump."
-          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/webpage.git" webpage-ver 2>/dev/null; then
-            echo "::warning::cannot clone wickra-lib/webpage — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a). Skipping webpage version sync."
-            exit 0
+          if ! git clone "https://x-access-token:${GH_TOKEN}@github.com/wickra-lib/webpage.git" webpage-ver; then
+            echo "::error::cannot clone wickra-lib/webpage; nothing was synced."
+            exit 1
           fi
           cd webpage-ver
           # api/*.md "Latest" lines, the nav version label, and the wickra-wasm
@@ -467,8 +465,8 @@ jobs:
           git config user.email "wickra-bot@users.noreply.github.com"
           git add api/*.md index.md .vitepress/config.ts package.json package-lock.json
           git commit -m "chore: sync published version to ${version}"
-          if ! git push 2>/dev/null; then
-            echo "::warning::push to wickra-lib/webpage failed — ABOUT_SYNC_TOKEN likely lacks write (findings P10.0a)."
-          else
-            echo "Webpage version synced to ${version}."
+          if ! git push; then
+            echo "::error::push to wickra-lib/webpage failed; nothing was synced. ABOUT_SYNC_TOKEN is rotated outside this workflow -- check that it still carries write on that repository."
+            exit 1
           fi
+          echo "Webpage version synced to ${version}."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`sync-about` reported success while syncing nothing.** Every clone and push
+  in the workflow was written as `if ! git <cmd> 2>/dev/null; then echo
+  "::warning::…"`, so a failure printed a warning, discarded the reason and let
+  the job go green. The v1.0.0 tag run did exactly that: it built the docs
+  commit, could not push it, and reported success — `wickra-docs` and the
+  webpage stayed on 0.9.9 while the release itself was live on five registries.
+  `ABOUT_SYNC_TOKEN` was rotated on 2026-07-01, two days after the last release,
+  so the first run that needed write was this one, seven weeks later. All twelve
+  guards now let git print why and fail the step: a sync that did not happen is
+  not a success. Nothing about the token is asserted in the message any more —
+  the clone guards claimed it "likely lacks write", which cannot be the cause of
+  a failed clone of a public repository.
+
 ## [1.0.0] - 2026-08-26
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not a success. Nothing about the token is asserted in the message any more —
   the clone guards claimed it "likely lacks write", which cannot be the cause of
   a failed clone of a public repository.
+- **The 1.0.0 release left `SECURITY.md` contradicting itself.** The version
+  strings were bumped, the prose around them was not: the supported-versions
+  section read "Wickra is pre-1.0. Security fixes are applied to the latest
+  released `1.0.0`", and the support timeline promised a policy revision "after
+  the `1.0.0` release" while claiming only `0.y.z` versions are supported.
+  `ROADMAP.md` still listed "API stabilization toward 1.0" as a future theme.
+  Both now describe 1.0 as shipped and the API as semver-stable.
 
 ## [1.0.0] - 2026-08-26
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,17 +8,17 @@ are recorded in [`CHANGELOG.md`](CHANGELOG.md).
 
 ## Status
 
-Wickra is **pre-1.0**. The public API is largely stable but may still change in
-minor releases; breaking changes are called out in the changelog.
+Wickra is at **1.0**. The public API follows semantic versioning: a breaking
+change requires a major release, and every change is recorded in the changelog.
 
 ## Themes
 
 - **Indicator coverage.** Continue broadening the indicator catalogue across
   families (trend, momentum, volatility, volume, statistics, market profile,
   and more), each with the same streaming/batch parity and test guarantees.
-- **API stabilization toward 1.0.** Settle the public `Indicator` and
-  `BarBuilder` traits and the binding surfaces, then commit to semantic
-  versioning stability for a 1.0 release.
+- **API stability.** The public `Indicator` and `BarBuilder` traits and the
+  binding surfaces are settled as of 1.0; keep them that way and reserve
+  breaking changes for a major release.
 - **Performance.** Keep a tick free of any pass over the history behind it, and maintain the benchmark suite;
   investigate further allocation and cache improvements.
 - **Bindings parity.** Keep the Python, Node.js and WASM bindings — plus

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,8 @@
 
 ## Supported versions
 
-Wickra is pre-1.0. Security fixes are applied to the latest released `1.0.0`
-version only; please upgrade to the newest release before reporting an issue.
+Security fixes are applied to the latest released version, `1.0.0`, only; please
+upgrade to the newest release before reporting an issue.
 
 | Version | Supported |
 | --- | --- |
@@ -111,12 +111,12 @@ publisher identity.
 
 ## Support timeline and end of support
 
-Wickra is **pre-1.0**: only the **latest released `0.y.z`** version receives
-security fixes. When a newer release is published, the previous version
-**immediately reaches end of support** and will not receive further fixes;
-users should upgrade to the latest release. The supported-versions table above
-is authoritative. After the `1.0.0` release this policy will be revised to
-support a defined window of releases.
+Only the **latest released version** receives security fixes. When a newer
+release is published, the previous version **immediately reaches end of
+support** and will not receive further fixes; users should upgrade to the
+latest release. The supported-versions table above is authoritative. A defined
+support window covering older releases may be introduced later; until it is,
+only the latest release is supported.
 
 ## Remediation policy (dependencies and code scanning)
 


### PR DESCRIPTION
Three things the 1.0.0 release exposed. Two are fixed here; the third was fixed
directly in the docs and webpage repos and is recorded below for the trail.

## Why nobody noticed

`sync-about.yml` guarded every clone and push as

```sh
if ! git <cmd> 2>/dev/null; then echo "::warning::..."
```

which throws away the reason git failed and lets the job finish **green**. A
sync that did not happen looks exactly like a sync that did.

The v1.0.0 tag run is what that cost:

```
[main 131764e] chore: sync published version to 1.0.0
 3 files changed, 13 insertions(+), 13 deletions(-)
##[warning]push to wickra-lib/wickra-docs failed — ABOUT_SYNC_TOKEN likely lacks write
```

The commit was built, the push was rejected, the job reported success.
`wickra-docs` and the webpage stayed on 0.9.9 while 1.0.0 was live on five
registries. `ABOUT_SYNC_TOKEN` was rotated on **2026-07-01**, two days after the
previous release, so this was the first run in seven weeks that needed write —
and nothing reported the gap.

All twelve guards now let git print why and `exit 1`. The messages also stop
asserting a cause: the clone guards blamed `ABOUT_SYNC_TOKEN likely lacks write`,
which cannot be why a clone of a *public* repository fails. The single remaining
`2>/dev/null` is the org-description read — a public GET with an explicit
`|| true` and a documented skip.

**This does not repair the token.** `ABOUT_SYNC_TOKEN` still needs write on
`wickra-docs`, `webpage`, `wickra.wiki` and `.github`, or the next release fails
this job instead of silently skipping it — which is the point.

## The 1.0 prose

`bump_version.py` replaced the version strings correctly; the prose around them
still assumed pre-1.0, so both files said two contradictory things at once.

| file | said |
|---|---|
| `SECURITY.md` | "Wickra is pre-1.0. Security fixes are applied to the latest released `1.0.0`" |
| `SECURITY.md` | only `0.y.z` is supported, and the policy "will be revised" after a release that had just happened |
| `ROADMAP.md` | "API stabilization toward 1.0" as a future theme |

The support policy itself is unchanged — only the latest release gets fixes. It
just no longer contradicts the table directly above it, and the promised
revision is stated as an open possibility rather than a pending event.

## Already pushed, outside this PR

Both sites were stale and are now correct, using the same replacements the
workflow performs:

- **wickra-docs** `3a9fb69` — `overview.md`, `Quickstart-Rust.md`,
  `Quickstart-Java.md`. Byte-for-byte the same diffstat as the commit the bot
  built and failed to push (3 files, 13 insertions, 13 deletions).
- **webpage** `a99fe74` — `api/*.md`, `index.md`, `.vitepress/config.ts`,
  `package.json`, `package-lock.json`.

The webpage version sync had been skipped for a different and *correct* reason:
it waits for `wickra-wasm@<version>` to appear on npm before committing, because
Cloudflare builds with `npm clean-install` and a lockfile pointing at an
unpublished version breaks the site. npm publishing was broken at the time (an
expired token), so it waited 15 minutes and gave up rather than push a
build-breaking commit. `wickra-wasm@1.0.0` is live now.

The lockfile edit was kept to four lines. Running `npm install
--package-lock-only` locally also stripped 52 `"libc"` lines from unrelated
optional dependencies — npm-version churn that has no business in a version-sync
commit when Cloudflare builds with `npm ci` — so the entry was edited directly
with the integrity hash read from the registry, and verified:

```
$ npm ci --dry-run
change wickra-wasm 0.9.9 => 1.0.0
added 92 packages, and changed 1 package
```
