### PR TITLE
chore: close the remaining blueprint findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,19 @@ jobs:
       - name: Every version declaration agrees
         run: python3 scripts/check_version_sync.py
 
+      # Each bindings/*/README.md is, or is a workflow line away from being, a
+      # published package's long description: PyPI renders the Python one, NuGet
+      # the C# one, pkg.go.dev the Go one. A link that leaves the package is
+      # dead there while resolving fine on GitHub, so nothing says so.
+      - name: Binding READMEs link only to what travels with them
+        run: python3 scripts/check_readme_links.py
+
+      # An SPDX expression in a manifest is a reference to two documents, not
+      # the documents. cargo decides what to package from git, so the copies
+      # have to be committed -- and committed copies drift.
+      - name: Every published package carries its licence texts
+        run: python3 scripts/check_license_copies.py
+
       # R is the one binding whose native half comes from a published release
       # rather than from this tree (bindings/r/configure downloads the C ABI for
       # DESCRIPTION's Version), so the pairing r-universe compiles is one our own
@@ -386,7 +399,7 @@ jobs:
         timeout-minutes: 6
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
+        uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
         timeout-minutes: 10 # fail fast on a stuck download instead of hanging the job
         with:
           tool: cargo-llvm-cov
@@ -452,7 +465,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
+        uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
         timeout-minutes: 10 # fail fast on a stuck download instead of hanging the job
         with:
           tool: cargo-semver-checks
@@ -472,7 +485,7 @@ jobs:
   fuzz-smoke:
     name: Fuzz (smoke)
     runs-on: ubuntu-latest
-    timeout-minutes: 30 # backstop: cap a wedged job instead of GitHub's 6h default (headroom for slow registry/package installs)
+    timeout-minutes: 40 # backstop: 13 targets at 30 s each plus the build of all of them; caps a wedged job instead of GitHub's 6h default
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -501,7 +514,7 @@ jobs:
         # attributes the modern nightly compiler rejects, so the install
         # never gets off the ground. The prebuilt binary avoids the entire
         # transitive-dep compile.
-        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
+        uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
         timeout-minutes: 10 # fail fast on a stuck download instead of hanging the job
         with:
           tool: cargo-fuzz
@@ -513,29 +526,26 @@ jobs:
         run: cargo +nightly-2026-07-01 fuzz build --target x86_64-unknown-linux-gnu
         working-directory: fuzz
 
-      - name: Fuzz csv_reader (30 s)
-        run: cargo +nightly-2026-07-01 fuzz run --target x86_64-unknown-linux-gnu csv_reader -- -max_total_time=30
+      # Every target cargo-fuzz knows about, rather than a hand-kept list of
+      # steps. Six of the thirteen were listed and the other seven had never
+      # been run: `fuzz build` proves a target compiles, which is not the same
+      # as proving it survives input. Deriving the list means a new target is
+      # fuzzed the moment it exists.
+      - name: Fuzz every target (30 s each)
         working-directory: fuzz
-
-      - name: Fuzz binance_envelope (30 s)
-        run: cargo +nightly-2026-07-01 fuzz run --target x86_64-unknown-linux-gnu binance_envelope -- -max_total_time=30
-        working-directory: fuzz
-
-      - name: Fuzz indicator_update (30 s)
-        run: cargo +nightly-2026-07-01 fuzz run --target x86_64-unknown-linux-gnu indicator_update -- -max_total_time=30
-        working-directory: fuzz
-
-      - name: Fuzz indicator_update_candle (30 s)
-        run: cargo +nightly-2026-07-01 fuzz run --target x86_64-unknown-linux-gnu indicator_update_candle -- -max_total_time=30
-        working-directory: fuzz
-
-      - name: Fuzz tick_aggregator (30 s)
-        run: cargo +nightly-2026-07-01 fuzz run --target x86_64-unknown-linux-gnu tick_aggregator -- -max_total_time=30
-        working-directory: fuzz
-
-      - name: Fuzz indicator_chain (30 s)
-        run: cargo +nightly-2026-07-01 fuzz run --target x86_64-unknown-linux-gnu indicator_chain -- -max_total_time=30
-        working-directory: fuzz
+        run: |
+          set -euo pipefail
+          targets=$(cargo +nightly-2026-07-01 fuzz list)
+          if [ -z "$targets" ]; then
+            echo "::error::cargo fuzz list returned nothing -- no target would be fuzzed"
+            exit 1
+          fi
+          while read -r target; do
+            [ -n "$target" ] || continue
+            echo "::group::$target"
+            cargo +nightly-2026-07-01 fuzz run --target x86_64-unknown-linux-gnu "$target" -- -max_total_time=30
+            echo "::endgroup::"
+          done <<< "$targets"
 
   python:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
@@ -662,7 +672,7 @@ jobs:
         # same taiki-e prebuilt-binary installer we already use for
         # cargo-llvm-cov and cargo-fuzz; it tracks the latest wasm-pack
         # release, which has `--features` as a top-level flag (since 0.12).
-        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
+        uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
         timeout-minutes: 10 # fail fast on a stuck download instead of hanging the job
         with:
           tool: wasm-pack
@@ -769,6 +779,22 @@ jobs:
         working-directory: bindings/node
         run: node scripts/prune-type-only-exports.mjs
 
+      # Both files are generated by napi and committed, and nothing compared
+      # the two. index.js drifted before -- it shipped 0.9.7 inside the v0.9.9
+      # tag -- because napi rewrites it only when somebody rebuilds, and a
+      # rebuild is not part of committing. One OS is enough: the output is
+      # platform-independent.
+      - name: Check the committed loader is in sync with napi
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! git diff --quiet -- bindings/node/index.js bindings/node/index.d.ts; then
+            echo "::error::bindings/node/index.js or index.d.ts is out of sync -- run npm run build in bindings/node and commit the result"
+            git --no-pager diff -- bindings/node/index.js bindings/node/index.d.ts
+            exit 1
+          fi
+
       # The Node test process has wedged on macOS runners (the step hung for
       # 1h+ while the same tests passed in ~1.5 min elsewhere). Wrap it so a
       # hung attempt is killed after 6 min and retried once, rather than
@@ -828,7 +854,7 @@ jobs:
         timeout-minutes: 6
 
       - name: Install cbindgen
-        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
+        uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
         timeout-minutes: 10 # fail fast on a stuck download instead of hanging the job
         with:
           tool: cbindgen
