### PR TITLE
ci: pin ureq to 2.x in the fuzz Dependabot entry too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,16 @@ updates:
       default-days: 7
     commit-message:
       prefix: "deps(cargo-fuzz)"
+    # The fuzz lockfile resolves through a path dependency on the workspace, so
+    # a proposal here can land in crates/wickra-data/Cargo.toml -- which is how
+    # #425 arrived titled "/fuzz" while changing the main tree. ureq is pinned to
+    # 2.x for the same reason as in the root entry: ureq 3 hard-depends on
+    # webpki-root-certs (CDLA-Permissive-2.0) regardless of TLS backend, and that
+    # licence is not in deny.toml's allow list, so the bump cannot pass the
+    # supply-chain gate.
+    ignore:
+      - dependency-name: "ureq"
+        update-types: ["version-update:semver-major"]
     groups:
       cargo-fuzz:
         patterns: ["*"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The npm lockfile recorded the package's own version twice, and one of them
+  was stale.** `bindings/node/package-lock.json` carries the version at the top
+  level and again in the `packages[""]` entry; only the first is what `npm
+  version` rewrites, so the second sat at 1.0.1 across two releases. It was
+  repaired by an unrelated Dependabot regeneration rather than by anything
+  watching, and `check_version_sync.py` had missed it because it treats the
+  lockfile as generated and only asserted that the version appears somewhere in
+  it. Both records are now checked exactly; the rest of the file stays a
+  presence check, because those versions belong to other people.
+
 - **`Vpin::update` could never return for a large trade size.** It distributes a
   trade's volume across buckets with `while remaining > 0.0 { ... remaining -=
   take }`, and once the size is large enough that the bucket volume falls below

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -75,6 +75,19 @@ TOUCHPOINTS: list[tuple[str, str, str, int]] = [
     ("bindings/java/README.md", "install snippets", r"@V@", 2),
     # Prose sentence, the supported row, and the unsupported bound.
     ("SECURITY.md", "supported version", r"@V@", 3),
+    # npm records the package's own version twice in the lockfile: once at the
+    # top level and once in the `packages[""]` entry. Only the first is what
+    # `npm version` rewrites, so the second goes stale on its own -- it sat at
+    # 1.0.1 across two releases and was repaired by an unrelated Dependabot
+    # regeneration (#426) rather than by anything watching. Both are ours and
+    # both are checked exactly; the rest of the lockfile stays a presence check
+    # in GENERATED, because those versions belong to other people.
+    (
+        "bindings/node/package-lock.json",
+        "own version, both records",
+        r'"name": "wickra",\s+"version": "@V@"',
+        2,
+    ),
 ]
 
 # Each platform package declares its own version.


### PR DESCRIPTION
The `cargo /fuzz` entry added yesterday closed a real gap — `fuzz/Cargo.lock` is its own workspace that the root entry never reached, so `libfuzzer-sys` and `arbitrary` went unwatched. It inherited none of the root entry's ignores, and the first proposal it produced was #425: ureq 2 → 3.

That bump cannot land. ureq 3 hard-depends on `webpki-root-certs` whatever the TLS backend, that crate is **CDLA-Permissive-2.0**, and CDLA is not in `deny.toml`'s allow list — `cargo-deny` rejects the graph. The reasoning is already written directly above the pinned line in `crates/wickra-data/Cargo.toml`, and the root `cargo` entry carries the matching ignore. This one now does too.

Worth recording why the proposal reached the main tree at all: the fuzz lockfile resolves through a path dependency on the workspace, so a pull request titled *"in /fuzz"* changed `crates/wickra-data/Cargo.toml`. A per-directory entry is not confined to that directory.