### PR TITLE
deps: update chacha20 to 0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",


### PR DESCRIPTION
`chacha20` 0.10.1 was yanked from crates.io on 2026-08-27, so `cargo-deny` now fails its advisories check on every push and pull request:

```
error[yanked]: detected yanked crate (try `cargo update -p chacha20`)
```

The crate is a transitive dependency, reaching the workspace through `tungstenite` -> `tokio-tungstenite` -> `wickra-data`, so every binding inherits it. 0.10.2 was published the same day as the yank and is the drop-in replacement.

`cargo update -p chacha20` moves nothing else: the diff is two lines in `Cargo.lock`. Verified locally with `cargo deny check advisories` (ok, no other yanked or vulnerable crates) and `cargo check --workspace --all-features`.