### PR TITLE
ci: lint the workflows for correctness, not only for security

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,53 @@
+name: actionlint
+
+# Correctness of the workflow files, which is the half zizmor does not cover.
+# zizmor reads them for security -- template injection, over-broad tokens,
+# unpinned actions. actionlint reads them for whether they work at all: unknown
+# `${{ }}` contexts, wrong event properties, invalid `needs` references, matrix
+# keys that no job uses, and -- through its bundled shellcheck -- errors inside
+# every `run:` block. This repository has around 2,400 lines of workflow and
+# several hundred lines of shell inside them; none of it was being checked.
+#
+# The binary is fetched from the upstream release and verified against the
+# checksum published with it. taiki-e/install-action has no actionlint manifest
+# and the project ships no action of its own, so the alternatives were a
+# third-party wrapper action or a docker pull; a pinned download with a verified
+# hash adds no supply-chain dependency at all, which is the same reasoning that
+# put cargo-deny behind a direct call rather than an action.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    timeout-minutes: 10 # backstop against a hung job, not a budget
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install actionlint
+        env:
+          VERSION: "1.7.12"
+          SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          set -euo pipefail
+          file="actionlint_${VERSION}_linux_amd64.tar.gz"
+          curl -fsSL --retry 5 --retry-all-errors -o "$file" \
+            "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/${file}"
+          echo "${SHA256}  ${file}" | sha256sum -c -
+          tar -xzf "$file" actionlint
+          ./actionlint --version
+
+      # shellcheck is preinstalled on the GitHub runners, so actionlint picks it
+      # up and lints the shell inside every `run:` block as well.
+      - name: Lint
+        run: ./actionlint -color

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,17 @@ jobs:
       # treat that as success so re-runs of the workflow don't fail.
       - name: Publish wickra-core (idempotent)
         run: |
-          out=$(cargo publish -p wickra-core --token "$CARGO_REGISTRY_TOKEN" 2>&1) && echo "$out" \
-            || (echo "$out" | grep -q "already uploaded\|already exists" && echo "skip: already published" \
-                || (echo "$out"; exit 1))
+          # if/then rather than `A && B || C`: that form runs C when B fails, not
+          # only when A does, so a failing echo would read as a failed publish
+          # (shellcheck SC2015).
+          if out=$(cargo publish -p wickra-core --token "$CARGO_REGISTRY_TOKEN" 2>&1); then
+            echo "$out"
+          elif printf '%s' "$out" | grep -q "already uploaded\|already exists"; then
+            echo "skip: already published"
+          else
+            echo "$out"
+            exit 1
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -69,9 +77,17 @@ jobs:
 
       - name: Publish wickra-data (idempotent)
         run: |
-          out=$(cargo publish -p wickra-data --token "$CARGO_REGISTRY_TOKEN" 2>&1) && echo "$out" \
-            || (echo "$out" | grep -q "already uploaded\|already exists" && echo "skip: already published" \
-                || (echo "$out"; exit 1))
+          # if/then rather than `A && B || C`: that form runs C when B fails, not
+          # only when A does, so a failing echo would read as a failed publish
+          # (shellcheck SC2015).
+          if out=$(cargo publish -p wickra-data --token "$CARGO_REGISTRY_TOKEN" 2>&1); then
+            echo "$out"
+          elif printf '%s' "$out" | grep -q "already uploaded\|already exists"; then
+            echo "skip: already published"
+          else
+            echo "$out"
+            exit 1
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -80,9 +96,17 @@ jobs:
 
       - name: Publish wickra (idempotent)
         run: |
