### PR TITLE
release: bump 1.0.3 -> 1.0.4

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,6 +50,10 @@ on NuGet), the **Go** binding (`bindings/go`, cgo), the **R** binding
 (`bindings/r`, `.Call`) and the **Java** binding (`bindings/java`, the Java FFM
 API / Panama, on Maven Central) are all generated from `wickra.h`.
 
+R is the one binding `release.yml` does not publish: r-universe builds it from
+`main`, and `bindings/r/configure` resolves the C ABI by downloading the GitHub
+release that matches the version in `DESCRIPTION`.
+
 | Crate | Path | What it owns | Public deps |
 |---|---|---|---|
 | `wickra-core` | `crates/wickra-core` | every indicator, the `Indicator` trait, `BatchExt`, `Candle`/`Tick` types, `Error` | `thiserror`, `rayon` (parallel batch) |


### PR DESCRIPTION
Version strings only, `1.0.3 -> 1.0.4`, produced by the bump script rather than by hand — plus the two CI jobs that this bump proved are red on every release.

### The bump

Twenty-four declarations across six package managers, the `wickra-core` path-dep in `wickra-data`, the `CHANGELOG.md` section and its compare links, and the workspace entries in `Cargo.lock` via a `cargo build`.

Two declarations the script left behind, both found by auditing its output rather than by trusting it:

- `bindings/node/package-lock.json` carries the package version **twice** — once at the top of the file and once inside `packages[""]`. Only the first moved. `scripts/check_version_sync.py` catches this one, which is what it exists for.
- `CITATION.cff` had its `date-released` advanced to today while `version` stayed on `1.0.3` — a citation naming the previous release under today's date, in the file GitHub's citation box and Zenodo both read. Nothing in CI looked at that field; `check_version_sync.py` now does.

Both were gaps in the bump script rather than in this repository. The script has since been fixed in its own repository, and a bump of this profile now reproduces this branch without a hand-fix.

### The two jobs that fail on every bump

`examples/java` and the Java benchmarks depend on `org.wickra:wickra` at the version in the tree. That version reaches Maven Central when the tag publishes it and not before, so between the bump and the tag it does not exist — and both jobs that resolve it from Central go red for the whole window.

CodeQL's java-kotlin build now installs the binding into the local repository before compiling the examples, the order `ci.yml` has always used; the examples are then analysed against the binding in this tree rather than the last published one. osv-scanner runs with `--no-resolve`, which turns off transitive resolution of manifests only: every non-test dependency in all three of our poms is `org.wickra:wickra` itself, whose own dependencies are test-scoped and outside the resolver's graph either way, and lockfiles are still scanned transitively because they need no resolution. `wickra-backtest` reached the same flag by the same route.

Both verified locally against an unpublished 1.0.4: the two `mvn` invocations succeed in sequence, and reverting the citation version fails the check.

### State

`scripts/check_version_sync.py` reports all 24 declarations in agreement. The only `1.0.3` strings left in the tree belong to `@napi-rs/cross-toolchain`.

No tag is pushed by this. That step waits for an explicit go, as it always does.

This commit carries no version strings of its own: that bump is already on
`main`. The first `v1.0.4` tag was pulled before anything published, and this
re-cuts the commit the new tag points at. It also adds the paragraph to
`ARCHITECTURE.md` that the pulled tag exposed as missing: R is the one binding
`release.yml` does not publish, so `bindings/r/configure` resolves the C ABI by
downloading the release that matches the version in `DESCRIPTION` -- which is
why a bump left untagged puts every r-universe build on a 404.
