### PR TITLE
fix: command injection in the C live-Binance example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Command injection in the C live-Binance example.** `examples/c/live_binance.c`
+  took a trading symbol from `argv[1]`, interpolated it into a URL and handed
+  that to `popen` as `curl "<url>"`. The quotes look like protection and are
+  not: a symbol containing a double quote closes them, and the rest runs as a
+  command. `./live_binance 'X" ; echo PWNED ; echo "'` executed `echo PWNED`.
+
+  Found by CodeQL on the first run after C/C++ joined the matrix — the language
+  the blueprint had described as one where "a memory mistake is not possible",
+  which was wrong twice over. Fixed by validating at the boundary: a Binance
+  symbol is uppercase letters and digits, anything else is refused before it
+  reaches the URL. Verified that the injection no longer executes and that a
+  valid symbol still works.
+
 - **Go standard-library advisories are recorded as not applying, with the
   reasoning.** Turning osv-scanner on surfaced 90 of them at once, all against
   `stdlib 1.23.99` — the scanner reads the `go` directive in a `go.mod` as the

--- a/examples/c/live_binance.c
+++ b/examples/c/live_binance.c
@@ -116,8 +116,35 @@ static int first_kline(const char *body, int64_t *open_time, double *close) {
     return 0;
 }
 
+/* A Binance symbol is uppercase alphanumeric and nothing else.
+ *
+ * It matters here because the symbol ends up inside a shell command: curl_get
+ * builds `curl "<url>"` and hands it to popen. The quotes around the URL do not
+ * make that safe -- a symbol containing a double quote closes them and the rest
+ * is run as a command. Rejecting anything outside [A-Z0-9] at the boundary is
+ * both the smaller change and the honest one for an example, which is code
+ * people copy. */
+static int symbol_is_sane(const char *symbol) {
+    if (symbol[0] == '\0' || strlen(symbol) > 20) {
+        return 0;
+    }
+    for (const char *c = symbol; *c != '\0'; c++) {
+        int upper = (*c >= 'A' && *c <= 'Z');
+        int digit = (*c >= '0' && *c <= '9');
+        if (!upper && !digit) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 int main(int argc, char **argv) {
     const char *symbol = (argc > 1) ? argv[1] : "BTCUSDT";
+    if (!symbol_is_sane(symbol)) {
+        fprintf(stderr,
+                "symbol must be uppercase letters and digits, e.g. BTCUSDT\n");
+        return 1;
+    }
     char url[256];
     snprintf(url, sizeof(url),
              "https://api.binance.com/api/v3/klines?symbol=%s&interval=1m&limit=2",


### PR DESCRIPTION
`examples/c/live_binance.c` took a trading symbol from `argv[1]`, interpolated it into a URL, and handed that to `popen` as `curl "<url>"`. The quotes around the URL look like protection and are not — a symbol containing a double quote closes them and the rest runs as a command:

```
./live_binance 'X" ; echo PWNED ; echo "'
```

executed `echo PWNED`. It is an example, which makes it worse rather than better: examples are the code people copy.

### How it surfaced

CodeQL, on the **first run after C/C++ joined the matrix**. The matrix had left the language out because the blueprint stated that C# and Java were the two bindings where a memory mistake is possible — and the first thing the newly-included language reported was not a memory mistake at all.

### The fix

Validated at the boundary rather than by quoting harder. A Binance symbol is uppercase letters and digits; anything else is refused before it reaches the URL.

Verified both directions: the injection no longer executes, an empty or lowercase symbol is rejected with a usable message, and `ETHUSDT` still fetches and prints real data.

Closes code scanning alert #646. Alert #645 (`zizmor/ref-version-mismatch`) is already `fixed` — that was the osv-scanner pin corrected in #439.