### PR TITLE
ci: measure the benchmarks on every pull request

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -60,7 +60,7 @@ jobs:
         run: cargo codspeed build -p wickra
 
       - name: Run them under instrumentation
-        uses: CodSpeedHQ/action@07725aac5ac9e687bba40b9bed8e2bd389a641c8 # v5.2.1
+        uses: CodSpeedHQ/action@373d6868929f444bc08d901fd0eb0ad52a8875ea # v5.2.1
         with:
           # Required since action v4, and it used to be inferred. `simulation`
           # counts instructions under instrumentation; `walltime` measures real

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -62,4 +62,10 @@ jobs:
       - name: Run them under instrumentation
         uses: CodSpeedHQ/action@07725aac5ac9e687bba40b9bed8e2bd389a641c8 # v5.2.1
         with:
+          # Required since action v4, and it used to be inferred. `simulation`
+          # counts instructions under instrumentation; `walltime` measures real
+          # time and needs CodSpeed's dedicated macro runners, which a standard
+          # GitHub runner is not -- there the timing would be as noisy as any
+          # other shared VM, which is the noise this job exists to avoid.
+          mode: simulation
           run: cargo codspeed run -p wickra

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,65 @@
+name: CodSpeed
+
+# Performance regressions were the one class of defect nothing here reported.
+# bench.yml runs on a schedule and prints numbers a person has to read; the
+# Python batch regression in August was found by re-measuring by hand, weeks
+# after it landed. This measures every pull request and says so in a comment.
+#
+# It counts instructions under instrumentation rather than timing wall clock.
+# That is what makes a shared runner usable: the number does not move because a
+# neighbour VM got busy. It is also why these figures are not the ones in
+# BENCHMARKS.md -- those are throughput, this is relative change. Both are true,
+# they answer different questions.
+#
+# crates/wickra-bench is deliberately absent. Its cross_lib bench measures kand,
+# ta and yata alongside us; instrumenting other people's crates on every pull
+# request costs the most and answers nothing about this one. It stays in
+# bench.yml on the schedule.
+on:
+  push:
+    branches: [main]
+    paths: ['crates/**', 'Cargo.toml', 'Cargo.lock', '.github/workflows/codspeed.yml']
+  pull_request:
+    branches: [main]
+    paths: ['crates/**', 'Cargo.toml', 'Cargo.lock', '.github/workflows/codspeed.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmarks:
+    name: Instruction counts
+    runs-on: ubuntu-latest
+    timeout-minutes: 30 # backstop: instrumentation is far slower per iteration than a plain run
+    permissions:
+      contents: read
+      # OpenID Connect against CodSpeed, which is what their action recommends
+      # over an upload token. A public repository needs no token at all.
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: ./.github/actions/setup-rust
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
+      - name: Install cargo-codspeed
+        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
+        timeout-minutes: 10 # fail fast on a stuck download instead of hanging the job
+        with:
+          tool: cargo-codspeed
+
+      # Named rather than --workspace, for the reason in the header: wickra-bench
+      # measures other crates and does not belong in a per-pull-request check.
+      - name: Build the benchmarks
+        run: cargo codspeed build -p wickra
+
+      - name: Run them under instrumentation
+        uses: CodSpeedHQ/action@07725aac5ac9e687bba40b9bed8e2bd389a641c8 # v5.2.1
+        with:
+          run: cargo codspeed run -p wickra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,41 +27,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alongside us, and instrumenting other people's crates on every pull request
   costs the most and answers nothing about this one.
 
-- **CodeQL analyses the C# and Java bindings**, both compiled rather than read
-  as source. The first C# pass ran with `build-mode: none` and GitHub reported
-  the result as low quality: 64% of calls resolved to a target against a
-  threshold of 85%. Two causes, and the second was self-inflicted -- without a
-  build no dependency resolves, and `paths-ignore` keeps the excluded generated
-  files out of the database entirely, so the hand-written code that calls into
-  them pointed at nothing. Building fixes both: the generated code compiles so
-  the calls resolve, while `paths-ignore` still filters its findings out of the
-  results.
+- **CodeQL analyses the C# and Java bindings.** The matrix covered Rust, Python
+  and JavaScript/TypeScript. C# and Java were the two largest surfaces it had no
+  view of, and the two where a memory mistake is possible at all: both reach the
+  C ABI directly, C# through `WickraHandle.cs` and `WickraNative.cs` with manual
+  handle lifetimes and native library resolution, Java through
+  `java.lang.foreign` with an `Arena` per handle and a `Cleaner` to release it.
+  None of that had ever been read by a static analyser.
 
-- **CodeQL analyses the Java binding.** The binding reaches the C ABI through
-  `java.lang.foreign` -- an `Arena` per handle, a `Cleaner` to release it, and
-  manual marshalling -- and none of it had ever been read by a static analyser.
-  No build is needed; `build-mode: none` covers Java as it does C#.
+  Both are compiled for the analysis rather than read as source. The first C#
+  pass ran with `build-mode: none` and GitHub reported it as low quality: 64% of
+  calls resolved to a target against a threshold of 85%. Two causes, and the
+  second was self-inflicted -- without a build no dependency resolves, and
+  `paths-ignore` keeps the excluded files out of the database entirely, so the
+  hand-written code calling into them pointed at nothing. Building fixes both:
+  the generated code compiles so the calls resolve, while `paths-ignore` still
+  filters its findings out of the results.
 
-  624 of the 636 files are generated from the C header and carry
-  `Do not edit by hand`, so they are excluded before the language is enabled
-  rather than dismissed afterwards. What stays in the analysis is
-  `internal/WickraNative.java`, which owns the arena, the cleaner and the library
-  lookup, plus the ten hand-written tests. That is the whole surface where a
-  Java-side leak or use-after-free could originate.
-
-- **CodeQL analyses the C# binding.** The matrix covered Rust, Python and
-  JavaScript/TypeScript; C# was the largest surface it had no view of, and the
-  one where a memory mistake is possible at all -- `WickraHandle.cs` and
-  `WickraNative.cs` carry manual handle lifetimes, disposal, and native library
-  resolution over the C ABI.
-
-  The three generated files are excluded first, not triaged afterwards.
-  `Indicators.g.cs` and `NativeMethods.g.cs` are 79,000 lines of P/Invoke
-  declarations and one-line delegating methods emitted from the C header, and
-  `GoldenAllTests.g.cs` is one test per catalogue entry. Turning the language on
-  without excluding them would have repeated what the napi glue did once
-  already: 518 findings at once, one per exported class, none of them about
-  anything anyone wrote.
+  The generated files are excluded before the languages are enabled, not triaged
+  afterwards. `Indicators.g.cs` and `NativeMethods.g.cs` are 79,000 lines of
+  P/Invoke declarations emitted from the C header, `GoldenAllTests.g.cs` is one
+  test per catalogue entry, and 624 of the 636 Java files are generated the same
+  way and carry `Do not edit by hand`. Turning the languages on without
+  excluding them would have repeated what the napi glue did once already: 518
+  findings at once, one per exported class, none of them about anything anyone
+  wrote. What stays in the analysis is the hand-written surface --
+  `WickraHandle.cs`, `WickraNative.cs`, `internal/WickraNative.java`, and the
+  tests -- which is the whole area where a leak or a use-after-free could
+  originate.
 
 - **`cargo-semver-checks` guards the published API.** `wickra-core`,
   `wickra-data` and `wickra` are on crates.io, and since 1.0.0 the version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CodSpeed measures the benchmarks on every pull request.** Performance
+  regressions were the one class of defect nothing here reported: `bench.yml`
+  runs on a schedule and prints numbers a person has to read, and the Python
+  batch regression in August was found by re-measuring by hand, weeks after it
+  landed.
+
+  It counts instructions under instrumentation rather than timing wall clock,
+  which is what makes a shared runner usable -- the figure does not move because
+  a neighbour VM got busy. These numbers are therefore not the ones in
+  `BENCHMARKS.md`: those are throughput, this is relative change.
+
+  `criterion` in `crates/wickra` now resolves to `codspeed-criterion-compat`
+  under the same name, so `indicators.rs` and `data_layer.rs` are untouched and
+  `cargo bench` behaves as before off a CodSpeed runner. `crates/wickra-bench`
+  keeps the plain crate: its `cross_lib` bench measures kand, ta and yata
+  alongside us, and instrumenting other people's crates on every pull request
+  costs the most and answers nothing about this one.
+
 - **CodeQL analyses the C# and Java bindings**, both compiled rather than read
   as source. The first C# pass ran with `build-mode: none` and GitHub reported
   the result as low quality: 64% of calls resolved to a target against a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +141,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chacha20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +210,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "codspeed"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7083f253260bcb4aaa3b4aa4c52973703dabc1a85c2f193997e2689aafa8a919"
+dependencies = [
+ "anyhow",
+ "cc",
+ "colored",
+ "getrandom 0.4.3",
+ "glob",
+ "libc",
+ "nix",
+ "serde",
+ "serde_json",
+ "statrs",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f24251445188c69d50f10179d795424bd71b533b7e3f84fc03f26893b01af0"
+dependencies = [
+ "clap",
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c38205d56e2cb4fe04b708de7f9653a3f1b89edbe3a20b28f21e9e525e9e061"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot 0.5.0",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,8 +337,8 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot",
- "itertools",
+ "criterion-plot 0.8.2",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "page_size",
@@ -274,12 +353,22 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "criterion-plot"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -554,6 +643,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +670,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -712,6 +813,26 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -890,6 +1011,18 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1499,6 +1632,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,7 +2040,7 @@ name = "wickra"
 version = "1.0.3"
 dependencies = [
  "approx",
- "criterion",
+ "codspeed-criterion-compat",
  "proptest",
  "wickra-core",
  "wickra-data",

--- a/crates/wickra/Cargo.toml
+++ b/crates/wickra/Cargo.toml
@@ -29,7 +29,15 @@ parallel = ["wickra-core/parallel"]
 
 [dev-dependencies]
 approx = { workspace = true }
-criterion = { workspace = true }
+# Not the workspace criterion: this is CodSpeed's drop-in replacement, pulled in
+# under the name `criterion` so the benches keep their `use criterion::{...}`
+# and not a line of indicators.rs or data_layer.rs has to change. Off a CodSpeed
+# runner it behaves as criterion does, so `cargo bench` locally is unaffected.
+#
+# crates/wickra-bench keeps the plain workspace criterion on purpose -- its
+# cross_lib bench measures kand, ta and yata alongside us, and instrumenting
+# other people's crates on every pull request is cost without an answer.
+criterion = { package = "codspeed-criterion-compat", version = "5.0.1", features = ["html_reports"] }
 proptest = { workspace = true }
 wickra-data = { path = "../wickra-data" }
 


### PR DESCRIPTION
## Why

Performance regressions were the one class of defect nothing here reported.

`bench.yml` runs on a schedule and prints numbers a person has to read. The Python batch regression in August was found by **re-measuring by hand, weeks after it landed**. This measures each pull request and comments the difference.

## What the numbers mean — and what they are not

CodSpeed counts **instructions under instrumentation**, not wall-clock time. That is what makes a shared runner usable: the figure does not move because a neighbour VM got busy.

It is also why these are **not** the numbers in `BENCHMARKS.md`. Those are throughput; this is relative change. Both are true, they answer different questions, and neither replaces the other.

## No source changes to the benchmarks

`criterion` in `crates/wickra` now resolves to `codspeed-criterion-compat` under the same name:

```toml
criterion = { package = "codspeed-criterion-compat", version = "5.0.1", features = ["html_reports"] }
```

So the 455 lines of `indicators.rs` and 117 of `data_layer.rs` keep their `use criterion::{…}` and are not touched at all. Off a CodSpeed runner it behaves as criterion does, so local `cargo bench` is unaffected.

Verified before committing: `cargo check --benches -p wickra` compiles clean against the replacement.

## What stays out, and why

`crates/wickra-bench` keeps the plain crate. Its `cross_lib` bench measures **kand, ta and yata** alongside us — instrumenting other people's crates on every pull request would be the most expensive job here and would answer nothing about this one. It stays on the schedule.

| Bench | Lines | Per PR |
|---|---|---|
| `indicators` | 455 | ✔ |
| `data_layer` | 117 | ✔ |
| `cross_lib` | 699 | ✘ — schedule only |

## No token

The action recommends OIDC over an upload token, and its own documentation says a public repository can omit the token altogether. The job declares `id-token: write` and nothing else.

**The organisation keeps its zero repository secrets** — the property reached when `ABOUT_SYNC_TOKEN` went away.

## Path filter

`crates/**`, `Cargo.toml`, `Cargo.lock` and this workflow. A documentation pull request does not need an instruction count, and the queue has jammed once already.

## First run

The CodSpeed app is already installed org-wide. `wickra` will show as *Configure* in their dashboard until this lands — that is a status label meaning "no run received yet", not a step to click. The first run on `main` flips it.