### PR TITLE
ci: analyse the C# and Java bindings with CodeQL, compiled

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -36,3 +36,13 @@ paths-ignore:
   - bindings/csharp/Wickra/Generated/Indicators.g.cs
   - bindings/csharp/Wickra/Generated/NativeMethods.g.cs
   - bindings/csharp/Wickra.Tests/GoldenAllTests.g.cs
+  # Java, same generator and the same stamp: 624 classes directly under
+  # org/wickra/ plus internal/NativeMethods.java, all emitted from the C header
+  # and all carrying "Do not edit by hand". 37,900 lines between them.
+  #
+  # Two files in the binding are written by a person and stay in the analysis:
+  # internal/WickraNative.java, which owns the FFI arena, the Cleaner and the
+  # library lookup, and every test under src/test. Those are the only places a
+  # Java memory mistake can originate here.
+  - bindings/java/src/main/java/org/wickra/*.java
+  - bindings/java/src/main/java/org/wickra/internal/NativeMethods.java

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,13 @@ jobs:
           # a use-after-free would live, and the only ones CodeQL had no view of.
           - language: csharp
             build-mode: none
+          # Java analyses without a build as well. The binding reaches the C ABI
+          # through java.lang.foreign: an Arena per handle, a Cleaner to release
+          # it, and manual marshalling. That is where a leak or a use-after-free
+          # would come from, and 624 of the 636 files around it are generated and
+          # excluded, so what is scanned is the part a person wrote.
+          - language: java-kotlin
+            build-mode: none
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,24 +39,40 @@ jobs:
             build-mode: none
           - language: javascript-typescript
             build-mode: none
-          # C# analyses without a build too. The binding is a P/Invoke surface
-          # over the C ABI: manual handle lifetimes, a Cleaner-equivalent
-          # Dispose, and native library resolution -- the places where a leak or
-          # a use-after-free would live, and the only ones CodeQL had no view of.
+          # C# and Java are compiled with an explicit command rather than read as
+          # source. `build-mode: none` was tried first and GitHub reported the
+          # result as low quality: 64% of C# calls resolved to a target against a
+          # threshold of 85%. Two causes, and the second was self-inflicted --
+          # without a build no dependency resolves, and paths-ignore keeps the
+          # excluded generated files out of the database entirely, so the
+          # hand-written code that calls into them pointed at nothing.
+          #
+          # Building fixes both at once: the generated code compiles, so the calls
+          # resolve, while paths-ignore still filters its findings out of the
+          # results. High resolution and no flood, rather than one or the other.
+          #
+          # `manual` over `autobuild`: this repository has several C# projects and
+          # two Maven trees, and guessing which to build is how a scan ends up
+          # quietly covering the wrong one.
           - language: csharp
-            build-mode: none
-          # Java analyses without a build as well. The binding reaches the C ABI
-          # through java.lang.foreign: an Arena per handle, a Cleaner to release
-          # it, and manual marshalling. That is where a leak or a use-after-free
-          # would come from, and 624 of the 636 files around it are generated and
-          # excluded, so what is scanned is the part a person wrote.
+            build-mode: manual
           - language: java-kotlin
-            build-mode: none
+            build-mode: manual
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      # Only the Java build needs this, and it needs a newer JDK than the
+      # runner default: the binding targets java.lang.foreign and the pom sets
+      # release 22.
+      - name: Set up JDK 25
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: "25"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
@@ -64,6 +80,24 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: .github/codeql/codeql-config.yml
+
+      # Spelled out per language rather than driven from a matrix field: a
+      # `run:` that expands a template is the shape zizmor flags, and two
+      # explicit steps read better than one indirect one.
+      #
+      # The test project is built rather than the library alone -- it pulls the
+      # library in by reference and adds the hand-written tests, which is most
+      # of what is left after the exclusions.
+      - name: Build the C# binding
+        if: matrix.language == 'csharp'
+        run: dotnet build bindings/csharp/Wickra.Tests/Wickra.Tests.csproj -c Release
+
+      # test-compile, not compile: it builds the hand-written tests too, and
+      # they are ten of the eleven files left after the exclusions. -DskipTests
+      # because CodeQL needs the code compiled, not exercised.
+      - name: Build the Java binding
+        if: matrix.language == 'java-kotlin'
+        run: mvn -B -f bindings/java test-compile -DskipTests
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   third-party wrapper or a docker pull; a pinned download with a verified hash
   adds no supply-chain dependency at all.
 
+- The Java jar is attached to the GitHub Release. `java-publish` stages the
+  native libraries for all six platforms into the binding's resources, deploys
+  to Maven Central, and now also uploads the packaged jar, so the release page
+  carries the same file Maven Central received. The sources and javadoc jars
+  stay on Maven Central, where a build tool resolves them on demand.
+
 ### Changed
 
 - **The indicator count is no longer pushed into four other repositories.**
@@ -114,14 +120,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   waits on all eight: `csharp-publish` and `java-publish` because it stages the
   files they upload, `go-mirror` because the notes claim the Go module is
   available.
-
-### Added
-
-- The Java jar is attached to the GitHub Release. `java-publish` stages the
-  native libraries for all six platforms into the binding's resources, deploys
-  to Maven Central, and now also uploads the packaged jar, so the release page
-  carries the same file Maven Central received. The sources and javadoc jars
-  stay on Maven Central, where a build tool resolves them on demand.
 
 ## [1.0.3] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CodeQL analyses the Java binding.** The binding reaches the C ABI through
+  `java.lang.foreign` -- an `Arena` per handle, a `Cleaner` to release it, and
+  manual marshalling -- and none of it had ever been read by a static analyser.
+  No build is needed; `build-mode: none` covers Java as it does C#.
+
+  624 of the 636 files are generated from the C header and carry
+  `Do not edit by hand`, so they are excluded before the language is enabled
+  rather than dismissed afterwards. What stays in the analysis is
+  `internal/WickraNative.java`, which owns the arena, the cleaner and the library
+  lookup, plus the ten hand-written tests. That is the whole surface where a
+  Java-side leak or use-after-free could originate.
+
 - **CodeQL analyses the C# binding.** The matrix covered Rust, Python and
   JavaScript/TypeScript; C# was the largest surface it had no view of, and the
   one where a memory mistake is possible at all -- `WickraHandle.cs` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CodeQL analyses the C# and Java bindings**, both compiled rather than read
+  as source. The first C# pass ran with `build-mode: none` and GitHub reported
+  the result as low quality: 64% of calls resolved to a target against a
+  threshold of 85%. Two causes, and the second was self-inflicted -- without a
+  build no dependency resolves, and `paths-ignore` keeps the excluded generated
+  files out of the database entirely, so the hand-written code that calls into
+  them pointed at nothing. Building fixes both: the generated code compiles so
+  the calls resolve, while `paths-ignore` still filters its findings out of the
+  results.
+
 - **CodeQL analyses the Java binding.** The binding reaches the C ABI through
   `java.lang.foreign` -- an `Arena` per handle, a `Cleaner` to release it, and
   manual marshalling -- and none of it had ever been read by a static analyser.


### PR DESCRIPTION
## What this does

Adds Java to the CodeQL matrix, and switches **both** Java and C# from `build-mode: none` to a compiled analysis.

## Why compiled, and why that is a correction

The C# pass merged in #420 ran with `build-mode: none` and reported zero findings. GitHub then flagged the analysis itself:

```
Percentage of calls with call target:      64 %  (threshold 85 %)
Percentage of expressions with known type: 86 %  (threshold 85 %)
```

A scan that cannot resolve a third of its call graph does not mean *found nothing*. It means *did not see enough* — the opposite of why the language was turned on.

**Two causes, and the second was self-inflicted.** Without a build no dependency resolves. And under `build-mode: none`, `paths-ignore` keeps the excluded generated files out of the database entirely — so `WickraHandle.cs` and `WickraNative.cs`, which call straight into `Indicators.g.cs` and `NativeMethods.g.cs`, pointed at nothing.

**Building resolves both at once.** The generated code compiles, so the calls find their target; `paths-ignore` still filters its findings out of the *results*. High resolution and no flood, rather than a choice between them.

## Why `manual` rather than `autobuild`

This repository has several C# projects and two Maven trees. Guessing which to build is how a scan ends up quietly covering the wrong one.

| Language | Command | Why that one |
|---|---|---|
| C# | `dotnet build bindings/csharp/Wickra.Tests/Wickra.Tests.csproj -c Release` | pulls the library in by reference and adds the hand-written tests |
| Java | `mvn -B -f bindings/java test-compile -DskipTests` | `test-compile` builds the tests too — ten of the eleven files left after exclusions. `-DskipTests` because CodeQL needs the code compiled, not exercised |

Java also gets a JDK 25 step: the binding targets `java.lang.foreign` and the pom sets `release 22`, both above the runner default. C# needs no setup — the SDK is preinstalled, and `Wickra.csproj` has no `ProjectReference` to native code, so it builds without the Rust step.

## The Java exclusions

Every generated file states it in its first line: `// Generated from bindings/c/include/wickra.h. Do not edit by hand.` Counted, not assumed:

| | Files | |
|---|---|---|
| `org/wickra/*.java` | **624** | all generated, one class per catalogue entry |
| `org/wickra/internal/NativeMethods.java` | 1 | generated |
| `org/wickra/internal/WickraNative.java` | 1 | **hand-written — stays in** |
| `src/test/**` | 10 | **hand-written — stay in** |

37,900 lines excluded, 11 files analysed. `WickraNative.java` owns the arena, the cleaner and the library lookup — if a Java-side leak or use-after-free exists, that is where it lives.

## One more thing

The build commands are written out per language rather than driven from a matrix field. A `run:` that expands a template is the shape zizmor flags, and it would have been the third time in this branch series.

Go and C/C++ stay out: Go would need a full Rust release build to analyse 19 files that are mostly tests.