### PR TITLE
ci(codeql): exclude the Node binding glue from analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,23 @@
+# CodeQL analysis configuration, referenced from .github/workflows/codeql.yml.
+#
+# `bindings/node/src/lib.rs` is excluded from analysis. The file is a thin
+# napi-derive wrapper over wickra-core: roughly 22,000 lines of `#[napi]`
+# attributes, `node_*_indicator!` macro invocations and one-line delegating
+# methods, with a single hand-written `unsafe` item — the `from_napi_value`
+# trait impl that napi requires.
+#
+# napi-derive expands every `#[napi]` into FFI glue that dereferences raw
+# `napi_env` and `napi_value` handles, and CodeQL attributes that generated
+# code back to the source span of the macro. The result is one
+# `rust/access-invalid-pointer` finding per exported class, anchored on a
+# struct identifier rather than on any pointer expression; 518 of them
+# appeared at once when the query first shipped, and every new indicator
+# adds another.
+#
+# `query-filters` matches on query id, tags and severity only — it cannot be
+# scoped to a path. Excluding the rule that way would also disable it for
+# `bindings/c/src`, which is where the workspace's real raw-pointer code
+# lives. Dropping this one file of generated glue keeps the rule active
+# everywhere it can say something useful.
+paths-ignore:
+  - bindings/node/src/lib.rs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3


### PR DESCRIPTION
Adds `.github/codeql/codeql-config.yml` and wires it into `codeql.yml`, excluding `bindings/node/src/lib.rs` from CodeQL analysis.

**Why.** The Rust query pack now carries `rust/access-invalid-pointer`. Its first run against this repo opened **518 findings**, all in `bindings/node/src/lib.rs`, all the same rule — one per exported class, each anchored on a `pub struct <X>Node` identifier or a `node_*_indicator!` invocation rather than on a pointer expression. `napi-derive` expands every `#[napi]` into FFI glue that dereferences raw `napi_env` and `napi_value` handles, and CodeQL attributes that generated code back to the macro's source span. The same scan produced no findings in the pyo3 or wasm-bindgen bindings.

The file has exactly one hand-written `unsafe` item — the `from_napi_value` trait impl napi requires. The rest is macro invocations and one-line delegating methods over `wickra-core`, which is analysed in full.

**Why `paths-ignore` and not `query-filters`.** `query-filters` matches on query id, tags and severity; it cannot be scoped to a path. Excluding the rule that way would also disable it for `bindings/c/src`, which is where the workspace's real raw-pointer code lives. Dropping the one file of generated glue keeps the rule active everywhere it can say something useful.

The 518 existing alerts were dismissed as false positives; this keeps each new indicator from opening another.