### PR TITLE
ci(sync-about): list C++ and C# in the About description

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -156,7 +156,7 @@ jobs:
           # actually live (Cloudflare Pages, P8.1); merging this PR is therefore
           # gated on the domain resolving, otherwise the About link would 404.
           homepage="https://docs.wickra.org"
-          desc="Streaming-first technical indicators with a Rust core and Python, Node.js, WebAssembly, C ABI, .NET, Go, Java, and R bindings. ${n} indicators, O(1) per-tick updates, no system dependencies. Drop-in TA-Lib replacement."
+          desc="Streaming-first technical indicators with a Rust core and Python, Node.js, WebAssembly, C, C++, C#, Go, Java, and R bindings. ${n} indicators, O(1) per-tick updates, no system dependencies. Drop-in TA-Lib replacement."
           # Enforce the homepage unconditionally — it is a constant, so this both
           # corrects the stale kingchenc URL and self-heals any future drift.
           # Same Administration-write permission as --description (no extra scope).


### PR DESCRIPTION
The hardcoded About description in `sync-about.yml` omitted C++ and named "C ABI, .NET" inside a list of languages, while the README, the docs site and the organization description all list the ten supported languages as Rust, Python, Node.js, WASM, C, C++, C#, Go, Java and R.

`bindings/c/include/wickra.hpp` ships a C++14 wrapper over the C ABI, so C++ is a first-class target and belongs in that list.

The workflow re-enforces this string on every push to main and on every `v*` tag, so correcting the About through the API alone would drift back on the next release. The repo About has been updated to match; this change keeps the workflow from reverting it.