-          out=$(cargo publish -p wickra --token "$CARGO_REGISTRY_TOKEN" 2>&1) && echo "$out" \
-            || (echo "$out" | grep -q "already uploaded\|already exists" && echo "skip: already published" \
-                || (echo "$out"; exit 1))
+          # if/then rather than `A && B || C`: that form runs C when B fails, not
+          # only when A does, so a failing echo would read as a failed publish
+          # (shellcheck SC2015).
+          if out=$(cargo publish -p wickra --token "$CARGO_REGISTRY_TOKEN" 2>&1); then
+            echo "$out"
+          elif printf '%s' "$out" | grep -q "already uploaded\|already exists"; then
+            echo "skip: already published"
+          else
+            echo "$out"
+            exit 1
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -404,7 +428,8 @@ jobs:
           fail=0
           publish_dir() {
             local dir=$1
-            local pkg=$(basename "$dir")
+            local pkg
+            pkg=$(basename "$dir")
             local pkgname="wickra-$pkg"
             local existing
             existing=$(npm view "$pkgname@$version" version 2>/dev/null)
@@ -589,9 +614,17 @@ jobs:
       - name: Publish wickra-wasm to npm (idempotent)
         working-directory: bindings/wasm/pkg
         run: |
-          out=$(npm publish --access public --provenance 2>&1) && echo "$out" \
-            || (echo "$out" | grep -q "You cannot publish over" && echo "skip: version already on npm" \
-                || (echo "$out"; exit 1))
+          # if/then rather than `A && B || C`: that form runs C when B fails, not
+          # only when A does, so a failing echo would read as a failed publish
+          # (shellcheck SC2015).
+          if out=$(npm publish --access public --provenance 2>&1); then
+            echo "$out"
+          elif printf '%s' "$out" | grep -q "You cannot publish over"; then
+            echo "skip: version already on npm"
+          else
+            echo "$out"
+            exit 1
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -1024,7 +1057,7 @@ jobs:
           # Java jar (the same file deployed to Maven Central).
           find artifacts -type f -name "*.jar" -exec cp {} release-assets/ \;
           ls -lh release-assets/
-          echo "asset-count=$(ls release-assets/ | wc -l)"
+          echo "asset-count=$(find release-assets -type f | wc -l)"
 
       - name: Create / update the draft GitHub Release with assets
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **actionlint checks the workflows for correctness**, which is the half zizmor
+  does not cover. zizmor reads them for security -- template injection,
+  over-broad tokens, unpinned actions. actionlint reads them for whether they
+  work at all: unknown `${{ }}` contexts, wrong event properties, invalid
+  `needs` references, and, through its bundled shellcheck, errors inside every
+  `run:` block. There are around 2,400 lines of workflow here with several
+  hundred lines of shell inside them, and none of it was being checked.
+
+  The binary is fetched from the upstream release and verified against the
+  published checksum. `taiki-e/install-action` carries no actionlint manifest
+  and the project ships no action of its own, so the alternatives were a
+  third-party wrapper or a docker pull; a pinned download with a verified hash
+  adds no supply-chain dependency at all.
+
 ### Changed
 
 - **The indicator count is no longer pushed into four other repositories.**


### PR DESCRIPTION
## Why

`zizmor` reads the workflow files for **security** — template injection, over-broad tokens, unpinned actions. Nothing reads them for **correctness**: unknown `${{ }}` contexts, wrong event properties, invalid `needs` references, matrix keys no job uses.

There are around 2,400 lines of workflow here, and several hundred lines of shell inside `run:` blocks that nothing checked either. actionlint runs shellcheck over those as part of its pass — shellcheck is preinstalled on the runners, so it picks it up automatically.

The two tools pair rather than overlap.

## How it is installed

The binary comes from the upstream release and is verified against the checksum published with it.

`taiki-e/install-action` carries no actionlint manifest (checked: 103 manifests, none for it) and the project ships no action of its own. That left a third-party wrapper action, a docker pull, or a pinned download with a verified hash. The last adds **no supply-chain dependency at all** — the same reasoning that put `cargo-deny` behind a direct call in `wickra-backtest` rather than an action.

Pinned to `v1.7.12` with its SHA-256; bumping it is a two-line change with the checksum from the release page.

## What it found locally

**Zero errors across all eleven workflow files.** The syntax side is already clean.

The shellcheck half could not run here — shellcheck is not installed on this machine, and actionlint reports `Rule "shellcheck" was disabled` rather than silently skipping. Whatever it finds will appear on this PR, which is the point of landing the check before the findings.

Negative-tested to confirm the tool actually reports: a scratch file with `github.evnt_name` and a `needs:` on a non-existent job produced both diagnostics as expected.