### PR TITLE
ci: analyse the C# binding with CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -19,5 +19,20 @@
 # `bindings/c/src`, which is where the workspace's real raw-pointer code
 # lives. Dropping this one file of generated glue keeps the rule active
 # everywhere it can say something useful.
+#
+# The C# binding is generated the same way and for the same reason: one class
+# per catalogue entry, emitted from the C header. Indicators.g.cs and
+# NativeMethods.g.cs are 79,000 lines of P/Invoke declarations and one-line
+# delegating methods between them, and GoldenAllTests.g.cs is a test per entry.
+# Excluding them leaves exactly the part worth reading -- WickraHandle.cs and
+# WickraNative.cs, where the handle lifetime and the native library resolution
+# actually live, plus the hand-written tests and examples.
+#
+# The rule for adding to this list: a path belongs here when a generator owns
+# the file end to end and stamps it as such, never because a finding in it was
+# inconvenient.
 paths-ignore:
   - bindings/node/src/lib.rs
+  - bindings/csharp/Wickra/Generated/Indicators.g.cs
+  - bindings/csharp/Wickra/Generated/NativeMethods.g.cs
+  - bindings/csharp/Wickra.Tests/GoldenAllTests.g.cs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,12 @@ jobs:
             build-mode: none
           - language: javascript-typescript
             build-mode: none
+          # C# analyses without a build too. The binding is a P/Invoke surface
+          # over the C ABI: manual handle lifetimes, a Cleaner-equivalent
+          # Dispose, and native library resolution -- the places where a leak or
+          # a use-after-free would live, and the only ones CodeQL had no view of.
+          - language: csharp
+            build-mode: none
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CodeQL analyses the C# binding.** The matrix covered Rust, Python and
+  JavaScript/TypeScript; C# was the largest surface it had no view of, and the
+  one where a memory mistake is possible at all -- `WickraHandle.cs` and
+  `WickraNative.cs` carry manual handle lifetimes, disposal, and native library
+  resolution over the C ABI.
+
+  The three generated files are excluded first, not triaged afterwards.
+  `Indicators.g.cs` and `NativeMethods.g.cs` are 79,000 lines of P/Invoke
+  declarations and one-line delegating methods emitted from the C header, and
+  `GoldenAllTests.g.cs` is one test per catalogue entry. Turning the language on
+  without excluding them would have repeated what the napi glue did once
+  already: 518 findings at once, one per exported class, none of them about
+  anything anyone wrote.
+
 - **`cargo-semver-checks` guards the published API.** `wickra-core`,
   `wickra-data` and `wickra` are on crates.io, and since 1.0.0 the version
   number is a promise: a patch release must not move the public surface. Nothing


### PR DESCRIPTION
## Why C# first

The matrix covers Rust, Python and JavaScript/TypeScript. C# is the largest surface it has no view of — and the one where a memory mistake is possible at all.

`WickraHandle.cs` and `WickraNative.cs` carry manual handle lifetimes, disposal and native library resolution over the C ABI. That is where a leak or a use-after-free would live, and nothing had ever read them.

**No build required.** C# analyses in `build-mode: none`, like the three already there, so this costs one job and no compile.

## The generated files are excluded first, not triaged afterwards

| File | Lines | What it is |
|---|---|---|
| `Wickra/Generated/Indicators.g.cs` | ~40k | one class per catalogue entry |
| `Wickra/Generated/NativeMethods.g.cs` | ~40k | P/Invoke declarations from the C header |
| `Wickra.Tests/GoldenAllTests.g.cs` | — | one test per entry |

Together **79,537 lines** of generated glue.

Turning the language on without excluding them would have repeated exactly what the napi binding did once already: **518 findings in a single run**, one per exported class, none of them about code anyone wrote. That is why `codeql-config.yml` exists.

What remains is **23 hand-written files** — the handle layer, the tests, and the examples. Which is the whole point of enabling it.

## A rule for the ignore list

The config now says when a path belongs there:

> a generator owns the file end to end and stamps it as such — never because a finding in it was inconvenient

Each of the three carries that stamp; the Java and Go generators do the same, which is what makes the same treatment possible for them later.

## What to expect on this PR

The first analysis of 23 previously unread files. If it finds nothing, the handle layer is in better shape than most P/Invoke code. If it finds something, it is worth knowing — that is the reason for the PR.

Java is the obvious next one, on the same pattern: ~620 of its 636 files carry `// Generated from bindings/c/include/wickra.h. Do not edit by hand.` Go and C/C++ are deliberately left out — Go would need a full Rust release build to analyse 19 files that are mostly tests.