### PR TITLE
fix: close the findings from the independent blueprint audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -106,7 +106,8 @@ updates:
     # target Python via --python-version). Dependabot bumps the .txt directly
     # and does NOT respect those targets, so every ci-pip group PR broke the
     # 3.9 rows (dropped `==` pins / pulled py3.10-only pytest/numpy/hypothesis).
-    # Security updates are unaffected by this limit.
+    # Security updates are exempt from the limit and still arrive -- which is
+    # why there is no `ignore` list below.
     open-pull-requests-limit: 0
     cooldown:
       default-days: 7
@@ -115,25 +116,22 @@ updates:
     groups:
       ci-pip:
         patterns: ["*"]
-    ignore:
-      # numpy >=2.5 dropped support for Python < 3.12, but the CI matrix still
-      # tests 3.9/3.10/3.11. Pin numpy in the hash-locked CI tooling so a bump
-      # can't break those rows again (a 2.5.1 bump did, and was reverted). The
-      # CI tooling only needs a working numpy, not the newest.
-      - dependency-name: "numpy"
-        update-types: ["version-update:semver-minor", "version-update:semver-major"]
-      # hypothesis >=6.142 requires Python >=3.10, but ci-dev-py39.txt targets
-      # 3.9. A bump to 6.157 broke every 3.9 matrix row (pip "Ignored the
-      # following versions that require a different python version"). Freeze
-      # hypothesis so the 3.9 dev-tooling lockfile stays installable.
-      - dependency-name: "hypothesis"
-        update-types: ["version-update:semver-minor", "version-update:semver-major"]
-      # pytest >=9 requires Python >=3.10 (9.0.0 "Requires-Python >=3.10"), but
-      # ci-dev-py39.txt targets the 3.9 matrix rows. A bump to 9.x made pip fail
-      # ("No matching distribution found for pytest==9.1.1") on every 3.9 job.
-      # Freeze pytest so the 3.9 dev-tooling lockfile stays installable.
-      - dependency-name: "pytest"
-        update-types: ["version-update:semver-minor", "version-update:semver-major"]
+    # No `ignore` here, deliberately. `open-pull-requests-limit: 0` above
+    # already suppresses every version-update pull request for this ecosystem,
+    # so an ignore adds nothing there. Its only remaining effect would be on
+    # *security* updates, which are exempt from the limit and are the one thing
+    # that should still get through.
+    #
+    # Three ignores used to sit here -- numpy, hypothesis, pytest -- each added
+    # because a bump broke the 3.9 matrix rows. That reasoning is about version
+    # updates, which the limit handles. Keeping them meant a future advisory in
+    # any of the three would produce no pull request at all: silence, rather
+    # than a red one somebody decides about. A security bump that breaks the
+    # 3.9 row is a visible problem; a suppressed advisory is not.
+    #
+    # Detection no longer rests on Dependabot either: osv-scanner runs in
+    # ci.yml across every ecosystem and fails the build on a vulnerable
+    # dependency whether or not a pull request exists.
 
   # GitHub Actions — keeps the SHA-pinned actions current (Dependabot reads
   # the version comment after each pinned SHA and bumps both together).

--- a/.github/workflows/check-indicator-count.yml
+++ b/.github/workflows/check-indicator-count.yml
@@ -115,8 +115,16 @@ jobs:
             echo "::error::docs/README.md does not say '**${n} indicators**' — lib.rs exports ${n}. Re-run the indicator wiring (it bumps docs/README.md), then push again."
             ok=false
           fi
+          # CITATION.cff is what GitHub's citation box and Zenodo read, and
+          # nothing was watching it: it said 214 indicators across 16 families
+          # when there were 514 across 24, and named three languages of ten. A
+          # release artefact in every sense except that no tool looked at it.
+          if ! grep -qE "^[[:space:]]+${n} indicators across" CITATION.cff; then
+            echo "::error::CITATION.cff does not say '${n} indicators across' — lib.rs exports ${n}. It is what the citation box and Zenodo read."
+            ok=false
+          fi
           if [ "$ok" = "true" ]; then
-            echo "README.md + docs/README.md counter already at ${n}; nothing to do."
+            echo "README.md, docs/README.md and CITATION.cff counter already at ${n}; nothing to do."
           else
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,7 +426,7 @@ jobs:
   # Supply-chain audit: security advisories, license policy, banned crates,
   # and source restrictions. Configured by deny.toml at the repo root.
   supply-chain:
-    name: Supply-chain (cargo-deny)
+    name: Supply-chain (cargo-deny + osv-scanner)
     runs-on: ubuntu-latest
     timeout-minutes: 30 # backstop: cap a wedged job instead of GitHub's 6h default (headroom for slow registry/package installs)
     steps:
@@ -449,6 +449,23 @@ jobs:
   # The baseline is the newest version already on crates.io, fetched by the tool
   # itself. On a release that has not moved the API this finds nothing; the run
   # that matters is the one where it does.
