### PR TITLE
ci(sync-about): describe the C ABI as a hub in the About text

### DIFF
--- a/.github/workflows/sync-about.yml
+++ b/.github/workflows/sync-about.yml
@@ -156,7 +156,7 @@ jobs:
           # actually live (Cloudflare Pages, P8.1); merging this PR is therefore
           # gated on the domain resolving, otherwise the About link would 404.
           homepage="https://docs.wickra.org"
-          desc="Streaming-first technical indicators with a Rust core and Python, Node.js, WebAssembly, C, C++, C#, Go, Java, and R bindings. ${n} indicators, O(1) per-tick updates, no system dependencies. Drop-in TA-Lib replacement."
+          desc="Streaming-first technical indicators with a Rust core: native Python, Node.js and WebAssembly bindings plus a C ABI hub for C, C++, C#, Go, Java and R. ${n} indicators, O(1) per-tick updates, no system dependencies. Drop-in TA-Lib replacement."
           # Enforce the homepage unconditionally — it is a constant, so this both
           # corrects the stale kingchenc URL and self-heals any future drift.
           # Same Administration-write permission as --description (no extra scope).


### PR DESCRIPTION
Follow-up to #401. That change added C++ and C# but flattened all ten languages into a single bindings list, which lost the distinction the README and the organization description both draw:

- **native bindings** — Python, Node.js, WebAssembly
- **C ABI hub** — C, C++, C#, Go, Java, R

The About description now reads `Streaming-first technical indicators with a Rust core: native Python, Node.js and WebAssembly bindings plus a C ABI hub for C, C++, C#, Go, Java and R.`, matching the wording used in the org description and in the README overview.