### PR TITLE
fix(node): stop shipping platform binaries in the main npm package

### DIFF
--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -25,9 +25,7 @@
   "homepage": "https://github.com/wickra-lib/wickra",
   "files": [
     "index.js",
-    "index.d.ts",
-    "npm",
-    "*.node"
+    "index.d.ts"
   ],
   "napi": {
     "binaryName": "wickra",


### PR DESCRIPTION
The published `wickra` package weighs **98.64 MB unpacked across 22 files**. The six platform packages it delegates to occupy 49.18 MB on npm in total — exactly half. Every binary ships twice.

## Cause

`files` listed both `npm` and `*.node`. `napi artifacts` fills `npm/<rid>/` with the freshly built binary for each of the six targets before publish, and a copy of each also sits in the package root, so both entries pull in the full set:

```
 6 x wickra.<rid>.node            (package root, via *.node)
 6 x npm/<rid>/wickra.<rid>.node  (scaffolding dir, via npm)
 6 x npm/<rid>/package.json
 4 x index.js, index.d.ts, package.json, README.md
──
22
```

## Why it is dead weight

`index.js` resolves `./wickra.<rid>.node` first and only falls back to the `wickra-<rid>` optional dependency. The bundled copy always wins, so the platform package npm downloads alongside it is never loaded. `npm install wickra` transfers the entire matrix plus one unused platform package.

For scale, comparable napi-rs projects using the same platform-package mechanism:

| Package | Unpacked |
|---|---|
| @node-rs/argon2 | 0.04 MB |
| @napi-rs/canvas | 0.12 MB |
| @swc/core | 0.13 MB |
| lightningcss | 0.49 MB |
| **wickra** | **98.64 MB** |

## Fix

Dropping only `npm` would have halved the package rather than fixed it, so both entries go. What remains is `index.js`, `index.d.ts`, `package.json` and the README npm always includes.

```
npm pack --dry-run   11.1 MB / 11 files  ->  257.2 kB / 4 files
```

The local root holds one binary; CI holds six, so the published delta is the full 98.64 MB -> ~257 kB.

## Verification

- `files` governs packing only — the platform packages carry their own `files: ["wickra.<rid>.node"]` and are published and packed from `npm/<rid>/` on disk, which `release.yml` reaches directly. Nothing in the release path reads the main package's file list.
- `index.js` contains no reference to `./npm/`; its only mention of the directory name is a URL inside an error message.
- The 1633 Node tests pass unchanged — local resolution is not affected by `files`.

Takes effect with the next release; `wickra@1.0.2` on npm stays as it is.