+
+      # osv-scanner.toml existed and nothing ran it. The file records two
+      # advisories assessed as not affecting this project, with the reasoning
+      # next to each -- and that assessment was load-bearing for nobody,
+      # because no workflow ever consulted it. It only had an effect if
+      # OpenSSF Scorecard happened to read it out of band.
+      #
+      # cargo-deny above covers the Rust graph only. This covers the other
+      # six ecosystems -- npm, PyPI, Maven, NuGet, Go modules, R -- which had
+      # no vulnerability scanning in CI at all.
+      - name: osv-scanner
+        uses: google/osv-scanner-action/osv-scanner-action@9bb69575e74019c2ad085a1860787043adf47ccb # v2.5.1
+        with:
+          scan-args: |-
+            --recursive
+            --config=osv-scanner.toml
+            ./
   semver:
     name: Public API (cargo-semver-checks)
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,18 @@ jobs:
             build-mode: none
           - language: javascript-typescript
             build-mode: none
+          # Go and C/C++ were the two languages the matrix left out, and the
+          # stated reason -- "C# and Java are the two bindings where a memory
+          # mistake is possible" -- was simply wrong. bindings/go casts slice
+          # base addresses through unsafe.Pointer and hands them to C, which is
+          # undefined for an empty slice, and manages handle lifetimes with
+          # runtime.SetFinalizer. bindings/r/src/wickra.c is C compiled into the
+          # CRAN package, and include/wickra.hpp is a hand-written RAII wrapper
+          # that the C examples compile and run in CI.
+          - language: go
+            build-mode: manual
+          - language: c-cpp
+            build-mode: manual
           # C# and Java are compiled with an explicit command rather than read as
           # source. `build-mode: none` was tried first and GitHub reported the
           # result as low quality: 64% of C# calls resolved to a target against a
@@ -80,6 +92,45 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: .github/codeql/codeql-config.yml
+
+      # Go and C/C++ both need the C ABI library present before they build:
+      # the Go binding links it through cgo, and the C examples link it via
+      # CMake. One cargo build serves both.
+      - name: Install Rust toolchain
+        if: matrix.language == 'go' || matrix.language == 'c-cpp'
+        uses: ./.github/actions/setup-rust
+
+      - name: Build the C ABI library
+        if: matrix.language == 'go' || matrix.language == 'c-cpp'
+        run: cargo build -p wickra-c --release
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "stable"
+          cache: false
+
+      - name: Build the Go binding
+        if: matrix.language == 'go'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p bindings/go/lib/linux_amd64
+          cp target/release/libwickra.so bindings/go/lib/linux_amd64/
+          go build ./...
+
+      # The C examples are the consumers of the header and of the hand-written
+      # C++ RAII wrapper, so compiling them is what puts both in the database.
+      # bindings/r/src/wickra.c is NOT covered here: it is compiled by the R
+      # toolchain during package build, and pulling that into this job would
+      # add a fragile dependency for one generated file. Said plainly rather
+      # than left to look like coverage.
+      - name: Build the C and C++ examples
+        if: matrix.language == 'c-cpp'
+        run: |
+          cmake -S examples/c -B examples/c/build
+          cmake --build examples/c/build --config Release
 
       # CodeQL sees exactly what the compiler walks, so anything it does not
       # build is not analysed. Building only the test project left the eleven

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -116,9 +116,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p bindings/go/lib/linux_amd64
-          cp target/release/libwickra.so bindings/go/lib/linux_amd64/
+          mkdir -p lib/linux_amd64
+          cp ../../target/release/libwickra.so lib/linux_amd64/
           go build ./...
+        working-directory: bindings/go
 
       # The C examples are the consumers of the header and of the hand-written
       # C++ RAII wrapper, so compiling them is what puts both in the database.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,8 +47,13 @@ jobs:
           # runtime.SetFinalizer. bindings/r/src/wickra.c is C compiled into the
           # CRAN package, and include/wickra.hpp is a hand-written RAII wrapper
           # that the C examples compile and run in CI.
+          # autobuild rather than manual: with a manual command CodeQL traced
+          # the build and then finalised an empty database. Its Go extractor
+          # runs its own build and finds the module in the subdirectory, which
+          # is what the language wants. The C ABI library is still staged in
+          # front of it, because cgo has to link.
           - language: go
-            build-mode: manual
+            build-mode: autobuild
           - language: c-cpp
             build-mode: manual
           # C# and Java are compiled with an explicit command rather than read as
@@ -111,22 +116,17 @@ jobs:
           go-version: "stable"
           cache: false
 
