### PR TITLE
ci: pass the repository slug to the Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,11 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: lcov.info
-          fail_ci_if_error: false
+          # An organization-level upload token carries no repository identity,
+          # so Codecov cannot route the upload without an explicit slug and
+          # falls back to a tokenless upload, which a protected branch rejects.
+          slug: ${{ github.repository }}
+          fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Coverage uploads have been failing in **every** repository since the switch to an organization-level Codecov token — this one included.

```
Token length: 50
Upload queued for processing failed: {"message":"Token required because branch is protected"}
```

## Cause

A repository token identifies its target; an organization token does not. Without a slug Codecov cannot route the upload, treats it as tokenless, and rejects it because `main` is a protected branch. The action documents the requirement in its own input description:

> `slug` — [Required when using the org token] Set to the owner/repo slug used instead of the private repo token.

The GitHub App is not the problem: `codecov` is installed on the organization with `repository_selection=all`. Nor is onboarding — Codecov reports this repository as `active=true, activated=true`.

## Timeline

| | |
|---|---|
| last recorded coverage | 2026-08-28T00:11Z |
| CI run at 19:57Z the same day | upload rejected |
| Codecov headline figure | 99.02%, stale since |

## Why `fail_ci_if_error` flips too

The upload has been failing for a day while the job reported `success`. That is exactly what kept this hidden, and it would hide the next breakage just as well.

## Scope

22 further repositories carry the same Codecov step and the same defect. They follow once this run confirms the fix, rather than changing 23 repositories on an unverified assumption — with `fail_ci_if_error: true` a wrong guess would turn every repository's CI red at once.
