### PR TITLE
release: bump 1.0.3 -> 1.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,11 +459,29 @@ jobs:
       # cargo-deny above covers the Rust graph only. This covers the other
       # six ecosystems -- npm, PyPI, Maven, NuGet, Go modules, R -- which had
       # no vulnerability scanning in CI at all.
+      #
+      # --no-resolve turns off transitive resolution of *manifests*. The default
+      # enricher resolves each pom.xml against Maven Central, and two of ours
+      # depend on org.wickra:wickra at the version in the tree -- which does not
+      # exist there until the release publishes it. So every version bump made
+      # this job fail on a lookup for the artefact the bump exists to create,
+      # with "0 packages affected by 0 known vulnerabilities" printed directly
+      # above the error. A check that goes red for a reason other than the one
+      # it checks teaches people to ignore it.
+      #
+      # The cost here is nil rather than merely small: every non-test dependency
+      # in all three of our poms is org.wickra:wickra itself, whose own
+      # dependencies are test-scoped, and test dependencies are outside the
+      # resolver's graph anyway. Everything pinned in a lockfile -- Cargo.lock,
+      # package-lock.json, go.mod -- is still scanned in full, transitively,
+      # because a lockfile needs no resolution. wickra-backtest reached the same
+      # flag by the same route.
       - name: osv-scanner
         uses: google/osv-scanner-action/osv-scanner-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
         with:
           scan-args: |-
             --recursive
+            --no-resolve
             --config=osv-scanner.toml
             ./
   semver:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -160,21 +160,25 @@ jobs:
             dotnet build "examples/csharp/$d" -c Release
           done
 
-      # test-compile, not compile: it builds the hand-written tests too, and
-      # they are ten of the eleven binding files left after the exclusions.
-      # -DskipTests because CodeQL needs the code compiled, not exercised.
+      # -DskipTests, not -Dmaven.test.skip: the hand-written tests still
+      # compile, and they are ten of the eleven binding files left after the
+      # exclusions. CodeQL needs the code compiled, not exercised.
       #
-      # examples/java is a separate Maven project and was therefore never
-      # analysed. It resolves org.wickra:wickra from Maven Central rather than
-      # from this tree, so what is analysed there is the example code against
-      # the published binding -- which is exactly the pairing a reader copying
-      # those files would get.
+      # examples/java is a separate Maven project, so it resolves
+      # org.wickra:wickra as a normal dependency rather than through a reactor.
+      # It has to come out of the local repository, which is why the binding is
+      # installed rather than merely compiled: the version in the tree is the
+      # one being released, and it does not exist on Maven Central until the tag
+      # publishes it. Resolving from Central instead made this job fail on every
+      # version bump, on a lookup for the artefact the bump exists to create.
+      # Installing first also means the examples are analysed against the
+      # binding in this tree, which is the code under review.
       - name: Build the Java binding and examples
         if: matrix.language == 'java-kotlin'
         shell: bash
         run: |
           set -euo pipefail
-          mvn -B -f bindings/java test-compile -DskipTests
+          mvn -B -f bindings/java install -DskipTests
           mvn -B -f examples/java test-compile -DskipTests
 
       - name: Perform CodeQL analysis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-08-31
+
 ### Added
 
 - **Streaming and batch are compared through the C ABI.** Every indicator
@@ -3511,7 +3513,8 @@ public API changes.
   optional Binance live feed.
 - Bindings for Python, Node.js, and WebAssembly.
 
-[Unreleased]: https://github.com/wickra-lib/wickra/compare/v1.0.3...HEAD
+[Unreleased]: https://github.com/wickra-lib/wickra/compare/v1.0.4...HEAD
+[1.0.4]: https://github.com/wickra-lib/wickra/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/wickra-lib/wickra/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/wickra-lib/wickra/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/wickra-lib/wickra/compare/v1.0.0...v1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   limit, were suppressed too. A future advisory in any of the three would have
   produced silence rather than a red pull request somebody decides about.
 
