### PR TITLE
examples(python): drop NumPy from the backtest example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The Python backtest example imported NumPy.** The README promises a data
+  layer that needs "no foreign package -- no pandas, no `csv-parse`, ... not even
+  NumPy", and `examples/python/live_binance.py` and `multi_timeframe.py` already
+  keep that promise; `backtest.py` still used NumPy for two things the standard
+  library does as well -- pulling one field out of a multi-output `batch`, and
+  taking the mean/min/max of a series. The `Matrix` rows now feed a list
+  comprehension, the columns are `array('d')` (which is what a scalar `batch`
+  already hands back), and the summary uses `math.isnan` with `sum`/`min`/`max`.
+  Output is byte-identical to the NumPy version across all nine series, and
+  `numpy` no longer appears in `sys.modules` after the example runs.
+
+
+### Fixed
 - **The per-binding reference benchmark discarded its own results.** Every other
   harness in the repository guards its measurement loop, but
   `examples/rust/src/bin/throughput.rs` -- the FFI-free Rust baseline that all

--- a/examples/python/backtest.py
+++ b/examples/python/backtest.py
@@ -14,32 +14,35 @@ indicators are wired correctly without pulling in pandas or a charting stack.
 from __future__ import annotations
 
 import argparse
+import math
 import sys
+from array import array
 from dataclasses import dataclass
-
-import numpy as np
 
 import wickra as ta
 
 
-def columns(matrix) -> np.ndarray:
-    """A multi-output ``batch`` returns a ``Matrix``, not a NumPy array; ``tolist``
-    is the documented bridge to one."""
-    return np.asarray(matrix.tolist(), dtype=np.float64)
+def column(matrix, index: int) -> list[float]:
+    """One field of a multi-output ``batch``.
+
+    A multi-output ``batch`` returns a ``Matrix``; ``tolist`` is the documented
+    bridge to plain rows, and this picks one field out of each.
+    """
+    return [row[index] for row in matrix.tolist()]
 
 
 @dataclass
 class History:
-    timestamp: np.ndarray
-    open: np.ndarray
-    high: np.ndarray
-    low: np.ndarray
-    close: np.ndarray
-    volume: np.ndarray
+    timestamp: array
+    open: array
+    high: array
+    low: array
+    close: array
+    volume: array
 
 
 def read_history(path: str) -> History:
-    """Load an OHLCV CSV into typed NumPy columns with Wickra's native
+    """Load an OHLCV CSV into typed columns with Wickra's native
     ``CandleReader`` — no manual CSV parsing.
 
     ``CandleReader`` validates the header (``timestamp,open,high,low,close,volume``),
@@ -54,10 +57,11 @@ def read_history(path: str) -> History:
     if not candles:
         raise ValueError(f"{path}: CSV has a header but no data rows")
     # CandleReader yields (open, high, low, close, volume, timestamp) tuples.
