### PR TITLE
ci: attach the NuGet package and the Java jar to the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -661,9 +661,9 @@ jobs:
           path: wickra-c-${{ matrix.target }}.tar.gz
           if-no-files-found: error
 
-  # Pack and publish the .NET binding to NuGet. Independent of the GitHub-release
-  # job so a C# hiccup never blocks the C/C++ asset release. Authentication uses
-  # NuGet Trusted Publishing (OIDC) — no long-lived API key. The 'wickra-release'
+  # Pack and publish the .NET binding to NuGet. The nupkg it packs is uploaded as
+  # a build artifact so github-release can attach it. Authentication uses NuGet
+  # Trusted Publishing (OIDC) — no long-lived API key. The 'wickra-release'
   # trusted-publishing policy on nuget.org (owner KingchenC, repo wickra-lib/wickra,
   # workflow release.yml) exchanges the GitHub OIDC token for a short-lived key.
   csharp-publish:
@@ -763,12 +763,13 @@ jobs:
           path: nupkg/*.nupkg
           if-no-files-found: error
 
-  # Publish the Java binding to Maven Central. Independent of the GitHub-release
-  # job so a Java hiccup never blocks the C/C++ asset release. The Maven Central
-  # namespace (org.wickra) is verified; authentication uses the Sonatype Central
-  # Portal token (CENTRAL_USERNAME / CENTRAL_PASSWORD) and artifacts are signed
-  # with the GPG key (GPG_PRIVATE_KEY / GPG_PASSPHRASE). The pom version must
-  # match the release tag (kept in sync by the version-bump checklist).
+  # Publish the Java binding to Maven Central. The jar this job packages is also
+  # uploaded as a build artifact so github-release can attach the very file Maven
+  # Central received. The Maven Central namespace (org.wickra) is verified;
+  # authentication uses the Sonatype Central Portal token (CENTRAL_USERNAME /
+  # CENTRAL_PASSWORD) and artifacts are signed with the GPG key (GPG_PRIVATE_KEY
+  # / GPG_PASSPHRASE). The pom version must match the release tag (kept in sync
+  # by the version-bump checklist).
   java-publish:
     name: Publish to Maven Central
     timeout-minutes: 45 # backstop only: release build/publish jobs compile from source (vendored OpenSSL) and must not be killed mid-build; far above the ~10 min real runtime
@@ -833,12 +834,27 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: mvn -B -f bindings/java -Prelease deploy -DskipTests
 
+      # `deploy` packages before it uploads, so the signed jar is already under
+      # target/. Only the main artefact is kept: the sources and javadoc jars
+      # belong on Maven Central, where a build tool resolves them on demand, and
+      # would only pad the release page.
+      - name: Upload the Java jar as a build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: java-jar
+          path: |
+            bindings/java/target/*.jar
+            !bindings/java/target/*-sources.jar
+            !bindings/java/target/*-javadoc.jar
+          if-no-files-found: error
+
   # Mirror the in-repo Go module (bindings/go) to the standalone wickra-go
   # repository so `go get github.com/wickra-lib/wickra-go` builds with no extra
   # steps. The in-repo module keeps the prebuilt libraries git-ignored; the
   # mirror commits them per platform under lib/<goos>_<goarch>/ alongside the
-  # vendored header. Independent of the GitHub-release job so a Go hiccup never
-  # blocks the C/C++ asset release. The push uses a fine-grained PAT
+  # vendored header. Produces no asset, but the release notes tell readers the
+  # Go module is live, so github-release waits on it rather than saying so ahead
+  # of time. The push uses a fine-grained PAT
   # (GO_MIRROR_TOKEN, contents:write on wickra-go); the mirror is a
   # derived artifact, so its bot commit is intentionally unsigned.
   go-mirror:
@@ -928,7 +944,22 @@ jobs:
   github-release:
     name: Attach assets to the draft GitHub Release
     timeout-minutes: 45 # backstop only: release build/publish jobs compile from source (vendored OpenSSL) and must not be killed mid-build; far above the ~10 min real runtime
-    needs: [cargo-publish, python-publish, node-publish, wasm-publish, c-abi-build]
+    # Every job that either produces an asset staged below or publishes something
+    # the release notes claim. csharp-publish and java-publish upload the nupkg
+    # and the jar this job stages, so without the dependency the release was
+    # assembled before those files existed and, with fail_on_unmatched_files
+    # false, shipped without them in silence. go-mirror produces no asset, but
+    # the notes tell readers the Go module is live -- a release should not say so
+    # before it is.
+    needs:
+      - cargo-publish
+      - python-publish
+      - node-publish
+      - wasm-publish
+      - c-abi-build
+      - csharp-publish
+      - java-publish
+      - go-mirror
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -988,6 +1019,10 @@ jobs:
           find artifacts -type f -name "*.crate" -exec cp {} release-assets/ \;
           # CycloneDX SBOMs (one per published crate).
           find artifacts -type f -name "*.cdx.json" -exec cp {} release-assets/ \;
+          # NuGet package (the same file pushed to nuget.org).
+          find artifacts -type f -name "*.nupkg" -exec cp {} release-assets/ \;
+          # Java jar (the same file deployed to Maven Central).
+          find artifacts -type f -name "*.jar" -exec cp {} release-assets/ \;
           ls -lh release-assets/
           echo "asset-count=$(ls release-assets/ | wc -l)"
 
@@ -1031,9 +1066,9 @@ jobs:
             ### Attached assets
 
             Pre-built artefacts for every supported platform — the same files this
-            workflow run published to crates.io, PyPI, and npm. C# ships to NuGet,
-            Java to Maven Central, Go to the wickra-go module, and R to r-universe
-            via their own release jobs.
+            workflow run published to crates.io, PyPI, npm, NuGet and Maven
+            Central. Go ships to the wickra-go module and R to r-universe via
+            their own release jobs.
 
             - `*.whl` / `wickra-*.tar.gz` — Python wheels + sdist (5 platforms, ABI3 ≥ 3.9)
             - `wickra.*.node` — native Node.js bindings (linux-x64-gnu, darwin-x64,
@@ -1043,6 +1078,9 @@ jobs:
             - `wickra-c-<target>.tar.gz` — C ABI: `include/wickra.h` + `wickra.hpp`
               and the cdylib/staticlib per target (linux/macos/windows × x64/arm64),
               the hub for C, C++, C#, Go, Java and R
+            - `Wickra.<version>.nupkg` — the .NET package as pushed to nuget.org
+            - `wickra-<version>.jar` — the Java binding as deployed to Maven
+              Central, natives for all six platforms bundled in
 
             ### Auto-generated changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Every release since the .NET binding shipped attached the package to
+  nuget.org but not to the release page.** `csharp-publish` packs the package,
+  pushes it, and uploads it as a build artifact -- and the staging step in
+  `github-release` listed six `find` patterns, none of which matched `*.nupkg`,
+  so the file was downloaded with the rest and then left behind. With
+  `fail_on_unmatched_files` false nothing reported it. `v1.0.3` carries 36
+  assets -- wheels, sdist, `.node` binaries, npm tarballs, `.crate` files and
+  SBOMs -- and NuGet was the one registry artefact with no counterpart there.
+  The registry was never affected: all 28 published versions are on nuget.org.
+
+- **The release could be published before NuGet, Maven Central and the Go module
+  were.** `github-release` waited on five of the eight publishing jobs, so the
+  three that ship to those three destinations could still be running -- or
+  failing -- while the release notes already told readers they were live. It now
+  waits on all eight: `csharp-publish` and `java-publish` because it stages the
+  files they upload, `go-mirror` because the notes claim the Go module is
+  available.
+
+### Added
+
+- The Java jar is attached to the GitHub Release. `java-publish` stages the
+  native libraries for all six platforms into the binding's resources, deploys
+  to Maven Central, and now also uploads the packaged jar, so the release page
+  carries the same file Maven Central received. The sources and javadoc jars
+  stay on Maven Central, where a build tool resolves them on demand.
+
 ## [1.0.3] - 2026-08-28
 
 ### Fixed


### PR DESCRIPTION
## What was wrong

`csharp-publish` packs the .NET package, pushes it to nuget.org and uploads it as a build artifact. The staging step in `github-release` listed six `find` patterns — `*.whl`, `*.tar.gz`, `*.node`, `wickra-*.tgz`, `*.crate`, `*.cdx.json` — and none of them matched `*.nupkg`. The file was downloaded with everything else and then left behind. With `fail_on_unmatched_files` set to false, nothing reported it.

`v1.0.3` carries 36 assets: 8 wheels, 1 sdist, 6 C ABI tarballs, 6 `.node` binaries, 8 npm tarballs, 3 crates, 3 SBOMs and the provenance bundle. NuGet was the one registry artefact with no counterpart among them. The registry itself was never affected — all 28 published versions are on nuget.org.

`java-publish` deployed to Maven Central without uploading anything at all, so the jar had no counterpart either. Of six registries, two had nothing on the release page.

## What changed

- `java-publish` uploads the packaged jar. The natives for all six platforms are already staged into `src/main/resources/native/` before the deploy, so the uploaded file is the one Maven Central received. The sources and javadoc jars are excluded — a build tool resolves those from Maven Central on demand, and on the release page they would only add noise.
- `github-release` stages `*.nupkg` and `*.jar` alongside the existing six patterns.
- `github-release` waits on all eight publishing jobs instead of five. `csharp-publish` and `java-publish` because it now stages the files they upload; `go-mirror` because the release notes tell readers the Go module is live, and a release should not say so before it is.
- The three job comments claimed the opposite — that staying out of the dependency graph kept a C#, Java or Go hiccup from blocking the C/C++ asset release. They now describe what the code does.
- The "Attached assets" section of the release body lists both new files.

## Effect on failure handling

This is a deliberate trade. Previously a failing NuGet, Maven or Go job still produced a published release whose notes claimed all three were live. Now the release is not published unless every publishing job succeeded, which is what `publish-release` was meant to gate on.

`wickra-backtest` already worked this way and documented the reasoning; this brings the two repositories back in line.

## Verification

`release.yml` parses; the resolved `github-release.needs` is the intended eight-job list, and `java-publish` ends on the upload step. The workflow only runs on a `v*` tag, so the next release is the first live exercise — expect 38 assets rather than 36.