+- **Two jobs failed on every version bump, on the artefact the bump exists to
+  create.** `examples/java` and the Java benchmarks depend on
+  `org.wickra:wickra` at the version in the tree, which reaches Maven Central
+  only when the tag publishes it. CodeQL's java-kotlin build resolved that
+  dependency from Central, and osv-scanner's default enricher resolved it there
+  too — so the bump that moves those poms to the next version broke both, and
+  osv-scanner printed "0 packages affected by 0 known vulnerabilities" directly
+  above its own error. CodeQL now installs the binding into the local
+  repository first, which also means the examples are analysed against the
+  binding in this tree rather than the last published one. osv-scanner runs with
+  `--no-resolve`, which costs nothing here: every non-test dependency in all
+  three poms is `org.wickra:wickra` itself, whose own dependencies are
+  test-scoped and outside the resolver's graph either way, and lockfiles need no
+  resolution to be scanned transitively.
+
+- **Two version declarations survived a bump.** A `package-lock.json` states the
+  root package's version twice — at the top of the file and inside
+  `packages[""]` — and only the first is what a bump rewrites, so
+  `scripts/check_version_sync.py` failed this release's own pull request.
+  `CITATION.cff` was worse: its `date-released` moved to the day of the bump
+  while its `version` stayed on the previous release, so the two lines
+  contradicted each other in the file GitHub's citation box and Zenodo both
+  read — and no check here looked at it. The bump tooling now writes both
+  declarations, and `check_version_sync.py` holds the citation version too.
+
 ### Security
 
 - **Command injection in the C live-Binance example.** `examples/c/live_binance.c`

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
-version: "1.0.3"
-date-released: "2026-08-30"
+version: "1.0.4"
+date-released: "2026-08-31"
 title: Wickra
 message: >-
   If you use Wickra in academic work, please cite it using the metadata

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "wickra"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "approx",
  "codspeed-criterion-compat",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-bench"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "criterion",
  "kand",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-c"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "tokio",
  "wickra-core",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-core"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "approx",
  "proptest",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-data"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "approx",
  "csv",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-examples"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "serde_json",
  "tokio",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-node"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "napi",
  "napi-build",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-python"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "bytemuck",
  "pyo3",
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "wickra-wasm"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "1.0.3"
+version = "1.0.4"
 authors = ["kingchenc <support@wickra.org>"]
 edition = "2021"
 rust-version = "1.86"
@@ -26,8 +26,8 @@ keywords = ["finance", "trading", "indicators", "technical-analysis", "ta"]
 categories = ["finance", "mathematics", "science"]
 
 [workspace.dependencies]
-wickra-core = { path = "crates/wickra-core", version = "1.0.3" }
-wickra-data = { path = "crates/wickra-data", version = "1.0.3" }
+wickra-core = { path = "crates/wickra-core", version = "1.0.4" }
+wickra-data = { path = "crates/wickra-data", version = "1.0.4" }
 
 thiserror = "2"
 rayon = "1.10"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported versions
 
-Security fixes are applied to the latest released version, `1.0.3`, only; please
+Security fixes are applied to the latest released version, `1.0.4`, only; please
 upgrade to the newest release before reporting an issue.
 
 | Version | Supported |
 | --- | --- |
-| 1.0.3 (latest) | :white_check_mark: |
-| < 1.0.3 | :x: |
+| 1.0.4 (latest) | :white_check_mark: |
+| < 1.0.4 | :x: |
 
 ## Reporting a vulnerability
 

--- a/bindings/csharp/Wickra/Wickra.csproj
+++ b/bindings/csharp/Wickra/Wickra.csproj
@@ -11,7 +11,7 @@
 
     <!-- NuGet package metadata -->
     <PackageId>Wickra</PackageId>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <Authors>kingchenc</Authors>
     <Description>High-performance streaming technical-analysis indicators (514 indicators) for .NET, backed by the native Rust core via the Wickra C ABI.</Description>
     <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -38,14 +38,14 @@ Maven:
 <dependency>
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
 </dependency>
 ```
 
 Gradle:
 
 ```kotlin