-    # Transpose into contiguous 1-D columns (batch() needs C-contiguous arrays).
-    o, h, l, c, v, ts = (np.array(col, dtype=np.float64) for col in zip(*candles))
+    # Transpose into contiguous 1-D columns; `array('d')` is the stdlib buffer
+    # `batch` already hands back, so no third-party array type is involved.
+    o, h, l, c, v, ts = (array("d", col) for col in zip(*candles))
     return History(
-        timestamp=ts.astype(np.int64),
+        timestamp=array("q", (int(t) for t in ts)),
         open=o,
         high=h,
         low=l,
@@ -77,16 +81,14 @@ def parse_args() -> argparse.Namespace:
 
 
 def summarize(name: str, values) -> None:
-    # A scalar `batch` returns `array.array('d')`, which NumPy reads through the
-    # buffer protocol but cannot be boolean-indexed directly.
-    valid = np.asarray(values, dtype=np.float64)
-    valid = valid[~np.isnan(valid)]
-    if valid.size == 0:
+    # A scalar `batch` returns `array.array('d')`; the warmup entries are NaN.
+    valid = [v for v in values if not math.isnan(v)]
+    if not valid:
         print(f"  {name:<12} (no valid samples — series too short)")
         return
     print(
-        f"  {name:<12} mean={valid.mean():>10.4f}  min={valid.min():>10.4f}  "
-        f"max={valid.max():>10.4f}  last={valid[-1]:>10.4f}"
+        f"  {name:<12} mean={sum(valid) / len(valid):>10.4f}  "
+        f"min={min(valid):>10.4f}  max={max(valid):>10.4f}  last={valid[-1]:>10.4f}"
     )
 
 
@@ -96,21 +98,21 @@ def main() -> int:
 
     rsi = ta.RSI(args.rsi).batch(history.close)
     ema = ta.EMA(args.ema).batch(history.close)
-    macd = columns(ta.MACD().batch(history.close))  # shape (n, 3)
-    bb = columns(ta.BollingerBands(args.bb_period, args.bb_mult).batch(history.close))  # (n, 4)
+    macd = ta.MACD().batch(history.close)  # (n, 3)
+    bb = ta.BollingerBands(args.bb_period, args.bb_mult).batch(history.close)  # (n, 4)
     atr = ta.ATR(14).batch(history.high, history.low, history.close)
-    adx = columns(ta.ADX(14).batch(history.high, history.low, history.close))  # (n, 3)
+    adx = ta.ADX(14).batch(history.high, history.low, history.close)  # (n, 3)
     obv = ta.OBV().batch(history.close, history.volume)
 
-    print(f"Backtest summary for {args.path} ({history.close.size} bars)")
+    print(f"Backtest summary for {args.path} ({len(history.close)} bars)")
     summarize(f"RSI({args.rsi})", rsi)
     summarize(f"EMA({args.ema})", ema)
-    summarize("MACD line", macd[:, 0])
-    summarize("MACD hist", macd[:, 2])
-    summarize(f"BB upper", bb[:, 0])
-    summarize(f"BB lower", bb[:, 2])
+    summarize("MACD line", column(macd, 0))
+    summarize("MACD hist", column(macd, 2))
+    summarize("BB upper", column(bb, 0))
+    summarize("BB lower", column(bb, 2))
     summarize("ATR(14)", atr)
-    summarize("ADX(14)", adx[:, 2])
+    summarize("ADX(14)", column(adx, 2))
     summarize("OBV", obv)
 
     return 0


### PR DESCRIPTION
The README promises a data layer that needs

> no foreign package — no pandas, no `csv-parse`, no `ws`/`websockets`, no
> `jackson`, no `jsonlite`, **not even NumPy**

`examples/python/live_binance.py` and `multi_timeframe.py` already hold to that.
`backtest.py` did not — it imported NumPy for two things the standard library
covers.

| was | now |
|---|---|
| `np.asarray(matrix.tolist())` then `[:, i]` to pick one field out of a multi-output `batch` | a list comprehension over the same `tolist()` rows |
| `np.asarray(values)`, boolean-masked with `~np.isnan`, then `.mean()/.min()/.max()` | `math.isnan` filter, then `sum`/`min`/`max` |
| OHLCV columns as `np.ndarray`, timestamps via `.astype(np.int64)` | `array('d')` and `array('q')` — `array('d')` is the buffer a scalar `batch` already returns |

Neither use was a need; both were conveniences.

## Verified, not assumed

- Output is **byte-identical** to the NumPy version across all nine series on the
  50 000-bar example CSV (`diff` of both runs, script-path line excluded).
- `numpy` is absent from `sys.modules` after the example has run, so the import
  is gone rather than merely unused.

Found while cleaning up stale branches: a June branch had set out to do exactly
this and was never merged. Rather than resurrect a two-month-old diff against
files that have since moved, this is the one import it was really about.
