### PR TITLE
bench: guard the reference harness and repair the Java benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The per-binding reference benchmark discarded its own results.** Every other
+  harness in the repository guards its measurement loop, but
+  `examples/rust/src/bin/throughput.rs` -- the FFI-free Rust baseline that all
+  nine bindings in BENCHMARKS.md §3 are measured against -- called
+  `ind.update(price);` and dropped the value, leaving the optimiser free to
+  delete work nothing reads. It has been that way since the benchmarks landed in
+  #246. Measured cost of the omission: `SMA(20)` streaming reports 1836 Mupd/s
+  unguarded and 1341 guarded, a 27% inflation on the one row every other row is
+  compared to. Batch was never affected (505 vs 514) because the result array is
+  returned.
+- **`bindings/java/benchmarks` did not compile.** Its pom pinned `wickra` 0.9.6,
+  three releases behind, so it built against an API where `Atr.batch` took a
+  `double[]` of timestamps; the current one takes `long[]`. Against a current jar
+  it failed at runtime with `NoSuchMethodError`, and against its own source it
+  failed to compile. Nothing caught it because CI does not build that module.
+  `Throughput.java` now declares `long[] timestamp`, which is what the binding
+  has taken for some time, and the redundant `(long)` cast at the call site is
+  gone.
+
+
+### Fixed
 - **`sync-about` reported success while syncing nothing.** Every clone and push
   in the workflow was written as `if ! git <cmd> 2>/dev/null; then echo
   "::warning::…"`, so a failure printed a warning, discarded the reason and let

--- a/bindings/java/benchmarks/src/main/java/org/wickra/benchmarks/Throughput.java
+++ b/bindings/java/benchmarks/src/main/java/org/wickra/benchmarks/Throughput.java
@@ -55,7 +55,7 @@ public final class Throughput {
         double[] low = new double[bars];
         double[] close = new double[bars];
         double[] volume = new double[bars];
-        double[] timestamp = new double[bars];
+        long[] timestamp = new long[bars];
         for (int i = 0; i < bars; i++) {
             double mid = 100 + Math.sin(i * 0.001) * 20 + i * 1e-4;
             double c = mid + Math.sin(i * 0.05) * 2;
@@ -88,7 +88,7 @@ public final class Throughput {
                 () -> {
                     try (Atr ind = new Atr(14)) {
                         for (int i = 0; i < n; i++) {
-                            ind.update(open[i], high[i], low[i], close[i], volume[i], (long) timestamp[i]);
+                            ind.update(open[i], high[i], low[i], close[i], volume[i], timestamp[i]);
                         }
                     }
                 },

--- a/examples/rust/src/bin/throughput.rs
+++ b/examples/rust/src/bin/throughput.rs
@@ -15,6 +15,7 @@
 
 use std::time::Instant;
 
+use std::hint::black_box;
 use wickra::{Atr, Candle, Indicator, MacdIndicator, Sma};
 
 /// Median elapsed-ns over a few repetitions, after one warmup pass.
@@ -73,27 +74,27 @@ fn main() {
     let sma_stream = time_ns(|| {
         let mut ind = Sma::new(20).unwrap();
         for &price in &close {
-            ind.update(price);
+            black_box(ind.update(price));
         }
     });
     let sma_batch = time_ns(|| {
         let mut ind = Sma::new(20).unwrap();
-        ind.batch_nan(&close);
+        black_box(ind.batch_nan(&close));
     });
     let atr_stream = time_ns(|| {
         let mut ind = Atr::new(14).unwrap();
         for &candle in &candles {
-            ind.update(candle);
+            black_box(ind.update(candle));
         }
     });
     let atr_batch = time_ns(|| {
         let mut ind = Atr::new(14).unwrap();
-        ind.batch_atr(&high, &low, &close);
+        black_box(ind.batch_atr(&high, &low, &close));
     });
     let macd_stream = time_ns(|| {
         let mut ind = MacdIndicator::new(12, 26, 9).unwrap();
         for &price in &close {
-            ind.update(price);
+            black_box(ind.update(price));
         }
     });
 


### PR DESCRIPTION
Two defects in the benchmark harnesses, found while re-measuring every published
number against v1.0.0. **Neither touches library code** — they change what the
benchmarks *report*, not what Wickra does.

## The reference row measured a loop the optimiser could delete

`examples/rust/src/bin/throughput.rs` is the FFI-free Rust baseline that all nine
bindings in BENCHMARKS.md §3 are compared against. It called

```rust
for &price in &close {
    ind.update(price);      // result dropped
}
```

The three criterion benches in this repository all guard their loops with
`black_box`; this one — an example binary rather than a bench target — never did,
not since the benchmarks landed in #246.

Measured cost of the omission on `SMA(20)`, 200 000 bars:

| | unguarded | guarded |
|---|---|---|
| streaming | 1836 Mupd/s | **1341** Mupd/s |
| batch | 514 | 505 |

A 27% inflation, and it lands on the one row every other row is measured against.
Batch was never affected — the result array is returned, so there was nothing to
elide.

## The Java benchmark did not compile

`bindings/java/benchmarks` pinned `wickra` **0.9.6**, three releases behind, so it
had been building against an API where `Atr.batch` took a `double[]` of
timestamps. The current API takes `long[]`.

- against a current jar: `NoSuchMethodError: double[] org.wickra.Atr.batch(double[], double[], double[], double[], double[], double[])`
- against its own source: `Throughput.java:[97] incompatible types: double[] cannot be converted to long[]`

Nothing reported it because CI does not build that module. The array is now
`long[]` and the now-redundant `(long)` cast at the update call site is gone. With
that, the Java row measures again: 60 Mupd/s streaming, 190 batch.

## Deliberately not in this PR

The published §3 reference value — **380 Mupd/s streaming** — does not reproduce
either way; guarded it measures 1341. That is a question for the tables, not for
the harness, and it is one of several numbers that need re-measuring on a machine
without foreign CPU load before anything is rewritten.
