### PR TITLE
ci: check the published API against its last release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,44 @@ jobs:
         with:
           command: check
 
+  # The published API is a promise. wickra-core, wickra-data and wickra are on
+  # crates.io, and since 1.0.0 the version number says what may change: a patch
+  # release must not move the public surface. Nothing checked that, and the
+  # surface is 514 exported types that ten language bindings sit on top of --
+  # exactly the shape where a rename slips through review and out to six
+  # registries in one irreversible run.
+  #
+  # The baseline is the newest version already on crates.io, fetched by the tool
+  # itself. On a release that has not moved the API this finds nothing; the run
+  # that matters is the one where it does.
+  semver:
+    name: Public API (cargo-semver-checks)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30 # backstop: it builds rustdoc JSON for each crate and its baseline
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/setup-rust
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
+      - name: Install cargo-semver-checks
+        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
+        timeout-minutes: 10 # fail fast on a stuck download instead of hanging the job
+        with:
+          tool: cargo-semver-checks
+
+      # Named explicitly rather than --workspace: wickra-bench and the binding
+      # crates are not published, so they have no baseline to compare against and
+      # nothing to promise.
+      - name: Check the published crates
+        run: |
+          cargo semver-checks check-release             -p wickra-core             -p wickra-data             -p wickra
+
   # Time-boxed fuzz smoke. Each target runs for ~30 s with libfuzzer; any panic
   # fails the job. The goal is to catch a regression in the harness (e.g. a
   # newly added indicator that panics on a particular input shape), not to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cargo-semver-checks` guards the published API.** `wickra-core`,
+  `wickra-data` and `wickra` are on crates.io, and since 1.0.0 the version
+  number is a promise: a patch release must not move the public surface. Nothing
+  checked that. The surface is 514 exported types with ten language bindings on
+  top of it -- exactly the shape where a rename slips past review and out to six
+  registries in one run that cannot be undone.
+
+  The baseline is the newest version already on crates.io, fetched by the tool.
+  The three crates are named explicitly rather than `--workspace`: the bench and
+  binding crates are unpublished, so they have no baseline and make no promise.
+
 - **actionlint checks the workflows for correctness**, which is the half zizmor
   does not cover. zizmor reads them for security -- template injection,
   over-broad tokens, unpinned actions. actionlint reads them for whether they


### PR DESCRIPTION
## Why

`wickra-core`, `wickra-data` and `wickra` are on crates.io, and since **1.0.0 the version number is a promise**: a patch release must not move the public surface.

Nothing checked it. The surface is **514 exported types** that ten language bindings sit on top of, and a tag publishes to six registries in one run that cannot be undone halfway. A rename that slips past review is not something to find out about from a downstream bug report.

## How the baseline works

`cargo-semver-checks` fetches the newest version already on crates.io and compares the working tree against it. No version is pinned here — the check moves with each release on its own.

On a change that does not touch the API it finds nothing. The run that matters is the one where it does.

## Why these three crates, named explicitly

`--workspace` would include `wickra-bench` and the binding crates. Those are unpublished: no baseline to compare against, and no promise to keep.

## Why in `ci.yml` rather than its own workflow

It is a cargo check on the code, so it belongs beside `supply-chain` (cargo-deny), not with the repository auditors like zizmor, CodeQL and actionlint. It also reuses the toolchain setup and cargo cache the other Rust jobs already have.

Installed through `taiki-e/install-action`, which already carries `cargo-llvm-cov` and `cargo-fuzz` here and has a manifest for this one — no new action, no unpinned download.

## Expected result on this PR

Main is at the released 1.0.3 and this PR changes no Rust code, so the check should pass with nothing to report. If it does find something, that is a pre-existing divergence between `main` and what was published — worth knowing either way.