-      - name: Build the Go binding
+      # Staged before CodeQL autobuilds: the cgo LDFLAGS point at
+      # ${SRCDIR}/lib/<goos>_<goarch>, so without the library there the build
+      # cannot link and nothing is extracted.
+      - name: Stage the native library for cgo
         if: matrix.language == 'go'
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p lib/linux_amd64
-          cp ../../target/release/libwickra.so lib/linux_amd64/
-          go build ./...
-        working-directory: bindings/go
+          mkdir -p bindings/go/lib/linux_amd64
+          cp target/release/libwickra.so bindings/go/lib/linux_amd64/
 
-      # The C examples are the consumers of the header and of the hand-written
-      # C++ RAII wrapper, so compiling them is what puts both in the database.
-      # bindings/r/src/wickra.c is NOT covered here: it is compiled by the R
-      # toolchain during package build, and pulling that into this job would
-      # add a fragile dependency for one generated file. Said plainly rather
-      # than left to look like coverage.
       - name: Build the C and C++ examples
         if: matrix.language == 'c-cpp'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,29 @@ jobs:
       contents: read
       actions: read
     steps:
+      # workflow_dispatch exists so a release whose publish step failed can be
+      # re-run without moving the tag. It must not become a way to publish from
+      # a branch: dispatched from main, GITHUB_REF_NAME is "main", cargo/npm/PyPI
+      # would push whatever the manifests currently say, and go-mirror would
+      # replace the contents of the public wickra-go and tag it "vmain".
+      #
+      # The `release` environment carries no deployment-branch policy, so this is
+      # the only thing standing in the way. Checked here rather than on each
+      # publish job: one gate, and a job that is skipped rather than failed reads
+      # as "nothing to do" instead of "refused".
+      - name: Refuse to publish from anything but a version tag
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          case "$REF" in
+            refs/tags/v*) echo "publishing for $REF" ;;
+            *)
+              echo "::error::release.yml publishes only for a refs/tags/v* ref; got $REF"
+              exit 1
+              ;;
+          esac
+
       - name: The tagged commit must have passed CI
         env:
           GH_TOKEN: ${{ github.token }}
@@ -469,6 +492,60 @@ jobs:
       # job loudly so the release does not silently land in a half-published
       # state. Previously this loop swallowed the second-attempt failure with
       # a `::warning::` and `return 0`; that mask is removed.
+      # The SPDX expression in every manifest is a reference to two documents;
+      # none of the npm packages carried either. check_license_copies.py says
+      # npm is 'handled at publish time' -- true in wickra-backtest, which has
+      # this step, and never true here, so the assertion delegated to a
+      # mechanism that did not exist.
+      #
+      # Copying is not enough: `files` decides what npm packs, and a name
+      # missing from it is dropped without a word. `npm pack --dry-run` is
+      # asked what would actually go out, before it goes out.
+      # `napi artifacts` distributes the downloaded binaries into npm/*/ by
+      # name. If a platform's build artefact never arrived, its directory is
+      # simply left without a .node -- and the loop below would publish a stub
+      # that installs cleanly and then fails at require() on that platform.
+      # node-build uses if-no-files-found: error and gate waits on it, so this
+      # is hard to reach; it is also cheap to prove rather than assume.
+      - name: Every platform package has its binary
+        working-directory: bindings/node
+        run: |
+          set -euo pipefail
+          missing=0
+          for dir in npm/*/; do
+            pkg=$(basename "$dir")
+            if ! ls "$dir"/*.node >/dev/null 2>&1; then
+              echo "::error::wickra-$pkg has no .node binary; it would publish as an empty stub"
+              missing=1
+            else
+              echo "wickra-$pkg: $(basename "$dir"/*.node)"
+            fi
+          done
+          [ "$missing" -eq 0 ]
+
+      - name: Stage the licence texts and prove they will be packed
+        working-directory: bindings/node
+        run: |
+          set -euo pipefail
+          for dir in . npm/*/; do
+            cp ../../LICENSE-MIT ../../LICENSE-APACHE "$dir/"
+          done
+          for dir in . npm/*/; do
+            ( cd "$dir" && npm pack --dry-run --json ) | node -e '
+              const chunks = [];
+              process.stdin.on("data", c => chunks.push(c));
+              process.stdin.on("end", () => {
+                const pkg = JSON.parse(chunks.join(""))[0];
+                const names = pkg.files.map(f => f.path);
+                const missing = ["LICENSE-MIT", "LICENSE-APACHE"].filter(n => !names.includes(n));
+                if (missing.length) {
+                  console.error(`::error::${pkg.name} would publish without ${missing.join(" and ")}`);
+                  process.exit(1);
+                }
+                console.log(`${pkg.name}: licence texts present`);
+              });'
+          done
+
       - name: Publish platform packages (idempotent)
         working-directory: bindings/node
         env:
@@ -1271,11 +1348,19 @@ jobs:
   attestations:
     name: Attest build provenance
     timeout-minutes: 45 # backstop only: release build/publish jobs compile from source (vendored OpenSSL) and must not be killed mid-build; far above the ~10 min real runtime
-    needs: [cargo-publish, python-wheels, python-sdist, github-release]
+    needs: [cargo-publish, python-wheels, python-sdist, c-abi-build,
+            csharp-publish, java-publish, github-release]
     runs-on: ubuntu-latest
-    # Signed SLSA build-provenance attestations for the published crates and
-    # Python wheels/sdist. npm tarballs already carry inline Sigstore provenance
-    # from `npm publish --provenance`, so they are covered there.
+    # Signed SLSA build-provenance attestations for everything published that
+    # does not already carry provenance of its own. npm tarballs do -- `npm
+    # publish --provenance` embeds it inline -- so the node and wasm packages are
+    # covered there and are not repeated here.
+    #
+    # The .nupkg, the .jar and the C ABI archives were covered nowhere. They are
+    # the two packages C# and Java consumers install and the archive people
+    # download and link against, and Scorecard reported Signed-Releases 10/10
+    # regardless, because it looks for a provenance file on the release rather
+    # than for coverage of what the release contains.
     #
     # The job stays isolated from the *publishes*: cargo/PyPI/npm all run upstream
     # of github-release, so a Sigstore hiccup here can never block or corrupt a
@@ -1303,11 +1388,30 @@ jobs:
           pattern: wheels-*
           path: artifacts/python
           merge-multiple: true
+      - name: Download the C ABI archives
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: c-abi-*
+          path: artifacts/c-abi
+          merge-multiple: true
+      - name: Download the NuGet package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nuget-package
+          path: artifacts/nuget
+      - name: Download the Java jar
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: java-jar
+          path: artifacts/java
       - name: Attest build provenance
         id: attest
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
+            artifacts/c-abi/*.tar.gz
+            artifacts/nuget/*.nupkg
+            artifacts/java/*.jar
             artifacts/crates/*.crate
             artifacts/python/*.whl
             artifacts/python/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -531,6 +531,8 @@ jobs:
             cp ../../LICENSE-MIT ../../LICENSE-APACHE "$dir/"
           done
           for dir in . npm/*/; do
