### PR TITLE
fix(release): restore third-party versions in the npm lockfiles

### DIFF
--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "wickra",
-      "version": "1.0.2",
+      "version": "1.0.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.7.2"
@@ -413,7 +413,7 @@
       "dependencies": {
         "@inquirer/prompts": "^8.5.2",
         "@napi-rs/cross-toolchain": "^1.0.3",
-        "@napi-rs/wasm-tools": "^1.0.2",
+        "@napi-rs/wasm-tools": "^1.0.1",
         "@octokit/rest": "^22.0.1",
         "clipanion": "^4.0.0-rc.4",
         "colorette": "^2.0.20",
@@ -1147,8 +1147,8 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools/-/wasm-tools-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools/-/wasm-tools-1.0.1.tgz",
       "integrity": "sha512-enkZYyuCdo+9jneCPE/0fjIta4wWnvVN9hBo2HuiMpRF0q3lzv1J6b/cl7i0mxZUKhBrV3aCKDBQnCOhwKbPmQ==",
       "dev": true,
       "license": "MIT",
@@ -1156,24 +1156,24 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@napi-rs/wasm-tools-android-arm-eabi": "1.0.2",
-        "@napi-rs/wasm-tools-android-arm64": "1.0.2",
-        "@napi-rs/wasm-tools-darwin-arm64": "1.0.2",
-        "@napi-rs/wasm-tools-darwin-x64": "1.0.2",
-        "@napi-rs/wasm-tools-freebsd-x64": "1.0.2",
-        "@napi-rs/wasm-tools-linux-arm64-gnu": "1.0.2",
-        "@napi-rs/wasm-tools-linux-arm64-musl": "1.0.2",
-        "@napi-rs/wasm-tools-linux-x64-gnu": "1.0.2",
-        "@napi-rs/wasm-tools-linux-x64-musl": "1.0.2",
-        "@napi-rs/wasm-tools-wasm32-wasi": "1.0.2",
-        "@napi-rs/wasm-tools-win32-arm64-msvc": "1.0.2",
-        "@napi-rs/wasm-tools-win32-ia32-msvc": "1.0.2",
-        "@napi-rs/wasm-tools-win32-x64-msvc": "1.0.2"
+        "@napi-rs/wasm-tools-android-arm-eabi": "1.0.1",
+        "@napi-rs/wasm-tools-android-arm64": "1.0.1",
+        "@napi-rs/wasm-tools-darwin-arm64": "1.0.1",
+        "@napi-rs/wasm-tools-darwin-x64": "1.0.1",
+        "@napi-rs/wasm-tools-freebsd-x64": "1.0.1",
+        "@napi-rs/wasm-tools-linux-arm64-gnu": "1.0.1",
+        "@napi-rs/wasm-tools-linux-arm64-musl": "1.0.1",
+        "@napi-rs/wasm-tools-linux-x64-gnu": "1.0.1",
+        "@napi-rs/wasm-tools-linux-x64-musl": "1.0.1",
+        "@napi-rs/wasm-tools-wasm32-wasi": "1.0.1",
+        "@napi-rs/wasm-tools-win32-arm64-msvc": "1.0.1",
+        "@napi-rs/wasm-tools-win32-ia32-msvc": "1.0.1",
+        "@napi-rs/wasm-tools-win32-x64-msvc": "1.0.1"
       }
     },
     "node_modules/@napi-rs/wasm-tools-android-arm-eabi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-android-arm-eabi/-/wasm-tools-android-arm-eabi-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-android-arm-eabi/-/wasm-tools-android-arm-eabi-1.0.1.tgz",
       "integrity": "sha512-lr07E/l571Gft5v4aA1dI8koJEmF1F0UigBbsqg9OWNzg80H3lDPO+auv85y3T/NHE3GirDk7x/D3sLO57vayw==",
       "cpu": [
         "arm"
@@ -1189,8 +1189,8 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-android-arm64/-/wasm-tools-android-arm64-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-android-arm64/-/wasm-tools-android-arm64-1.0.1.tgz",
       "integrity": "sha512-WDR7S+aRLV6LtBJAg5fmjKkTZIdrEnnQxgdsb7Cf8pYiMWBHLU+LC49OUVppQ2YSPY0+GeYm9yuZWW3kLjJ7Bg==",
       "cpu": [
         "arm64"
@@ -1206,8 +1206,8 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-darwin-arm64/-/wasm-tools-darwin-arm64-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-darwin-arm64/-/wasm-tools-darwin-arm64-1.0.1.tgz",
       "integrity": "sha512-qWTI+EEkiN0oIn/N2gQo7+TVYil+AJ20jjuzD2vATS6uIjVz+Updeqmszi7zq7rdFTLp6Ea3/z4kDKIfZwmR9g==",
       "cpu": [
         "arm64"
@@ -1223,8 +1223,8 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-darwin-x64/-/wasm-tools-darwin-x64-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-darwin-x64/-/wasm-tools-darwin-x64-1.0.1.tgz",
       "integrity": "sha512-bA6hubqtHROR5UI3tToAF/c6TDmaAgF0SWgo4rADHtQ4wdn0JeogvOk50gs2TYVhKPE2ZD2+qqt7oBKB+sxW3A==",
       "cpu": [
         "x64"
@@ -1240,8 +1240,8 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-freebsd-x64/-/wasm-tools-freebsd-x64-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-freebsd-x64/-/wasm-tools-freebsd-x64-1.0.1.tgz",
       "integrity": "sha512-90+KLBkD9hZEjPQW1MDfwSt5J1L46EUKacpCZWyRuL6iIEO5CgWU0V/JnEgFsDOGyyYtiTvHc5bUdUTWd4I9Vg==",
       "cpu": [
         "x64"
@@ -1257,8 +1257,8 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-arm64-gnu/-/wasm-tools-linux-arm64-gnu-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-arm64-gnu/-/wasm-tools-linux-arm64-gnu-1.0.1.tgz",
       "integrity": "sha512-rG0QlS65x9K/u3HrKafDf8cFKj5wV2JHGfl8abWgKew0GVPyp6vfsDweOwHbWAjcHtp2LHi6JHoW80/MTHm52Q==",
       "cpu": [
         "arm64"
@@ -1274,8 +1274,8 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-arm64-musl/-/wasm-tools-linux-arm64-musl-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-arm64-musl/-/wasm-tools-linux-arm64-musl-1.0.1.tgz",
       "integrity": "sha512-jAasbIvjZXCgX0TCuEFQr+4D6Lla/3AAVx2LmDuMjgG4xoIXzjKWl7c4chuaD+TI+prWT0X6LJcdzFT+ROKGHQ==",
       "cpu": [
         "arm64"
@@ -1291,8 +1291,8 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools-linux-x64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-x64-gnu/-/wasm-tools-linux-x64-gnu-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-x64-gnu/-/wasm-tools-linux-x64-gnu-1.0.1.tgz",
       "integrity": "sha512-Plgk5rPqqK2nocBGajkMVbGm010Z7dnUgq0wtnYRZbzWWxwWcXfZMPa8EYxrK4eE8SzpI7VlZP1tdVsdjgGwMw==",
       "cpu": [
         "x64"
@@ -1308,8 +1308,8 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-x64-musl/-/wasm-tools-linux-x64-musl-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-linux-x64-musl/-/wasm-tools-linux-x64-musl-1.0.1.tgz",
       "integrity": "sha512-GW7AzGuWxtQkyHknHWYFdR0CHmW6is8rG2Rf4V6GNmMpmwtXt/ItWYWtBe4zqJWycMNazpfZKSw/BpT7/MVCXQ==",
       "cpu": [
         "x64"
@@ -1325,8 +1325,8 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-wasm32-wasi/-/wasm-tools-wasm32-wasi-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-wasm32-wasi/-/wasm-tools-wasm32-wasi-1.0.1.tgz",
       "integrity": "sha512-/nQVSTrqSsn7YdAc2R7Ips/tnw5SPUcl3D7QrXCNGPqjbatIspnaexvaOYNyKMU6xPu+pc0BTnKVmqhlJJCPLA==",
       "cpu": [
         "wasm32"
@@ -1342,8 +1342,8 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-arm64-msvc/-/wasm-tools-win32-arm64-msvc-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-arm64-msvc/-/wasm-tools-win32-arm64-msvc-1.0.1.tgz",
       "integrity": "sha512-PFi7oJIBu5w7Qzh3dwFea3sHRO3pojMsaEnUIy22QvsW+UJfNQwJCryVrpoUt8m4QyZXI+saEq/0r4GwdoHYFQ==",
       "cpu": [
         "arm64"
@@ -1359,8 +1359,8 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools-win32-ia32-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-ia32-msvc/-/wasm-tools-win32-ia32-msvc-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-ia32-msvc/-/wasm-tools-win32-ia32-msvc-1.0.1.tgz",
       "integrity": "sha512-gXkuYzxQsgkj05Zaq+KQTkHIN83dFAwMcTKa2aQcpYPRImFm2AQzEyLtpXmyCWzJ0F9ZYAOmbSyrNew8/us6bw==",
       "cpu": [
         "ia32"
@@ -1376,8 +1376,8 @@
       }
     },
     "node_modules/@napi-rs/wasm-tools-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-x64-msvc/-/wasm-tools-win32-x64-msvc-1.0.2.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-tools-win32-x64-msvc/-/wasm-tools-win32-x64-msvc-1.0.1.tgz",
       "integrity": "sha512-rEAf05nol3e3eei2sRButmgXP+6ATgm0/38MKhz9Isne82T4rPIMYsCIFj0kOisaGeVwoi2fnm7O9oWp5YVnYQ==",
       "cpu": [
         "x64"


### PR DESCRIPTION
Fixes the failing Node jobs on `main`.

The 1.0.1 -> 1.0.2 bump (#410) replaced every occurrence of the old version token in `bindings/node/package-lock.json` and `examples/node/package-lock.json`, including fourteen `@napi-rs/wasm-tools` entries that legitimately sat at 1.0.1. Those versions do not exist on npm:

```
npm error 404 Not Found - GET https://registry.npmjs.org/@napi-rs/wasm-tools/-/wasm-tools-1.0.2.tgz
```

Every Node job fails on `npm ci`, and the same failure took down two Node builds in the v1.0.2 release run. The package is a transitive dependency of `@napi-rs/cli`, so it appears in no `package.json` and `npm install` could not repair it — the lockfile was internally consistent, just wrong.

Both lockfiles are rebuilt from the pre-bump revision with a name-scoped patch: the root `version`, dependency-map entries keyed by a `wickra` package, and `version`/`resolved` inside a `wickra` block. Nineteen replacements in `bindings/node`, seven in `examples/node`, and 43 third-party occurrences left alone. Verified with a clean `npm ci`.

Audited the other twenty bump touchpoints for the same collateral: the Java poms, the csproj, the R `DESCRIPTION` and `pyproject.toml` each changed exactly one line, all ours. The lockfiles were the only files carrying third-party versions.

The bump tool is fixed separately (`kingchenc/wickra-script-helpers@ab92777`) so this cannot recur: npm manifests now go through a structural patcher, and every other format refuses any line that names a package which is not ours.