### PR TITLE
ci: name the pinned r-lib action version accurately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1030,7 +1030,7 @@ jobs:
         run: cargo build -p wickra-c --release
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: "release"
           use-public-rspm: true
@@ -1040,7 +1040,7 @@ jobs:
       # compiling testthat / knitr and their deps from source — the slow, flaky
       # path that previously blew past the job timeout on the ubuntu runner.
       - name: Install R dependencies (cached binaries)
-        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           working-directory: bindings/r
           extra-packages: |


### PR DESCRIPTION
Clears the two open zizmor `ref-version-mismatch` alerts (#639, #640) on `ci.yml`.

Both `r-lib/actions` steps are pinned to `d3c5be51b12e724e68f33216ca3c148b66d5f0b6` with the comment `# v2`. That hash is tag **v2.12.1**; the floating `v2` tag has since moved to `465b7d8e732c`. zizmor flags the pair because the comment claims a version the hash does not correspond to — the pin is fine, the label is not.

Only the comment changes. Moving the pin to whatever `v2` currently points at would be a dependency upgrade, which belongs to Dependabot rather than to a comment fix.

Checked the rest of the workflows for the same shape: `lycheeverse/lychee-action` also carries a bare `# v2`, but there the `v2` tag does point at the pinned `e7477775783e`, so it is correct and untouched.