@@ -916,6 +942,25 @@ jobs:
           retry_wait_seconds: 20
           command: dotnet test bindings/csharp/Wickra.Tests/Wickra.Tests.csproj -c Release
           shell: bash
+
+      # GoldenAllTests.g.cs is written by gen_golden_test.py from the catalogue
+      # and committed, and nothing compared the two: a new indicator that never
+      # had the generator re-run simply has no golden test on the C# side, and
+      # the suite stays green while covering one entry less.
+      #
+      # Its two siblings under Wickra/Generated/ cannot be checked the same way:
+      # the generator that writes them is not in this repository.
+      - name: Check the generated C# golden tests are in sync
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python bindings/csharp/gen_golden_test.py
+          if ! git diff --quiet -- bindings/csharp/Wickra.Tests/GoldenAllTests.g.cs; then
+            echo "::error::GoldenAllTests.g.cs is out of sync -- run python bindings/csharp/gen_golden_test.py and commit the result"
+            git --no-pager diff --stat -- bindings/csharp/Wickra.Tests/GoldenAllTests.g.cs
+            exit 1
+          fi
 
       - name: Build the C# examples
         shell: bash
@@ -1089,7 +1134,7 @@ jobs:
         run: cargo build -p wickra-c --release
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+        uses: r-lib/actions/setup-r@465b7d8e732ca3921382b1674c59bada9cbf3399 # v2.13.0
         with:
           r-version: "release"
           use-public-rspm: true
@@ -1099,7 +1144,7 @@ jobs:
       # compiling testthat / knitr and their deps from source — the slow, flaky
       # path that previously blew past the job timeout on the ubuntu runner.
       - name: Install R dependencies (cached binaries)
-        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+        uses: r-lib/actions/setup-r-dependencies@465b7d8e732ca3921382b1674c59bada9cbf3399 # v2.13.0
         with:
           working-directory: bindings/r
           extra-packages: |
@@ -1204,7 +1249,7 @@ jobs:
       - name: Set up JDK 25
         id: setup-java
         continue-on-error: true
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "25"
@@ -1219,7 +1264,7 @@ jobs:
 
       - name: Set up JDK 25 (retry)
         if: steps.setup-java.outcome == 'failure'
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "25"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,37 +69,53 @@ jobs:
       # release 22.
       - name: Set up JDK 25
         if: matrix.language == 'java-kotlin'
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "25"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: .github/codeql/codeql-config.yml
 
-      # Spelled out per language rather than driven from a matrix field: a
-      # `run:` that expands a template is the shape zizmor flags, and two
-      # explicit steps read better than one indirect one.
-      #
-      # The test project is built rather than the library alone -- it pulls the
-      # library in by reference and adds the hand-written tests, which is most
-      # of what is left after the exclusions.
-      - name: Build the C# binding
+      # CodeQL sees exactly what the compiler walks, so anything it does not
+      # build is not analysed. Building only the test project left the eleven
+      # examples and the benchmark unscanned -- 11 of 23 C# files -- and the
+      # examples are the code people copy into their own projects.
+      - name: Build the C# binding, examples and benchmarks
         if: matrix.language == 'csharp'
-        run: dotnet build bindings/csharp/Wickra.Tests/Wickra.Tests.csproj -c Release
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet build bindings/csharp/Wickra.Tests/Wickra.Tests.csproj -c Release
+          dotnet build bindings/csharp/benchmarks/Benchmarks.csproj -c Release
+          for d in streaming backtest multi_timeframe parallel_assets \
+                   strategy_rsi_mean_reversion strategy_macd_adx \
+                   strategy_bollinger_squeeze fetch_btcusdt live_binance; do
+            dotnet build "examples/csharp/$d" -c Release
+          done
 
       # test-compile, not compile: it builds the hand-written tests too, and
-      # they are ten of the eleven files left after the exclusions. -DskipTests
-      # because CodeQL needs the code compiled, not exercised.
-      - name: Build the Java binding
+      # they are ten of the eleven binding files left after the exclusions.
+      # -DskipTests because CodeQL needs the code compiled, not exercised.
+      #
+      # examples/java is a separate Maven project and was therefore never
+      # analysed. It resolves org.wickra:wickra from Maven Central rather than
+      # from this tree, so what is analysed there is the example code against
+      # the published binding -- which is exactly the pairing a reader copying
+      # those files would get.
+      - name: Build the Java binding and examples
         if: matrix.language == 'java-kotlin'
-        run: mvn -B -f bindings/java test-compile -DskipTests
+        shell: bash
+        run: |
+          set -euo pipefail
+          mvn -B -f bindings/java test-compile -DskipTests
+          mvn -B -f examples/java test-compile -DskipTests
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -49,7 +49,7 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
+        uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
         timeout-minutes: 10 # fail fast on a stuck download instead of hanging the job
         with:
           tool: cargo-codspeed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,59 @@ jobs:
   # --------------------------------------------------------------------------
   # crates.io: three crates in dependency order
   # --------------------------------------------------------------------------
