### PR TITLE
ci: name the exact action version each pin resolves to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1030,7 +1030,7 @@ jobs:
         run: cargo build -p wickra-c --release
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: "release"
           use-public-rspm: true
@@ -1040,7 +1040,7 @@ jobs:
       # compiling testthat / knitr and their deps from source — the slow, flaky
       # path that previously blew past the job timeout on the ubuntu runner.
       - name: Install R dependencies (cached binaries)
-        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           working-directory: bindings/r
           extra-packages: |
@@ -1254,7 +1254,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
+      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: --config lychee.toml --no-progress --root-dir "${{ github.workspace }}" "*.md" "bindings/*/README.md"
           fail: true

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
+      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: --config lychee.toml --no-progress --root-dir "${{ github.workspace }}" "*.md" "bindings/*/README.md"
           fail: true


### PR DESCRIPTION
Four `uses:` lines pinned a commit SHA but commented it with a floating major (`# v2`), so the comment said less than the pin did. The SHA provides the supply-chain property; the comment tells a reader — or a future updater — which release they are on, and `# v2` cannot answer that.

Both mappings were verified against the upstream tag refs rather than inferred:

| Action | SHA | Tag |
|---|---|---|
| `lycheeverse/lychee-action` | `e7477775` | `v2.9.0` |
| `r-lib/actions` | `d3c5be51` | `v2.12.1` |

`r-lib/actions` is a monorepo, so `setup-r` and `setup-r-dependencies` share one tag.

No behaviour changes — the SHAs are untouched, only what the comments claim. The same defect class was fixed in the backtest repository, which already pins these two SHAs with the exact comments above.