+            # shellcheck disable=SC2016 -- the ${...} below are JavaScript template
+            # literals inside a single-quoted node script, not shell expansions.
             ( cd "$dir" && npm pack --dry-run --json ) | node -e '
               const chunks = [];
               process.stdin.on("data", c => chunks.push(c));

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -531,8 +531,9 @@ jobs:
             cp ../../LICENSE-MIT ../../LICENSE-APACHE "$dir/"
           done
           for dir in . npm/*/; do
-            # shellcheck disable=SC2016 -- the ${...} below are JavaScript template
-            # literals inside a single-quoted node script, not shell expansions.
+            # The ${...} below are JavaScript template literals inside a
+            # single-quoted node script, not shell expansions.
+            # shellcheck disable=SC2016
             ( cd "$dir" && npm pack --dry-run --json ) | node -e '
               const chunks = [];
               process.stdin.on("data", c => chunks.push(c));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   carries the same file Maven Central received. The sources and javadoc jars
   stay on Maven Central, where a build tool resolves them on demand.
 
+- **CodeQL analyses Go and C/C++.** The matrix left out the binding that casts
+  slice base addresses through `unsafe.Pointer` and manages handle lifetimes
+  with `runtime.SetFinalizer`, and the hand-written C++ RAII wrapper that the C
+  examples compile and run in CI. The stated reason — that C# and Java were the
+  only bindings where a memory mistake is possible — was wrong.
+
+- **Every platform package is proved to have its binary before publishing.** If
+  a build artefact never arrives, `napi artifacts` leaves that directory without
+  a `.node` and the stub publishes as an empty package that installs cleanly and
+  fails at `require()`. Hard to reach, cheap to prove.
+
+- **The committed napi loader is regenerated for `@napi-rs/cli` 3.8.6.** The
+  bump (#426) changed only the lockfile, and `index.js` is generated rather than
+  written: 3.8.6 emits WASI-flavour selection and a shared
+  `createLoadErrorChain` that 3.7.4 did not. The drift check added the day
+  before caught it on `main` -- the pull request itself was green because
+  Dependabot tested it against a base commit from before that check existed.
+- **The npm lockfile recorded the package's own version twice, and one of them
+  was stale.** `bindings/node/package-lock.json` carries the version at the top
+  level and again in the `packages[""]` entry; only the first is what `npm
+  version` rewrites, so the second sat at 1.0.1 across two releases. It was
+  repaired by an unrelated Dependabot regeneration rather than by anything
+  watching, and `check_version_sync.py` had missed it because it treats the
+  lockfile as generated and only asserted that the version appears somewhere in
+  it. Both records are now checked exactly; the rest of the file stays a
+  presence check, because those versions belong to other people.
+
+- **`Vpin::update` could never return for a large trade size.** It distributes a
+  trade's volume across buckets with `while remaining > 0.0 { ... remaining -=
+  take }`, and once the size is large enough that the bucket volume falls below
+  one ULP of it, the subtraction changes nothing: at 1.4e277 against a bucket of
+  8, `remaining` stays exactly where it was and the loop never ends. Not slow --
+  non-terminating. A single trade hung the caller for good, and 1.4e277 passes
+  `Trade::new` unchanged, so this was reachable through the ordinary validating
+  API rather than only through `new_unchecked`.
+
+  The loop is now bounded by what can still be observed. A trade is one-sided,
+  so every complete bucket it fills carries an imbalance of exactly the bucket
+  volume, and the window keeps only the last `num_buckets`; anything beyond that
+  pushes values identical to the ones it evicts. The bound keeps the remainder
+  that decides where the next bucket boundary falls, so it is exact rather than
+  an approximation — a test asserts that one 1000.5-sized trade leaves the same
+  state as 2001 trades of 0.5.
+
+  Found by `fuzz/fuzz_targets/indicator_update_trade.rs` on its first ever run.
+  It was one of seven targets that were built but never executed, which is what
+  the change to fuzzing every declared target was for.
+
+- **Every release since the .NET binding shipped attached the package to
+  nuget.org but not to the release page.** `csharp-publish` packs the package,
+  pushes it, and uploads it as a build artifact -- and the staging step in
+  `github-release` listed six `find` patterns, none of which matched `*.nupkg`,
+  so the file was downloaded with the rest and then left behind. With
+  `fail_on_unmatched_files` false nothing reported it. `v1.0.3` carries 36
+  assets -- wheels, sdist, `.node` binaries, npm tarballs, `.crate` files and
+  SBOMs -- and NuGet was the one registry artefact with no counterpart there.
+  The registry was never affected: all 28 published versions are on nuget.org.
+
+- **The release could be published before NuGet, Maven Central and the Go module
+  were.** `github-release` waited on five of the eight publishing jobs, so the
+  three that ship to those three destinations could still be running -- or
+  failing -- while the release notes already told readers they were live. It now
+  waits on all eight: `csharp-publish` and `java-publish` because it stages the
+  files they upload, `go-mirror` because the notes claim the Go module is
+  available.
+
+
 ### Changed
 
 - **A release is all-or-nothing: nothing is published unless everything is
@@ -254,60 +321,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **The committed napi loader is regenerated for `@napi-rs/cli` 3.8.6.** The
-  bump (#426) changed only the lockfile, and `index.js` is generated rather than
-  written: 3.8.6 emits WASI-flavour selection and a shared
-  `createLoadErrorChain` that 3.7.4 did not. The drift check added the day
-  before caught it on `main` -- the pull request itself was green because
-  Dependabot tested it against a base commit from before that check existed.
-- **The npm lockfile recorded the package's own version twice, and one of them
-  was stale.** `bindings/node/package-lock.json` carries the version at the top
-  level and again in the `packages[""]` entry; only the first is what `npm
-  version` rewrites, so the second sat at 1.0.1 across two releases. It was
-  repaired by an unrelated Dependabot regeneration rather than by anything
-  watching, and `check_version_sync.py` had missed it because it treats the
-  lockfile as generated and only asserted that the version appears somewhere in
-  it. Both records are now checked exactly; the rest of the file stays a
-  presence check, because those versions belong to other people.
+- **A manual run of `release.yml` could publish from a branch.** The workflow
+  carries `workflow_dispatch` so a failed publish can be retried without moving
+  the tag, and the `release` environment has no deployment-branch policy, so
+  nothing stopped a dispatch from `main`: the gate would pass (main *has* a
+  green CI run), cargo, npm and PyPI would publish whatever the manifests said,
+  and `go-mirror` would replace the contents of the public `wickra-go` and tag
+  it `vmain`. The gate now refuses any ref that is not `refs/tags/v*`. The
+  blueprint's claim that "release.yml runs on `push: tags` and nothing else" —
+  which is why the environment was left unprotected — was simply wrong.
 
-- **`Vpin::update` could never return for a large trade size.** It distributes a
-  trade's volume across buckets with `while remaining > 0.0 { ... remaining -=
-  take }`, and once the size is large enough that the bucket volume falls below
-  one ULP of it, the subtraction changes nothing: at 1.4e277 against a bucket of
-  8, `remaining` stays exactly where it was and the loop never ends. Not slow --
-  non-terminating. A single trade hung the caller for good, and 1.4e277 passes
-  `Trade::new` unchanged, so this was reachable through the ordinary validating
-  API rather than only through `new_unchecked`.
+- **The seven npm packages shipped without either licence text.** Every manifest
+  declares `MIT OR Apache-2.0`, which is a reference to two documents, and
+  neither travelled. `check_license_copies.py` asserted npm was "handled at
+  publish time (see release.yml)" — true in the sibling repository it was ported
+  from, never true here. release.yml now stages the copies and proves with `npm
+  pack --dry-run` that they are actually packed, because `files` decides what npm
+  ships and a name missing from it is dropped without a word. All seven `files`
+  allowlists name them, and the script verifies both halves rather than
+  delegating to a step that might not exist.
 
-  The loop is now bounded by what can still be observed. A trade is one-sided,
-  so every complete bucket it fills carries an imbalance of exactly the bucket
-  volume, and the window keeps only the last `num_buckets`; anything beyond that
-  pushes values identical to the ones it evicts. The bound keeps the remainder
-  that decides where the next bucket boundary falls, so it is exact rather than
-  an approximation — a test asserts that one 1000.5-sized trade leaves the same
-  state as 2001 trades of 0.5.
+- **`CITATION.cff` was three hundred indicators out of date** — "214 indicators
+  across 16 families", naming three languages of ten, while the catalogue holds
+  514 across twenty-four. It is what GitHub's citation box and Zenodo read, and
+  no check had ever looked at it. `check-indicator-count.yml` now holds it to the
+  count alongside the two READMEs.
 
-  Found by `fuzz/fuzz_targets/indicator_update_trade.rs` on its first ever run.
-  It was one of seven targets that were built but never executed, which is what
-  the change to fuzzing every declared target was for.
+- **`.nupkg`, `.jar` and the C ABI archives had no build provenance.** The
+  attestation job covered crates, wheels and the sdist; npm packages carry their
+  own inline provenance. That left the two packages C# and Java consumers
+  install, and the archive people download and link against, attested nowhere —
+  while Scorecard reported Signed-Releases 10/10, because it looks for a
+  provenance file on the release rather than for coverage of its contents.
 
-- **Every release since the .NET binding shipped attached the package to
-  nuget.org but not to the release page.** `csharp-publish` packs the package,
-  pushes it, and uploads it as a build artifact -- and the staging step in
-  `github-release` listed six `find` patterns, none of which matched `*.nupkg`,
-  so the file was downloaded with the rest and then left behind. With
-  `fail_on_unmatched_files` false nothing reported it. `v1.0.3` carries 36
-  assets -- wheels, sdist, `.node` binaries, npm tarballs, `.crate` files and
-  SBOMs -- and NuGet was the one registry artefact with no counterpart there.
-  The registry was never affected: all 28 published versions are on nuget.org.
+- **`osv-scanner.toml` was executed by nothing.** The file records two advisories
+  assessed as not affecting this project, and that assessment was load-bearing
+  for no one: no workflow consulted it. `cargo-deny` covers the Rust graph only,
+  so npm, PyPI, Maven, NuGet, Go modules and R had no vulnerability scanning in
+  CI at all. osv-scanner now runs in the supply-chain job.
 
-- **The release could be published before NuGet, Maven Central and the Go module
-  were.** `github-release` waited on five of the eight publishing jobs, so the
-  three that ship to those three destinations could still be running -- or
-  failing -- while the release notes already told readers they were live. It now
-  waits on all eight: `csharp-publish` and `java-publish` because it stages the
-  files they upload, `go-mirror` because the notes claim the Go module is
-  available.
+- **Three Dependabot `ignore` entries suppressed security updates.**
+  `open-pull-requests-limit: 0` already blocks every version-update pull request
+  for the CI Python tooling, so the ignores on numpy, hypothesis and pytest had
+  exactly one remaining effect: security updates, which are exempt from the
+  limit, were suppressed too. A future advisory in any of the three would have
+  produced silence rather than a red pull request somebody decides about.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Go standard-library advisories are recorded as not applying, with the
+  reasoning.** Turning osv-scanner on surfaced 90 of them at once, all against
+  `stdlib 1.23.99` — the scanner reads the `go` directive in a `go.mod` as the
+  standard library in use. That is the right reading for an application and the
+  wrong one for a library: the directive is a *minimum* language version, and
+  whoever imports the module builds it with their own toolchain. Nothing here
+  ships a Go binary; CI and the release workflow both build the mirror with
+  `stable`.
+
+  Raising the directive would fix the report and force every consumer of the Go
+  binding onto that toolchain — a decision about who can use the module, not a
+  fix for anything this repository builds. It is left as a decision rather than
+  taken quietly.
+
 - **GHSA-6w46-j5rx-g56g (pytest tmpdir handling) is recorded as not affecting
   this project**, with the reasoning in `osv-scanner.toml` rather than left to
   be rediscovered. pytest is a CI-only test dependency and is never shipped, and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,13 +13,14 @@ repository-code: "https://github.com/wickra-lib/wickra"
 url: "https://wickra.org"
 abstract: >-
   Wickra is a streaming-first technical-analysis library implemented in
-  Rust with bindings for Python, Node.js and WebAssembly. Each indicator
-  is a state machine that updates in constant time per new input, so
-  identical code paths serve live-trading workloads and historical
-  back-testing. The library covers 214 indicators across 16 families
-  (moving averages, momentum, volatility, volume, statistics, Ehlers
-  digital-signal-processing cycles, pivots, DeMark, Ichimoku, candlestick
-  patterns, market profile, and risk/performance metrics).
+  Rust, usable from ten languages: Rust, Python, Node.js, WebAssembly, C,
+  C++, C#, Java, Go and R. Each indicator is a state machine that updates
+  in constant time per new input, so identical code paths serve
+  live-trading workloads and historical back-testing. The library covers
+  514 indicators across twenty-four families (moving averages, momentum,
+  volatility, volume, statistics, Ehlers digital-signal-processing cycles,
+  pivots, DeMark, Ichimoku, candlestick and chart patterns, market profile,
+  microstructure, and risk/performance metrics).
 keywords:
   - technical-analysis
   - technical-indicators

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -4,7 +4,9 @@
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [
-    "wickra.darwin-arm64.node"
+    "wickra.darwin-arm64.node",
+    "LICENSE-MIT",
+    "LICENSE-APACHE"
   ],
   "license": "MIT OR Apache-2.0",
   "engines": {

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -4,7 +4,9 @@
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [
-    "wickra.darwin-x64.node"
+    "wickra.darwin-x64.node",
+    "LICENSE-MIT",
+    "LICENSE-APACHE"
   ],
   "license": "MIT OR Apache-2.0",
   "engines": {

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -4,7 +4,9 @@
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [
-    "wickra.linux-arm64-gnu.node"
+    "wickra.linux-arm64-gnu.node",
+    "LICENSE-MIT",
+    "LICENSE-APACHE"
   ],
   "license": "MIT OR Apache-2.0",
   "engines": {

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -4,7 +4,9 @@
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [
-    "wickra.linux-x64-gnu.node"
+    "wickra.linux-x64-gnu.node",
+    "LICENSE-MIT",
+    "LICENSE-APACHE"
   ],
   "license": "MIT OR Apache-2.0",
   "engines": {

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -4,7 +4,9 @@
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [
-    "wickra.win32-arm64-msvc.node"
+    "wickra.win32-arm64-msvc.node",
+    "LICENSE-MIT",
+    "LICENSE-APACHE"
   ],
   "license": "MIT OR Apache-2.0",
   "engines": {

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -4,7 +4,9 @@
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [
-    "wickra.win32-x64-msvc.node"
+    "wickra.win32-x64-msvc.node",
+    "LICENSE-MIT",
+    "LICENSE-APACHE"
   ],
   "license": "MIT OR Apache-2.0",
   "engines": {

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -25,7 +25,9 @@
   "homepage": "https://github.com/wickra-lib/wickra",
   "files": [
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "LICENSE-MIT",
+    "LICENSE-APACHE"
   ],
   "napi": {
     "binaryName": "wickra",

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -27,3 +27,24 @@ reason = "tools.jackson.core:jackson-core 3.x is not a dependency of this projec
 [[IgnoredVulns]]
 id = "GHSA-6w46-j5rx-g56g"
 reason = "pytest is a CI-only test dependency, never shipped; the flaw needs a second local user, which a single-user ephemeral runner does not have. Pinned at 8.4.2 because pytest 9 requires Python >= 3.10 and the 3.9 matrix row needs it."
+
+# Go stdlib advisories against the `go` directive. osv-scanner reads the version
+# in a go.mod as the standard library in use and reports every advisory fixed
+# after it -- 90 of them at the time of writing, all against `stdlib 1.23.99`.
+#
+# For an application that is the right reading. For a library it is not: the
+# directive is a *minimum* language version, and whoever imports the module
+# builds it with their own toolchain. Nothing in this repository ships a Go
+# binary. CI builds with `stable`, and release.yml assembles and compiles the
+# wickra-go mirror with `stable` as well, so no artefact produced here is linked
+# against a 1.23 standard library.
+#
+# The alternative is to raise the directive, which forces every consumer of the
+# Go binding onto that toolchain. That is a compatibility decision about who can
+# use the module, not a fix for anything this repository builds -- so it is left
+# as a decision rather than taken silently here.
+[[PackageOverrides]]
+ecosystem = "Go"
+name = "stdlib"
+ignore = true
+reason = "The `go` directive is a minimum language version, not the toolchain in use. CI and the release workflow build with `stable`; no artefact here links a 1.23 standard library."

--- a/scripts/check_license_copies.py
+++ b/scripts/check_license_copies.py
@@ -23,6 +23,7 @@ Run from the repository root:  python scripts/check_license_copies.py
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import sys
@@ -110,8 +111,52 @@ def main() -> int:
         print("\ncopy LICENSE-MIT and LICENSE-APACHE from the repository root.", file=sys.stderr)
         return 1
 
-    print(f"\n{len(directories)} published packages carry both licence texts.")
+    npm_problems = check_npm()
+    if npm_problems:
+        print("\nthe npm packages would ship without their licence texts:",
+              file=sys.stderr)
+        for failure in npm_problems:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print(f"\n{len(directories)} published packages carry both licence texts, "
+          "and the npm side is staged and allow-listed.")
     return 0
+
+
+def check_npm() -> list[str]:
+    """The npm side: the staging step must exist, and `files` must name the texts."""
+    problems = []
+    release_yml = os.path.join(ROOT, ".github", "workflows", "release.yml")
+    if not os.path.isfile(release_yml):
+        return ["release.yml is missing"]
+    with open(release_yml, encoding="utf-8") as handle:
+        workflow = handle.read()
+    if "cp ../../LICENSE-MIT ../../LICENSE-APACHE" not in workflow:
+        problems.append(
+            "release.yml stages no licence copies for the npm packages -- the "
+            "delegation in this file's header would be to nothing")
+
+    manifests = [os.path.join(ROOT, "bindings", "node", "package.json")]
+    npm_dir = os.path.join(ROOT, "bindings", "node", "npm")
+    if os.path.isdir(npm_dir):
+        manifests += [os.path.join(npm_dir, name, "package.json")
+                      for name in sorted(os.listdir(npm_dir))]
+    for manifest in manifests:
+        if not os.path.isfile(manifest):
+            continue
+        with open(manifest, encoding="utf-8") as handle:
+            declared = json.load(handle)
+        listed = declared.get("files")
+        rel = os.path.relpath(manifest, ROOT).replace(os.sep, "/")
+        if listed is None:
+            continue  # no allowlist: npm packs everything, nothing can be dropped
+        absent = [n for n in LICENCES if n not in listed]
+        if absent:
+            problems.append(f"{rel}: `files` omits {' and '.join(absent)}")
+        else:
+            print(f"  {rel:<44} allow-listed")
+    return problems
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Eight findings from an independent audit, ordered by what each would have cost. One pull request.

### A manual run of `release.yml` could publish from a branch

`workflow_dispatch` is there so a failed publish can be retried without moving the tag, and the `release` environment carries **no deployment-branch policy**. So nothing stopped a dispatch from `main`: the gate passes (main *does* have a green CI run), cargo/npm/PyPI publish whatever the manifests say, and `go-mirror` replaces the contents of the public `wickra-go` and tags it **`vmain`**.

The gate now refuses any ref that is not `refs/tags/v*`. The blueprint's claim that release.yml "runs on `push: tags` and nothing else" — the stated reason for leaving the environment unprotected — was wrong.

### The seven npm packages shipped without either licence text

Every manifest declares `MIT OR Apache-2.0`, which is a reference to two documents, and neither travelled. `check_license_copies.py` asserted npm was *"handled at publish time (see release.yml)"* — true in the sibling repository the script was ported from, never true here.

Copying alone would not have been enough: `files` decides what npm packs, and a name missing from it is dropped without a word — verified locally, `npm pack --dry-run` did not include them. The step now stages the copies **and asks `npm pack --dry-run` what would actually go out**; all seven allowlists name them; and the script verifies both halves rather than delegating to a step that might not exist.

### `CITATION.cff` was three hundred indicators out of date

*"214 indicators across 16 families"*, naming three languages of ten, against 514 across twenty-four. It is what GitHub's citation box and Zenodo read, and no check had ever looked at it. It now sits alongside the two READMEs in the count check.

### `.nupkg`, `.jar` and the C ABI archives had no build provenance

The two packages C# and Java consumers install, and the archive people download and link against. Scorecard reported `Signed-Releases 10/10` regardless, because it looks for a provenance file *on* the release rather than for coverage of its contents.

### `osv-scanner.toml` was executed by nothing

Two advisories assessed as not affecting this project — load-bearing for nobody, since no workflow consulted the file. `cargo-deny` covers the Rust graph only, so npm, PyPI, Maven, NuGet, Go modules and R had **no vulnerability scanning in CI at all**.

### Three Dependabot ignores suppressed security updates

`open-pull-requests-limit: 0` already blocks every version-update pull request for the CI Python tooling. So the ignores on numpy, hypothesis and pytest had exactly one remaining effect: the security updates that are *exempt* from the limit were suppressed too. Silence, rather than a red pull request somebody decides about.

### CodeQL analyses Go and C/C++

The matrix left out the binding that casts slice base addresses through `unsafe.Pointer` and manages handle lifetimes with `runtime.SetFinalizer`, and the hand-written C++ RAII wrapper the C examples compile and run in CI. The stated reason — that C# and Java were the only bindings where a memory mistake is possible — was wrong. `bindings/r/src/wickra.c` stays outside the database (built by the R toolchain) and the workflow says so rather than letting it look covered.

### Every platform package is proved to have its binary

If a build artefact never arrives, `napi artifacts` leaves that directory without a `.node` and the stub publishes as a package that installs cleanly and fails at `require()`. Hard to reach; cheap to prove.