+  # Nothing reaches a registry until every artefact exists and the tagged commit
+  # is known to have been green. Before this job, cargo-publish and wasm-publish
+  # declared no dependencies at all: crates.io could receive a version while the
+  # Python wheels were still building, and a wheel failing afterwards left the
+  # crate published and unwithdrawable. Six registries cannot be made atomic,
+  # but the common failure -- something does not build -- can be moved in front
+  # of the first irreversible step instead of running beside it.
+  gate:
+    name: Nothing publishes before this
+    needs: [python-wheels, python-sdist, node-build, c-abi-build, wasm-build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: The tagged commit must have passed CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # ci.yml runs on pushes to main and on pull requests, never on a tag,
+          # so this workflow cannot see the tag's health in its own run. Ask what
+          # the commit itself was graded, which is the merge commit the tag
+          # points at and therefore the state that was actually tested.
+          ci=$(gh api "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${SHA}&per_page=1"                  -q '.workflow_runs[0].conclusion // "none"')
+          echo "ci.yml on ${SHA}: ${ci}"
+          if [ "$ci" != "success" ]; then
+            echo "::error::the tagged commit has no successful ci.yml run (${ci}); refusing to publish"
+            exit 1
+          fi
+
+          # And nothing else that did run may have failed. Listing required
+          # workflows by name would go stale -- codspeed.yml is path-filtered and
+          # legitimately does not run for a version bump -- so the rule is about
+          # outcomes rather than about a roster: whatever ran, none of it is red.
+          bad=$(gh api "repos/${REPO}/actions/runs?head_sha=${SHA}&per_page=100"                   -q '[.workflow_runs[]
+                       | select(.name != "Release")
+                       | select(.conclusion == "failure" or .conclusion == "timed_out"
+                                or .conclusion == "cancelled")
+                       | .name] | unique | join(", ")')
+          if [ -n "$bad" ]; then
+            echo "::error::the tagged commit has failing runs (${bad}); refusing to publish"
+            exit 1
+          fi
+          echo "every workflow that ran on this commit is green"
+
   cargo-publish:
     name: Publish to crates.io
+    needs: [gate]
     timeout-minutes: 45 # backstop only: release build/publish jobs compile from source (vendored OpenSSL) and must not be killed mid-build; far above the ~10 min real runtime
     runs-on: ubuntu-latest
     # The publish jobs run with long-lived registry tokens. Binding them to a
@@ -256,7 +307,7 @@ jobs:
   python-publish:
     name: Publish to PyPI
     timeout-minutes: 45 # backstop only: release build/publish jobs compile from source (vendored OpenSSL) and must not be killed mid-build; far above the ~10 min real runtime
-    needs: [python-wheels, python-sdist]
+    needs: [gate, python-wheels, python-sdist]
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -347,7 +398,7 @@ jobs:
   node-publish:
     name: Publish to npm
     timeout-minutes: 45 # backstop only: release build/publish jobs compile from source (vendored OpenSSL) and must not be killed mid-build; far above the ~10 min real runtime
-    needs: node-build
+    needs: [gate, node-build]
     runs-on: ubuntu-latest
     environment: release
     # `id-token: write` lets npm publish embed a Sigstore provenance
@@ -524,17 +575,17 @@ jobs:
   # --------------------------------------------------------------------------
   # Note: this job's npm publish call uses `--provenance` (see below),
   # which requires the `id-token: write` permission set at the job level.
-  wasm-publish:
-    name: Publish wickra-wasm to npm
-    timeout-minutes: 45 # backstop only: release build/publish jobs compile from source (vendored OpenSSL) and must not be killed mid-build; far above the ~10 min real runtime
+  # The WASM package is built here rather than inside the publish job, so a
+  # build failure lands in front of the gate instead of after crates.io has
+  # already received the version. What is published downstream is the very
+  # tarball this job packs and attaches to the release, so the two cannot
+  # diverge.
+  wasm-build:
+    name: Build wickra-wasm
+    timeout-minutes: 45 # backstop only: compiles from source; far above the ~10 min real runtime
     runs-on: ubuntu-latest
-    environment: release
-    # `id-token: write` lets npm publish embed a Sigstore provenance
-    # attestation generated from the GitHub Actions OIDC token (same
-    # mechanism as the node-publish job above).
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -546,7 +597,6 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Wait before Node retry
         if: steps.setup_node.outcome == 'failure'
@@ -560,7 +610,6 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org"
 
       - uses: ./.github/actions/setup-rust
         with:
@@ -611,13 +660,43 @@ jobs:
           name: wasm-tarball
           path: bindings/wasm/pkg/wickra-wasm-*.tgz
 
+  wasm-publish:
+    name: Publish wickra-wasm to npm
+    needs: [gate, wasm-build]
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    environment: release
+    # `id-token: write` lets npm publish embed a Sigstore provenance
+    # attestation generated from the GitHub Actions OIDC token (same
+    # mechanism as the node-publish job above).
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Download the packed tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: wasm-tarball
+          path: wasm-pkg
+
       - name: Publish wickra-wasm to npm (idempotent)
-        working-directory: bindings/wasm/pkg
         run: |
-          # if/then rather than `A && B || C`: that form runs C when B fails, not
-          # only when A does, so a failing echo would read as a failed publish
-          # (shellcheck SC2015).
-          if out=$(npm publish --access public --provenance 2>&1); then
+          set -euo pipefail
+          tarball=$(find wasm-pkg -name 'wickra-wasm-*.tgz' | head -1)
+          if [ -z "$tarball" ]; then
+            echo "::error::wasm-build produced no tarball"
+            exit 1
+          fi
+          # if/then rather than `A && B || C`: that form runs C when B fails,
+          # not only when A does, so a failing echo would read as a failed
+          # publish (shellcheck SC2015).
+          if out=$(npm publish "$tarball" --access public --provenance 2>&1); then
             echo "$out"
           elif printf '%s' "$out" | grep -q "You cannot publish over"; then
             echo "skip: version already on npm"
@@ -702,7 +781,7 @@ jobs:
   csharp-publish:
     name: Publish to NuGet
     timeout-minutes: 45 # backstop only: release build/publish jobs compile from source (vendored OpenSSL) and must not be killed mid-build; far above the ~10 min real runtime
-    needs: c-abi-build
+    needs: [gate, c-abi-build]
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -806,7 +885,7 @@ jobs:
   java-publish:
     name: Publish to Maven Central
     timeout-minutes: 45 # backstop only: release build/publish jobs compile from source (vendored OpenSSL) and must not be killed mid-build; far above the ~10 min real runtime
-    needs: c-abi-build
+    needs: [gate, c-abi-build]
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -893,7 +972,7 @@ jobs:
   go-mirror:
     name: Mirror the Go module to wickra-go
     timeout-minutes: 45 # backstop only: release build/publish jobs compile from source (vendored OpenSSL) and must not be killed mid-build; far above the ~10 min real runtime
-    needs: c-abi-build
+    needs: [gate, c-abi-build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
       # consumers can audit the published dependency tree without
       # re-resolving Cargo.lock.
       - name: Install cargo-cyclonedx
-        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
+        uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
         timeout-minutes: 10 # fail fast on a stuck download instead of hanging the job
         with:
           tool: cargo-cyclonedx
@@ -573,7 +573,7 @@ jobs:
       - name: Install wasm-pack (latest, via prebuilt binary)
         # See the matching note in ci.yml: jetli's default installs an old
         # 0.10.x wasm-pack whose build subcommand rejects --features.
-        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
+        uses: taiki-e/install-action@742a3317eac7bd62f91cd888b4eead5e784ba833 # v2.87.1
         timeout-minutes: 10 # fail fast on a stuck download instead of hanging the job
         with:
           tool: wasm-pack
@@ -850,7 +850,7 @@ jobs:
       # setup-java writes a settings.xml with the 'central' server credentials
       # (mapped from the env vars below) and imports the GPG signing key.
       - name: Set up JDK 25 + Maven Central credentials + GPG
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "25"
@@ -912,8 +912,14 @@ jobs:
           set -e
           out=wickra-go-module
           mkdir -p "$out/include" "$out/lib"
-          # Single-package Go source + vendored C ABI header.
-          cp bindings/go/*.go "$out/"
+          # Single-package Go source + vendored C ABI header. The *_test.go
+          # files stay behind: they read ../../testdata/golden, a path that
+          # exists in this repository and not in a module fetched with `go get`,
+          # so shipping them means `go test` on the published module fails at
+          # os.Open. The tests belong to the source repo; the module ships the
+          # library.
+          find bindings/go -maxdepth 1 -name '*.go' -not -name '*_test.go' \
+            -exec cp {} "$out/" \;
           cp bindings/go/include/wickra.h "$out/include/"
           cp bindings/go/README.md "$out/"
           # Ship the dual license so pkg.go.dev detects a redistributable license.
@@ -947,6 +953,67 @@ jobs:
             mkdir -p "$out/lib/$dir"; cp "$src" "$out/lib/$dir/"
           done
           echo "assembled module:"; find "$out" -type f | sort
+
+      - name: Set up Go
+        id: setup-go
+        continue-on-error: true
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "stable"
+          cache: false
+
+      - name: Retry Go setup (CDN flake)
+        if: steps.setup-go.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::setup-go failed (likely CDN flake), waiting 30s before retry..."
+          sleep 30
+
+      - name: Set up Go (retry)
+        if: steps.setup-go.outcome == 'failure'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "stable"
+          cache: false
+
+      # Nothing here ever compiled the module it publishes. The tree is
+      # assembled by copying files and rewriting an import path with sed, and
+      # was pushed to pkg.go.dev on that basis alone -- a wrong header, a
+      # missing library or a botched sed would have surfaced on a user's
+      # machine. Build it, and run it, before it leaves.
+      - name: Verify the assembled module builds and runs
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd wickra-go-module
+          cat > smoke_main_test.go <<'GO'
+          package wickra
+
+          import "testing"
+
+          // Links against the staged linux_amd64 library and exercises one
+          // indicator end to end: constructor, update, destructor. Compiling
+          // proves the header and the cgo directives; running proves the
+          // library is actually loadable.
+          func TestAssembledModuleSmoke(t *testing.T) {
+            s, err := NewSma(3)
+            if err != nil {
+              t.Fatalf("NewSma: %v", err)
+            }
+            defer s.Close()
+            var last float64
+            for _, v := range []float64{1, 2, 3, 4, 5} {
+              last = s.Update(v)
+            }
+            if last < 3.999999999 || last > 4.000000001 {
+              t.Fatalf("sma(3) over 1..5 = %v, want 4", last)
+            }
+          }
+          GO
+          go vet ./...
+          go test -run TestAssembledModuleSmoke -v ./...
+          rm smoke_main_test.go
+          echo "module builds, links and runs"
 
       - name: Push to wickra-go and tag the release
         shell: bash
@@ -1060,7 +1127,7 @@ jobs:
           echo "asset-count=$(find release-assets -type f | wc -l)"
 
       - name: Create / update the draft GitHub Release with assets
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: Wickra ${{ steps.tag.outputs.tag }}
@@ -1159,7 +1226,7 @@ jobs:
           merge-multiple: true
       - name: Attest build provenance
         id: attest
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             artifacts/crates/*.crate

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -52,6 +52,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -38,4 +38,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Streaming and batch are compared through the C ABI.** Every indicator
+  exposes `update` and `batch`, and they must agree -- a consumer switching
+  between a live feed and a backfill gets the same numbers, or one of the two
+  paths is wrong. Node and Python assert this; C, the ABI every other binding
+  sits on, never did. `examples/c/streaming_vs_batch_test.c` checks a scalar
+  and a candle indicator, deliberately reusing the Node suite's series,
+  tolerance and NaN handling so a disagreement between languages is about the
+  library rather than about the test.
+
+- **`scripts/check_readme_links.py`** holds each `bindings/*/README.md` to
+  linking only what travels with the package. These are published long
+  descriptions -- PyPI renders the Python one, NuGet the C# one -- where a link
+  out of the package is dead while resolving fine on GitHub, so nothing says
+  so. Links that stay inside the package are fine: `man/figures/logo.png` in
+  the R binding is the R convention and ships with the package.
+
+- **`scripts/check_license_copies.py`** verifies that every published package
+  carries both licence texts byte-for-byte, deriving the list from the
+  workspace rather than a hand-kept one.
+
 - **The published crates carry their licence texts.** `cargo package` only
   includes files inside the crate directory, so the root `LICENSE-MIT` and
   `LICENSE-APACHE` never travelled: `wickra-core-1.0.3.crate` shipped 532 files
@@ -127,6 +147,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stay on Maven Central, where a build tool resolves them on demand.
 
 ### Changed
+
+- **Every fuzz target is fuzzed, not six of thirteen.** The workflow listed the
+  targets to run by hand and seven had never been run: `fuzz build` proves a
+  target compiles, which is not the same as proving it survives input. The list
+  now comes from `cargo fuzz list`, so a new target is fuzzed the moment it
+  exists rather than when somebody remembers.
+
+- **The Go module is built and run before it is published.** `go-mirror`
+  assembles the tree by copying files and rewriting an import path with `sed`,
+  then pushed it to pkg.go.dev on that basis alone -- a wrong header, a missing
+  library or a botched `sed` would have surfaced on a user's machine. It now
+  compiles the assembled module and exercises one indicator end to end first.
+  The `*_test.go` files stay behind: they read `../../testdata/golden`, which
+  does not exist in a module fetched with `go get`, so shipping them meant
+  `go test` on the published module failed at `os.Open`.
+
+- **The committed napi loader and the generated C# golden tests are checked for
+  drift.** `index.js` shipped 0.9.7 inside the v0.9.9 tag because napi rewrites
+  it only when somebody rebuilds. Both are now regenerated in CI and compared.
+  `Indicators.g.cs` and `NativeMethods.g.cs` cannot be checked this way: their
+  generator is not in this repository.
+
+- **CodeQL analyses the C# and Java examples and benchmarks.** Under
+  `build-mode: manual` it sees exactly what the compiler walks, so building only
+  the test project left 11 of 23 C# files unanalysed -- including every example,
+  which is the code people copy into their own projects.
+
+- **Seven action pins moved to their newest release**, each resolved to the
+  commit rather than to the annotated tag object that a ref lookup returns.
 
 - **`scripts/update-lockfiles.sh` no longer installs uv by itself.** It piped
   `https://astral.sh/uv/install.sh` into a shell, which runs whatever is behind

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A release is all-or-nothing: nothing is published unless everything is
+  green.** `cargo-publish` and `wasm-publish` declared no dependencies at all,
+  so crates.io could receive a version while the Python wheels were still
+  building. A wheel failing afterwards left the crate published, unwithdrawable,
+  and the release half-shipped -- with the notes claiming otherwise.
+
+  Every publish job now waits on a `gate` job, and the gate waits on all five
+  build jobs *and* on evidence that the tagged commit was green. `ci.yml` does
+  not run on tags, so the release cannot infer the tag's health from its own
+  run: the gate asks the API what the commit was graded, requires a successful
+  `ci.yml` run on that exact SHA, and refuses if any other workflow that ran on
+  it failed. Listing required workflows by name would go stale -- `codspeed.yml`
+  is path-filtered and legitimately does not run for a version bump -- so the
+  rule is about outcomes rather than about a roster.
+
+  The WASM package is built in its own `wasm-build` job for the same reason: it
+  used to be compiled inside the publish job, which put its build behind the
+  gate rather than in front of it. What is published is now the very tarball
+  that is attached to the release, so the two cannot diverge.
+
+  Six registries cannot be made atomic -- a registry can still fail mid-upload
+  after another has succeeded. What this removes is the common case, which is
+  not a registry outage but something that does not build.
+
 - **Every fuzz target is fuzzed, not six of thirteen.** The workflow listed the
   targets to run by hand and seven had never been run: `fuzz build` proves a
   target compiles, which is not the same as proving it survives input. The list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`Vpin::update` could never return for a large trade size.** It distributes a
+  trade's volume across buckets with `while remaining > 0.0 { ... remaining -=
+  take }`, and once the size is large enough that the bucket volume falls below
+  one ULP of it, the subtraction changes nothing: at 1.4e277 against a bucket of
+  8, `remaining` stays exactly where it was and the loop never ends. Not slow --
+  non-terminating. A single trade hung the caller for good, and 1.4e277 passes
+  `Trade::new` unchanged, so this was reachable through the ordinary validating
+  API rather than only through `new_unchecked`.
+
+  The loop is now bounded by what can still be observed. A trade is one-sided,
+  so every complete bucket it fills carries an imbalance of exactly the bucket
+  volume, and the window keeps only the last `num_buckets`; anything beyond that
+  pushes values identical to the ones it evicts. The bound keeps the remainder
+  that decides where the next bucket boundary falls, so it is exact rather than
+  an approximation — a test asserts that one 1000.5-sized trade leaves the same
+  state as 2001 trades of 0.5.
+
+  Found by `fuzz/fuzz_targets/indicator_update_trade.rs` on its first ever run.
+  It was one of seven targets that were built but never executed, which is what
+  the change to fuzzing every declared target was for.
+
 - **Every release since the .NET binding shipped attached the package to
   nuget.org but not to the release page.** `csharp-publish` packs the package,
   pushes it, and uploads it as a build artifact -- and the staging step in

--- a/crates/wickra-core/src/indicators/vpin.rs
+++ b/crates/wickra-core/src/indicators/vpin.rs
@@ -116,6 +116,32 @@ impl Indicator for Vpin {
     fn update(&mut self, trade: Trade) -> Option<f64> {
         let mut remaining = trade.size;
         let buy = trade.side == Side::Buy;
+
+        // Bound the work at what can still be observed. A trade is one-sided,
+        // so every complete bucket it fills carries an imbalance of exactly
+        // `bucket_volume`, and the window keeps only the last `num_buckets`:
+        // closing more than that pushes values identical to the ones it
+        // evicts. Dropping them is exact rather than approximate, because the
+        // remainder that decides where the next bucket boundary falls is kept.
+        //
+        // Without the bound the loop does not merely do useless work. Once the
+        // size is large enough that `bucket_volume` falls below one ULP of it
+        // -- 1.4e277 against a bucket of 8 -- `remaining -= take` leaves
+        // `remaining` unchanged, so `while remaining > 0.0` never terminates.
+        // A single malformed trade hung the caller forever. Found by
+        // fuzz/fuzz_targets/indicator_update_trade.rs.
+        let capacity = self.bucket_volume - self.cur_total;
+        let window_full = self.num_buckets as f64 * self.bucket_volume;
+        if remaining.is_infinite() {
+            // Infinitely one-sided: it fills the window and leaves nothing over.
+            remaining = capacity + window_full;
+        } else if remaining > capacity {
+            let beyond = remaining - capacity;
+            if beyond / self.bucket_volume > self.num_buckets as f64 {
+                remaining = capacity + window_full + beyond % self.bucket_volume;
+            }
+        }
+
         // Distribute the trade's volume across one or more buckets.
         while remaining > 0.0 {
             let capacity = self.bucket_volume - self.cur_total;
@@ -274,5 +300,62 @@ mod tests {
         let mut b = Vpin::new(8.0, 5).unwrap();
         let streamed: Vec<_> = trades.iter().map(|t| b.update(*t)).collect();
         assert_eq!(batch, streamed);
+    }
+
+    // The exact input libFuzzer found: a size so large that subtracting a
+    // bucket from it is below one ULP, so the distribution loop could never
+    // make progress and `update` never returned. Any assertion here is
+    // secondary to the test completing at all.
+    #[test]
+    fn enormous_size_terminates() {
+        let mut vpin = Vpin::new(8.0, 5).unwrap();
+        let value = vpin.update(trade(1.397_926_697_262_895_6e277, Side::Buy));
+        assert_eq!(
+            value,
+            Some(1.0),
+            "a one-sided flood is maximally imbalanced"
+        );
+    }
+
+    // `Trade::new` rejects a non-finite size, so this one is only reachable
+    // through `new_unchecked` -- which is what the fuzz harness uses, and what
+    // a binding that has already validated upstream may use too. The finite
+    // case above needs no such help: 1.4e277 passes the validating constructor
+    // unchanged, so the hang was reachable through the ordinary API.
+    #[test]
+    fn infinite_size_terminates() {
+        let mut vpin = Vpin::new(8.0, 5).unwrap();
+        let flood = Trade::new_unchecked(100.0, f64::INFINITY, Side::Buy, 0);
+        assert_eq!(vpin.update(flood), Some(1.0));
+    }
+
+    // Bounding the loop must not move the next bucket boundary. A size well
+    // past the window still leaves a remainder, and the bucket after it has to
+    // start where it would have without the bound.
+    #[test]
+    fn bounding_preserves_the_remainder() {
+        let mut bounded = Vpin::new(8.0, 5).unwrap();
+        bounded.update(trade(1000.5, Side::Buy));
+
+        // The same volume delivered as many small trades, which never triggers
+        // the bound, must leave the estimator in the same state.
+        let mut unbounded = Vpin::new(8.0, 5).unwrap();
+        for _ in 0..2001 {
+            unbounded.update(trade(0.5, Side::Buy));
+        }
+        assert_eq!(bounded.cur_total, unbounded.cur_total);
+        assert_eq!(
+            bounded.update(trade(1.0, Side::Sell)),
+            unbounded.update(trade(1.0, Side::Sell))
+        );
+    }
+
+    #[test]
+    fn a_size_below_the_bound_is_untouched() {
+        // 6 buckets' worth against a 5-bucket window: right at the edge, and
+        // the bound must not engage where the loop still terminates on its own.
+        let mut vpin = Vpin::new(8.0, 5).unwrap();
+        assert_eq!(vpin.update(trade(48.0, Side::Buy)), Some(1.0));
+        assert_eq!(vpin.cur_total, 0.0);
     }
 }

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -67,6 +67,7 @@ add_wickra_example(smoke smoke.c TRUE)                 # links the boundary, ass
 add_wickra_example(archetypes archetypes.c TRUE)       # one indicator per FFI archetype
 add_wickra_example(streaming streaming.c TRUE)         # multi-indicator tick stream
 add_wickra_example(cpp_smoke smoke.cpp TRUE)           # C++ RAII wrapper (wickra.hpp)
+add_wickra_example(streaming_vs_batch_test streaming_vs_batch_test.c TRUE)  # update() == batch()
 add_wickra_example(backtest backtest.c TRUE)           # indicator basket over a CSV
 add_wickra_example(multi_timeframe multi_timeframe.c TRUE)  # resample + per-TF indicators
 add_wickra_example(parallel_assets parallel_assets.c TRUE)  # serial vs OpenMP fan-out

--- a/examples/c/streaming_vs_batch_test.c
+++ b/examples/c/streaming_vs_batch_test.c
@@ -1,0 +1,127 @@
+/* Streaming/batch equivalence through the C ABI.
+ *
+ * Every indicator exposes both `update` (one input at a time) and `batch` (a
+ * whole series at once). They must agree: a consumer that switches from a live
+ * feed to a backfill, or the other way round, gets the same numbers, or the
+ * library is wrong about one of the two paths.
+ *
+ * The other bindings assert this -- Node in __tests__/indicators.test.js,
+ * Python in test_streaming_vs_batch.py -- and C did not, which left the ABI
+ * every other binding sits on as the one surface where the two were never
+ * compared.
+ *
+ * Input series, tolerance and NaN handling deliberately mirror the Node suite,
+ * so a disagreement between the two languages is a disagreement about the
+ * library rather than about the test.
+ */
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "wickra.h"
+
+#define N 120
+
+static double close_[N], high_[N], low_[N], open_[N], volume_[N];
+static int64_t ts_[N];
+static int failures = 0;
+
+static void build_series(void) {
+    for (int i = 0; i < N; i++) {
+        close_[i] = 100.0 + sin(i * 0.2) * 10.0 + i * 0.1;
+        high_[i] = close_[i] + 1.5;
+        low_[i] = close_[i] - 1.5;
+        open_[i] = close_[i] - 0.5;
+        volume_[i] = 1000.0 + (i % 7) * 50.0;
+        ts_[i] = (int64_t)i * 60000;
+    }
+}
+
+/* NaN equals NaN here: an indicator that has not warmed up reports NaN from
+ * both paths, and that agreement is part of what is being checked. */
+static int same(double a, double b) {
+    if (isnan(a) || isnan(b)) return isnan(a) && isnan(b);
+    if (isinf(a) || isinf(b)) return a == b;
+    return fabs(a - b) < 1e-9;
+}
+
+static void report(const char *name, int i, double streamed, double batched) {
+    fprintf(stderr, "%s: streaming and batch disagree at %d: %.17g vs %.17g\n",
+            name, i, streamed, batched);
+    failures++;
+}
+
+static void pass(const char *name) {
+    printf("  %-8s streaming == batch over %d inputs\n", name, N);
+}
+
+/* One scalar indicator: `batch` over the close series against `update` per
+ * element on a fresh handle. */
+#define CHECK_SCALAR(NAME, CTOR)                                              \
+    do {                                                                      \
+        double batched[N];                                                    \
+        void *b = (CTOR);                                                     \
+        void *s = (CTOR);                                                     \
+        int ok = 1;                                                           \
+        if (b == NULL || s == NULL) {                                         \
+            fprintf(stderr, "%s: constructor returned NULL\n", #NAME);        \
+            failures++;                                                       \
+            break;                                                            \
+        }                                                                     \
+        wickra_##NAME##_batch(b, close_, batched, N);                         \
+        for (int i = 0; i < N; i++) {                                         \
+            double streamed = wickra_##NAME##_update(s, close_[i]);           \
+            if (!same(streamed, batched[i])) {                                \
+                report(#NAME, i, streamed, batched[i]);                       \
+                ok = 0;                                                       \
+                break;                                                        \
+            }                                                                 \
+        }                                                                     \
+        wickra_##NAME##_free(b);                                              \
+        wickra_##NAME##_free(s);                                              \
+        if (ok) pass(#NAME);                                                  \
+    } while (0)
+
+int main(void) {
+    build_series();
+    printf("streaming/batch equivalence through the C ABI:\n");
+
+    CHECK_SCALAR(sma, wickra_sma_new(14));
+    CHECK_SCALAR(ema, wickra_ema_new(14));
+    CHECK_SCALAR(rsi, wickra_rsi_new(14));
+
+    /* A candle indicator takes six parallel arrays rather than one. That is a
+     * different marshalling path on both sides, so it gets its own check
+     * instead of being assumed covered by the scalar case. */
+    {
+        double batched[N];
+        struct Atr *b = wickra_atr_new(14);
+        struct Atr *s = wickra_atr_new(14);
+        int ok = 1;
+        if (b == NULL || s == NULL) {
+            fprintf(stderr, "atr: constructor returned NULL\n");
+            failures++;
+        } else {
+            wickra_atr_batch(b, open_, high_, low_, close_, volume_, ts_, batched, N);
+            for (int i = 0; i < N; i++) {
+                double streamed = wickra_atr_update(s, open_[i], high_[i], low_[i],
+                                                    close_[i], volume_[i], ts_[i]);
+                if (!same(streamed, batched[i])) {
+                    report("atr", i, streamed, batched[i]);
+                    ok = 0;
+                    break;
+                }
+            }
+            wickra_atr_free(b);
+            wickra_atr_free(s);
+            if (ok) pass("atr");
+        }
+    }
+
+    if (failures > 0) {
+        fprintf(stderr, "\n%d indicator(s) disagree between the two paths\n", failures);
+        return 1;
+    }
+    printf("\nboth paths agree for every indicator checked.\n");
+    return 0;
+}

--- a/scripts/check_license_copies.py
+++ b/scripts/check_license_copies.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Every published package must carry the licence texts it claims.
+
+The repository is dual-licensed and every manifest says so, but an SPDX
+expression is a reference to two documents, not the documents. A package that
+ships the expression alone leaves whoever received it with terms they have to go
+and find.
+
+The npm packages are handled at publish time (see release.yml), because npm is
+happy to pack a file that appears in the working tree moments beforehand. Cargo
+is not: it decides what to package from git, so a copy that is untracked makes
+`cargo publish` refuse the dirty tree, and a copy that is gitignored is dropped
+from the .crate entirely. Committed copies are the only thing that works, and the
+cost of a committed copy is drift -- which is what this checks.
+
+Locations are derived, not listed: every workspace member that can go to
+crates.io, plus the Python binding, whose wheel and sdist are built by maturin
+from that directory. Add a publishable crate and this starts requiring its
+licences without anyone remembering to edit the list.
+
+Run from the repository root:  python scripts/check_license_copies.py
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+LICENCES = ("LICENSE-MIT", "LICENSE-APACHE")
+# maturin builds the wheel and sdist from here, and picks up any LICEN[CS]E* it
+# finds beside the manifest (PEP 639). Not a crates.io package -- its Cargo.toml
+# says publish = false -- so it cannot be derived from the workspace below.
+EXTRA = ("bindings/python",)
+
+# SPDX-named copies at LICENSES/<identifier>.txt. Not a package -- this is the
+# layout licence scanners look for, so the `MIT OR Apache-2.0` that every
+# manifest declares resolves to the actual texts without anyone having to guess
+# which root file is which. Byte-identical to that pair, hence checked here
+# rather than trusted.
+SPDX_COPIES = {
+    "LICENSES/MIT.txt": "LICENSE-MIT",
+    "LICENSES/Apache-2.0.txt": "LICENSE-APACHE",
+}
+
+
+def workspace_members() -> list[str]:
+    with open(os.path.join(ROOT, "Cargo.toml"), encoding="utf-8") as handle:
+        text = handle.read()
+    block = re.search(r"(?ms)^members\s*=\s*\[(.*?)\]", text)
+    if block is None:
+        raise SystemExit("no [workspace] members list in Cargo.toml")
+    return re.findall(r'"([^"]+)"', block.group(1))
+
+
+def publishable(member: str) -> bool:
+    """False when the member's manifest opts out of crates.io."""
+    manifest = os.path.join(ROOT, member, "Cargo.toml")
+    if not os.path.isfile(manifest):
+        raise SystemExit(f"workspace member {member} has no Cargo.toml")
+    with open(manifest, encoding="utf-8") as handle:
+        return re.search(r"(?m)^publish\s*=\s*false", handle.read()) is None
+
+
+def main() -> int:
+    originals = {}
+    for name in LICENCES:
+        path = os.path.join(ROOT, name)
+        if not os.path.isfile(path):
+            print(f"{name} is missing from the repository root", file=sys.stderr)
+            return 1
+        with open(path, "rb") as handle:
+            originals[name] = handle.read()
+
+    directories = [m for m in workspace_members() if publishable(m)] + list(EXTRA)
+    failures = []
+    for directory in directories:
+        problems = []
+        for name in LICENCES:
+            path = os.path.join(ROOT, directory, name)
+            if not os.path.isfile(path):
+                problems.append(f"{directory}/{name} is missing")
+                continue
+            with open(path, "rb") as handle:
+                if handle.read() != originals[name]:
+                    problems.append(f"{directory}/{name} differs from the root copy")
+        failures.extend(problems)
+        status = "licence texts present" if not problems else f"{len(problems)} problem(s)"
+        print(f"  {directory:<32} {status}")
+
+    spdx_problems = []
+    for copy, original in sorted(SPDX_COPIES.items()):
+        path = os.path.join(ROOT, copy)
+        if not os.path.isfile(path):
+            spdx_problems.append(f"{copy} is missing")
+            continue
+        with open(path, "rb") as handle:
+            if handle.read() != originals[original]:
+                spdx_problems.append(f"{copy} differs from {original}")
+    failures.extend(spdx_problems)
+    status = ("SPDX-named copies present" if not spdx_problems
+              else f"{len(spdx_problems)} problem(s)")
+    print(f"  {'LICENSES/':<32} {status}")
+
+    if failures:
+        print("\npublished packages would ship without their licence texts:", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        print("\ncopy LICENSE-MIT and LICENSE-APACHE from the repository root.", file=sys.stderr)
+        return 1
+
+    print(f"\n{len(directories)} published packages carry both licence texts.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_readme_links.py
+++ b/scripts/check_readme_links.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Binding READMEs must not use repository-relative links.
+
+Each `bindings/*/README.md` is, or is one workflow line away from being, the long
+description of a published package: PyPI renders the Python one, NuGet the C#
+one, pkg.go.dev the Go one, r-universe the R one. A link like
+`../../docs/COOKBOOK.md` resolves on GitHub and nowhere else -- on a registry page
+it is simply broken, and nothing in the build says so, because the file it points
+at does exist in the repository.
+
+So the rule is: anything that ships as package metadata links absolutely. The
+repository's own README is exempt and deliberately keeps relative links -- it is
+read on GitHub far more than anywhere else, and that is the convention the main
+wickra repository uses too.
+
+Run from the repository root:  python scripts/check_readme_links.py
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import sys
+
+ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+
+# A markdown link target that is neither absolute nor a same-page anchor. Also
+# catches HTML `src=`/`href=` attributes, which the banner markup uses.
+LINK = re.compile(r"\]\(\s*(?!https?://|#|mailto:)([^)\s]+)")
+ATTR = re.compile(r"(?:src|href)=\"(?!https?://|#|mailto:)([^\"]+)\"")
+
+
+def relative_targets(text: str, package_dir: str) -> list[str]:
+    """Relative targets that will not resolve once the package is unpacked.
+
+    A relative link is only broken off GitHub when it points at something that
+    does not travel with the package. One that stays inside the package
+    directory does travel and resolves wherever the package is unpacked:
+    `man/figures/logo.png` in the R binding is the standard R convention for
+    exactly that, and both CRAN and r-universe render it.
+
+    So the test is not "is it relative" but "does it leave the package, or point
+    at nothing".
+    """
+    found = ([m.group(1) for m in LINK.finditer(text)]
+             + [m.group(1) for m in ATTR.finditer(text)])
+    escaping = []
+    for target in found:
+        clean = target.split("#", 1)[0].split("?", 1)[0]
+        if not clean:
+            continue
+        resolved = os.path.normpath(os.path.join(package_dir, clean))
+        inside = os.path.commonpath([resolved, package_dir]) == package_dir
+        if not inside or not os.path.exists(resolved):
+            escaping.append(target)
+    return escaping
+
+
+def main() -> int:
+    paths = sorted(glob.glob(os.path.join(ROOT, "bindings", "*", "README.md")))
+    if not paths:
+        print("no binding READMEs found", file=sys.stderr)
+        return 1
+
+    failures = []
+    for path in paths:
+        rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
+        with open(path, encoding="utf-8") as handle:
+            found = relative_targets(handle.read(), os.path.dirname(path))
+        if found:
+            failures.append(f"{rel}: {', '.join(sorted(set(found)))}")
+        print(f"  {rel:<28} {'broken links: ' + str(len(found)) if found else 'all links resolve'}")
+
+    if failures:
+        print(
+            "\nthese READMEs ship as package long descriptions, where a link "
+            "that leaves the package, or points at nothing, is dead:",
+            file=sys.stderr,
+        )
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        print(
+            "\nuse https://github.com/wickra-lib/wickra/blob/main/<path> "
+            "instead.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nall {len(paths)} binding READMEs link only to what travels with them.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Seven findings. Coverage for the six language bindings is deliberately not among them — six toolchains, six CI jobs, and it changes a publicly visible number, so it gets its own round.

### Fuzzing: six of thirteen targets were actually fuzzed

The workflow listed targets by hand and seven had never been run. `fuzz build` proves a target compiles, which is not what fuzzing is for. Rather than adding seven more steps for the next person to forget, the list now comes from `cargo fuzz list` — so *every declared target is fuzzed* is structurally true instead of a property of a maintained list. Thirteen at 30 s each, so the job budget goes 30 → 40 minutes.

### The Go module was published without ever being compiled

`go-mirror` assembles the tree by copying files and rewriting an import path with `sed`, then pushed it to pkg.go.dev on that basis alone. A wrong header, a missing library or a botched `sed` would have surfaced on a user's machine. It now builds the assembled module and runs one indicator end to end first.

That surfaced a second defect: the seven `*_test.go` files were copied into the module and read `../../testdata/golden` — a path that exists here and not in a module fetched with `go get`. `go test` on the published module failed at `os.Open`. The tests stay in the repository; the module ships the library.

### Drift checks for the generated files

The committed napi loader is regenerated and compared (`index.js` shipped **0.9.7 inside the v0.9.9 tag**, because napi rewrites it only when somebody rebuilds), and so are the generated C# golden tests.

`Indicators.g.cs` and `NativeMethods.g.cs` **cannot** be checked this way: the generator that writes them is not in this repository. Stated in the workflow rather than left as an unexplained gap.

### Two check scripts

- `check_readme_links.py` — binding READMEs are published package descriptions, where a link out of the package is dead while resolving fine on GitHub. The rule needed sharpening while porting: a link that stays *inside* the package resolves after unpacking, and `man/figures/logo.png` in the R binding is the R convention for exactly that. So the test is whether a link leaves the package or points at nothing, not whether it is relative.
- `check_license_copies.py` — both licence texts, byte-for-byte, in every published package, with the list derived from the workspace.

### C streaming/batch equivalence

Node and Python assert that `update` and `batch` agree. C — the ABI every other binding sits on — was the one surface where they were never compared. The new test reuses the Node suite's series, tolerance and NaN handling, so a disagreement between the two is about the library rather than about the test.

Verified both ways: it passes, and with the streaming handle constructed at a different period it names the index and exits 1.

### CodeQL sees the examples now

Under `build-mode: manual` CodeQL analyses exactly what the compiler walks, so building only the test project left **11 of 23** C# files out — every example among them, which is the code readers copy into their own projects.

### Action pins

Seven were behind, each resolved to the **commit** rather than to the annotated tag object a ref lookup returns. The five in `pages.yml` are untouched: that workflow is not tracked in this repository.

---

Blueprint checker: **73/79 → 77/79**. The two that remain are coverage (deferred) and the three generated files whose generator lives outside this repository.

---

### Also in this branch: a release is all-or-nothing

`cargo-publish` and `wasm-publish` declared **no dependencies at all**. crates.io could receive a version while the Python wheels were still building, and a wheel failing afterwards left the crate published, unwithdrawable, and the release half-shipped. Making `github-release` wait on all eight publish jobs stopped the release page from lying; it did not stop the publishing.

Every publish job now waits on a `gate`, and the gate waits on all five build jobs **and** on evidence that the tagged commit was green. `ci.yml` does not run on tags, so the workflow cannot see the tag's health in its own run: the gate asks the API what the commit was graded, requires a successful `ci.yml` run on that SHA, and refuses if anything else that ran on it failed. Naming required workflows would go stale (`codspeed.yml` is path-filtered), so the rule is about outcomes, not a roster.

The WASM package moves into its own `wasm-build` job for the same reason — it was compiled inside the publish job, which put its build *behind* the gate. The publish step now uploads the packed tarball itself, so npm and the release get the same bytes.

Six registries cannot be made atomic. What this removes is the common case, which is not a registry outage but something that does not build.