-implementation("org.wickra:wickra:1.0.3")
+implementation("org.wickra:wickra:1.0.4")
 ```
 
 The native library ships prebuilt per platform (Linux, macOS, Windows — x64 and

--- a/bindings/java/benchmarks/pom.xml
+++ b/bindings/java/benchmarks/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.wickra</groupId>
       <artifactId>wickra</artifactId>
-      <version>1.0.3</version>
+      <version>1.0.4</version>
     </dependency>
   </dependencies>
 

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra</groupId>
   <artifactId>wickra</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <packaging>jar</packaging>
 
   <name>Wickra</name>

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('wickra-android-arm64')
         const bindingPackageVersion = require('wickra-android-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('wickra-android-arm-eabi')
         const bindingPackageVersion = require('wickra-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('wickra-win32-x64-gnu')
         const bindingPackageVersion = require('wickra-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('wickra-win32-x64-msvc')
         const bindingPackageVersion = require('wickra-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('wickra-win32-ia32-msvc')
         const bindingPackageVersion = require('wickra-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('wickra-win32-arm64-msvc')
         const bindingPackageVersion = require('wickra-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('wickra-darwin-universal')
       const bindingPackageVersion = require('wickra-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('wickra-darwin-x64')
         const bindingPackageVersion = require('wickra-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('wickra-darwin-arm64')
         const bindingPackageVersion = require('wickra-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('wickra-freebsd-x64')
         const bindingPackageVersion = require('wickra-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('wickra-freebsd-arm64')
         const bindingPackageVersion = require('wickra-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-x64-musl')
           const bindingPackageVersion = require('wickra-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-x64-gnu')
           const bindingPackageVersion = require('wickra-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-arm64-musl')
           const bindingPackageVersion = require('wickra-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-arm64-gnu')
           const bindingPackageVersion = require('wickra-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-arm-musleabihf')
           const bindingPackageVersion = require('wickra-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-arm-gnueabihf')
           const bindingPackageVersion = require('wickra-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-loong64-musl')
           const bindingPackageVersion = require('wickra-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-loong64-gnu')
           const bindingPackageVersion = require('wickra-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-riscv64-musl')
           const bindingPackageVersion = require('wickra-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('wickra-linux-riscv64-gnu')
           const bindingPackageVersion = require('wickra-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('wickra-linux-ppc64-gnu')
         const bindingPackageVersion = require('wickra-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('wickra-linux-s390x-gnu')
         const bindingPackageVersion = require('wickra-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('wickra-openharmony-arm64')
         const bindingPackageVersion = require('wickra-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('wickra-openharmony-x64')
         const bindingPackageVersion = require('wickra-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('wickra-openharmony-arm')
         const bindingPackageVersion = require('wickra-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '1.0.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -648,8 +648,8 @@ if (!nativeBinding || forceWasi) {
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           const bindingPackageVersion = require('wickra-wasm32-wasi/package.json').version
-          if (bindingPackageVersion !== '1.0.3') {
-            throw new Error(`WASI binding package version mismatch, expected 1.0.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.4') {
+            throw new Error(`WASI binding package version mismatch, expected 1.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
         wasiBinding = require('wickra-wasm32-wasi')

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-arm64",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Native binding for wickra (macOS Apple Silicon). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-arm64.node",
   "files": [

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-darwin-x64",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Native binding for wickra (macOS Intel). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.darwin-x64.node",
   "files": [

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-arm64-gnu",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Native binding for wickra (linux arm64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-arm64-gnu.node",
   "files": [

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-linux-x64-gnu",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Native binding for wickra (linux x64 GNU). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.linux-x64-gnu.node",
   "files": [

--- a/bindings/node/npm/win32-arm64-msvc/package.json
+++ b/bindings/node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-arm64-msvc",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Native binding for wickra (Windows arm64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-arm64-msvc.node",
   "files": [

--- a/bindings/node/npm/win32-x64-msvc/package.json
+++ b/bindings/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra-win32-x64-msvc",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Native binding for wickra (Windows x64 MSVC). Installed automatically as an optional dependency of wickra on matching platforms.",
   "main": "wickra.win32-x64-msvc.node",
   "files": [

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wickra",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wickra",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.7.2"
@@ -15,12 +15,12 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "1.0.3",
-        "wickra-darwin-x64": "1.0.3",
-        "wickra-linux-arm64-gnu": "1.0.3",
-        "wickra-linux-x64-gnu": "1.0.3",
-        "wickra-win32-arm64-msvc": "1.0.3",
-        "wickra-win32-x64-msvc": "1.0.3"
+        "wickra-darwin-arm64": "1.0.4",
+        "wickra-darwin-x64": "1.0.4",
+        "wickra-linux-arm64-gnu": "1.0.4",
+        "wickra-linux-x64-gnu": "1.0.4",
+        "wickra-win32-arm64-msvc": "1.0.4",
+        "wickra-win32-x64-msvc": "1.0.4"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1901,8 +1901,8 @@
       "license": "ISC"
     },
     "node_modules/wickra-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-1.0.3.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-arm64/-/wickra-darwin-arm64-1.0.4.tgz",
       "integrity": "sha512-4eZiBR/yGUdr4nzhEUFy2i69XgNx64iI2ax/LPamsThgylC0KpHOZKK19QzJ2d9KbK4C8nMjME5FLuR+4GNEwQ==",
       "cpu": [
         "arm64"
@@ -1917,8 +1917,8 @@
       }
     },
     "node_modules/wickra-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-1.0.3.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/wickra-darwin-x64/-/wickra-darwin-x64-1.0.4.tgz",
       "integrity": "sha512-6hf8zI3QPjTFp4zCpmgUwDvNtu6jHqNUHKD5e55POo0CgA52HkpyxSPtVm8TGTIZDI7kPjlbOdBM8CJ76mmXwA==",
       "cpu": [
         "x64"
@@ -1933,8 +1933,8 @@
       }
     },
     "node_modules/wickra-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-1.0.3.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/wickra-linux-arm64-gnu/-/wickra-linux-arm64-gnu-1.0.4.tgz",
       "integrity": "sha512-kSe6y0xBMSiqdPLXNjwop5WZdHtvdBNKSEBCwZ4hFq33p4apW25/wrlzv9/oDuyD4kuPabJEhCCnFOplh58CUg==",
       "cpu": [
         "arm64"
@@ -1949,8 +1949,8 @@
       }
     },
     "node_modules/wickra-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-1.0.3.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/wickra-linux-x64-gnu/-/wickra-linux-x64-gnu-1.0.4.tgz",
       "integrity": "sha512-tWBWS4qz7hxM4xnpFb59bhf6TaLwXq0Z3jEa/2l7r8PiHA94g8r8S53NRMiT+4yiL5hSWe/nUiC/YXdRrhEZ4g==",
       "cpu": [
         "x64"
@@ -1965,8 +1965,8 @@
       }
     },
     "node_modules/wickra-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-1.0.3.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/wickra-win32-arm64-msvc/-/wickra-win32-arm64-msvc-1.0.4.tgz",
       "integrity": "sha512-EXIckHxAtF75PUGDKRzXyqMe9ldP0JjSdu68WFN6iJfp+McYrGu6h40TEJlQ/oUEIoPqiZB/xhVyo/el5Lg7zw==",
       "cpu": [
         "arm64"
@@ -1981,8 +1981,8 @@
       }
     },
     "node_modules/wickra-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-1.0.3.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/wickra-win32-x64-msvc/-/wickra-win32-x64-msvc-1.0.4.tgz",
       "integrity": "sha512-Yfsqq1Xwp6hdxMyLze411vNdo7BDwI6+lPSe7A9XdqyPecNDbtKwYLpsal2r8EHbNzqM+R8XnuRtUaEQS5VlUQ==",
       "cpu": [
         "x64"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickra",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Streaming-first technical indicators: incremental, fast, install-free. Node bindings powered by Rust.",
   "author": "kingchenc <support@wickra.org>",
   "main": "index.js",
@@ -45,12 +45,12 @@
     "node": ">= 22"
   },
   "optionalDependencies": {
-    "wickra-linux-x64-gnu": "1.0.3",
-    "wickra-linux-arm64-gnu": "1.0.3",
-    "wickra-darwin-x64": "1.0.3",
-    "wickra-darwin-arm64": "1.0.3",
-    "wickra-win32-x64-msvc": "1.0.3",
-    "wickra-win32-arm64-msvc": "1.0.3"
+    "wickra-linux-x64-gnu": "1.0.4",
+    "wickra-linux-arm64-gnu": "1.0.4",
+    "wickra-darwin-x64": "1.0.4",
+    "wickra-darwin-arm64": "1.0.4",
+    "wickra-win32-x64-msvc": "1.0.4",
+    "wickra-win32-arm64-msvc": "1.0.4"
   },
   "scripts": {
     "build": "napi build --platform --release && node scripts/prune-type-only-exports.mjs",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "wickra"
-version = "1.0.3"
+version = "1.0.4"
 description = "Streaming-first technical indicators: incremental, fast, install-free."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/bindings/r/DESCRIPTION
+++ b/bindings/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: wickra
 Type: Package
 Title: Streaming-First Technical Indicators
-Version: 1.0.3
+Version: 1.0.4
 Authors@R: person("kingchenc", role = c("aut", "cre"), email = "support@wickra.org")
 Description: R bindings for the Wickra technical-analysis library over its C ABI
     hub. Exposes 514 indicators, each an incremental streaming state machine

--- a/crates/wickra-data/Cargo.toml
+++ b/crates/wickra-data/Cargo.toml
@@ -27,7 +27,7 @@ workspace = true
 # (rayon) feature on — the WASM binding needs a rayon-free build and the data
 # layer never uses the parallel batch path. Native bindings re-enable `parallel`
 # through their own wickra-core dependency (cargo unifies the features).
-wickra-core = { path = "../wickra-core", version = "1.0.3", default-features = false }
+wickra-core = { path = "../wickra-core", version = "1.0.4", default-features = false }
 thiserror = { workspace = true }
 csv = "1.3"
 serde = { version = "1", features = ["derive"] }

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.wickra.examples</groupId>
   <artifactId>wickra-examples</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <packaging>jar</packaging>
 
   <name>Wickra Java examples</name>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.wickra</groupId>
       <artifactId>wickra</artifactId>
-      <version>1.0.3</version>
+      <version>1.0.4</version>
     </dependency>
   </dependencies>
 

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -14,7 +14,7 @@
     },
     "../../bindings/node": {
       "name": "wickra",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
@@ -23,12 +23,12 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "wickra-darwin-arm64": "1.0.3",
-        "wickra-darwin-x64": "1.0.3",
-        "wickra-linux-arm64-gnu": "1.0.3",
-        "wickra-linux-x64-gnu": "1.0.3",
-        "wickra-win32-arm64-msvc": "1.0.3",
-        "wickra-win32-x64-msvc": "1.0.3"
+        "wickra-darwin-arm64": "1.0.4",
+        "wickra-darwin-x64": "1.0.4",
+        "wickra-linux-arm64-gnu": "1.0.4",
+        "wickra-linux-x64-gnu": "1.0.4",
+        "wickra-win32-arm64-msvc": "1.0.4",
+        "wickra-win32-x64-msvc": "1.0.4"
       }
     },
     "node_modules/wickra": {

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -75,6 +75,11 @@ TOUCHPOINTS: list[tuple[str, str, str, int]] = [
     ("bindings/java/README.md", "install snippets", r"@V@", 2),
     # Prose sentence, the supported row, and the unsupported bound.
     ("SECURITY.md", "supported version", r"@V@", 3),
+    # The citation names the release it belongs to. The bump moves the
+    # `date-released` beside it, so a stale `version` here is not merely absent
+    # -- the two lines disagree, and GitHub's citation box and Zenodo both read
+    # them. Nothing else in CI touches this file.
+    ("CITATION.cff", "citation version", r'(?m)^version: "@V@"$', 1),
     # npm records the package's own version twice in the lockfile: once at the
     # top level and once in the `packages[""]` entry. Only the first is what
     # `npm version` rewrites, so the second goes stale on its own -- it sat at


### PR DESCRIPTION
Version strings only, `1.0.3 -> 1.0.4`, produced by the bump script rather than by hand — plus the two CI jobs that this bump proved are red on every release.

### The bump

Twenty-four declarations across six package managers, the `wickra-core` path-dep in `wickra-data`, the `CHANGELOG.md` section and its compare links, and the workspace entries in `Cargo.lock` via a `cargo build`.

Two declarations the script left behind, both found by auditing its output rather than by trusting it:

- `bindings/node/package-lock.json` carries the package version **twice** — once at the top of the file and once inside `packages[""]`. Only the first moved. `scripts/check_version_sync.py` catches this one, which is what it exists for.
- `CITATION.cff` had its `date-released` advanced to today while `version` stayed on `1.0.3` — a citation naming the previous release under today's date, in the file GitHub's citation box and Zenodo both read. Nothing in CI looked at that field; `check_version_sync.py` now does.

Both were gaps in the bump script rather than in this repository. The script has since been fixed in its own repository, and a bump of this profile now reproduces this branch without a hand-fix.

### The two jobs that fail on every bump

`examples/java` and the Java benchmarks depend on `org.wickra:wickra` at the version in the tree. That version reaches Maven Central when the tag publishes it and not before, so between the bump and the tag it does not exist — and both jobs that resolve it from Central go red for the whole window.

CodeQL's java-kotlin build now installs the binding into the local repository before compiling the examples, the order `ci.yml` has always used; the examples are then analysed against the binding in this tree rather than the last published one. osv-scanner runs with `--no-resolve`, which turns off transitive resolution of manifests only: every non-test dependency in all three of our poms is `org.wickra:wickra` itself, whose own dependencies are test-scoped and outside the resolver's graph either way, and lockfiles are still scanned transitively because they need no resolution. `wickra-backtest` reached the same flag by the same route.

Both verified locally against an unpublished 1.0.4: the two `mvn` invocations succeed in sequence, and reverting the citation version fails the check.

### State

`scripts/check_version_sync.py` reports all 24 declarations in agreement. The only `1.0.3` strings left in the tree belong to `@napi-rs/cross-toolchain`.

No tag is pushed by this. That step waits for an explicit go, as it always does.
