### PR TITLE
fix: build the URL from a sanitised copy, not from argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,8 +379,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the blueprint had described as one where "a memory mistake is not possible",
   which was wrong twice over. Fixed by validating at the boundary: a Binance
   symbol is uppercase letters and digits, anything else is refused before it
-  reaches the URL. Verified that the injection no longer executes and that a
-  valid symbol still works.
+  reaches the URL — and the URL is built from a *copy* the check filled one
+  character at a time, not from `argv[1]`. Checking in place and then using the
+  original pointer anyway leaves the value that reaches the command the one that
+  came from outside, and loses the guarantee to any later edit between the check
+  and the use. Verified that the injection no longer executes, that an
+  over-long or lowercase symbol is refused, and that a valid symbol still
+  fetches.
 
 - **Go standard-library advisories are recorded as not applying, with the
   reasoning.** Turning osv-scanner on surfaced 90 of them at once, all against

--- a/examples/c/live_binance.c
+++ b/examples/c/live_binance.c
@@ -116,31 +116,43 @@ static int first_kline(const char *body, int64_t *open_time, double *close) {
     return 0;
 }
 
-/* A Binance symbol is uppercase alphanumeric and nothing else.
+/* Copy `in` into `out` if it is a plausible Binance symbol, otherwise refuse.
  *
- * It matters here because the symbol ends up inside a shell command: curl_get
- * builds `curl "<url>"` and hands it to popen. The quotes around the URL do not
- * make that safe -- a symbol containing a double quote closes them and the rest
- * is run as a command. Rejecting anything outside [A-Z0-9] at the boundary is
- * both the smaller change and the honest one for an example, which is code
- * people copy. */
-static int symbol_is_sane(const char *symbol) {
-    if (symbol[0] == '\0' || strlen(symbol) > 20) {
-        return 0;
-    }
-    for (const char *c = symbol; *c != '\0'; c++) {
+ * It matters because the symbol ends up inside a shell command: curl_get builds
+ * `curl "<url>"` and hands it to popen. The quotes around the URL do not make
+ * that safe -- a symbol containing a double quote closes them and the rest is
+ * run as a command.
+ *
+ * Checking argv[1] in place and then using argv[1] anyway is not enough: the
+ * value that reaches the command is still the one that came from outside, and a
+ * later edit between the check and the use silently loses the guarantee. What
+ * gets built into the URL is therefore a separate buffer that this function
+ * filled one character at a time, each one proven to be an uppercase letter or
+ * a digit. Nothing else can be in it, by construction rather than by review.
+ */
+static int copy_symbol(const char *in, char *out, size_t out_size) {
+    size_t n = 0;
+    for (const char *c = in; *c != '\0'; c++) {
         int upper = (*c >= 'A' && *c <= 'Z');
         int digit = (*c >= '0' && *c <= '9');
         if (!upper && !digit) {
             return 0;
         }
+        if (n + 1 >= out_size) {
+            return 0;
+        }
+        out[n++] = *c;
     }
+    if (n == 0) {
+        return 0;
+    }
+    out[n] = '\0';
     return 1;
 }
 
 int main(int argc, char **argv) {
-    const char *symbol = (argc > 1) ? argv[1] : "BTCUSDT";
-    if (!symbol_is_sane(symbol)) {
+    char symbol[21];
+    if (!copy_symbol((argc > 1) ? argv[1] : "BTCUSDT", symbol, sizeof(symbol))) {
         fprintf(stderr,
                 "symbol must be uppercase letters and digits, e.g. BTCUSDT\n");
         return 1;


### PR DESCRIPTION
Alert #646 is still open after #440, and the reason is in the fix rather than in CodeQL: **the first version checked `argv[1]` and then went on using `argv[1]`.** Functionally that is safe — nothing outside `[A-Z0-9]` gets past the check — but the value that reaches the command is still the one that came from outside, so the data flow CodeQL follows was never broken.

`copy_symbol` now fills a local buffer one character at a time, each proven to be an uppercase letter or a digit, and the URL is built from that buffer. What ends up inside `curl "<url>"` cannot contain anything else *by construction* rather than by review. The length bound comes from the destination size rather than a separate `strlen`, so the two cannot drift apart.

Verified locally: the injection attempt is refused, an over-long symbol is refused, and `ETHUSDT` still fetches and prints real data.

### If the alert survives this

Then CodeQL's taint tracking follows the character-by-character copy, which it may well do, and the finding is a false positive on code that is provably safe. The honest end state in that case is dismissal **with the justification recorded** — not another round of restructuring to satisfy the analyser. I will say so rather than keep iterating.