### PR TITLE
ci: ignore ureq outright in the fuzz entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,9 +51,16 @@ updates:
     # webpki-root-certs (CDLA-Permissive-2.0) regardless of TLS backend, and that
     # licence is not in deny.toml's allow list, so the bump cannot pass the
     # supply-chain gate.
+    # No `update-types` here, unlike the root entry. Dependabot proposed ureq
+    # 2 -> 3 three times (#425, #435, #437), the last one against a base that
+    # already carried the semver-major form of this ignore -- so that form does
+    # not match a *requirement* change the way it matches a version update.
+    # Ignoring the dependency outright is what actually holds.
+    #
+    # Nothing is lost by the blunter form: the root cargo entry keeps its
+    # `update-types`, so ureq 2.x patches still arrive from there.
     ignore:
       - dependency-name: "ureq"
-        update-types: ["version-update:semver-major"]
     groups:
       cargo-fuzz:
         patterns: ["*"]


### PR DESCRIPTION
Dependabot proposed ureq 2 → 3 three times: #425, #435, and now #437 — the last one against `85dab82c`, a base that **already carried** `update-types: ["version-update:semver-major"]` on this entry.

#435 was closed with the note that if it returned after a fresh run, the semver-major form was not matching a *requirement* change the way it matches a version update. It returned. So that is what it is, and the entry ignores `ureq` outright.

The blunter form costs nothing: the root `cargo` entry keeps its `update-types`, so ureq 2.x patches still arrive from there. This entry exists to watch `fuzz/Cargo.lock`, where ureq is not the point.

The bump itself stays unmergeable for the original reason — ureq 3 hard-depends on `webpki-root-certs`, CDLA-Permissive-2.0 is not in `deny.toml`'s allow list, and `cargo-deny` rejects the graph.