### PR TITLE
fix(release): publish the wasm tarball as a path, not a repo shorthand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -776,7 +776,11 @@ jobs:
           # if/then rather than `A && B || C`: that form runs C when B fails,
           # not only when A does, so a failing echo would read as a failed
           # publish (shellcheck SC2015).
-          if out=$(npm publish "$tarball" --access public --provenance 2>&1); then
+          # "./" is load-bearing: npm reads a bare `dir/file.tgz` as the
+          # `owner/repo` GitHub shorthand and tries to clone it, rather than
+          # reading the file. Without it the step dies on `git ls-remote` with
+          # code 128, before it ever reaches the registry.
+          if out=$(npm publish "./$tarball" --access public --provenance 2>&1); then
             echo "$out"
           elif printf '%s' "$out" | grep -q "You cannot publish over"; then
             echo "skip: version already on npm"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -270,7 +270,7 @@ calls).
 | change benchmark coverage | `crates/wickra/benches/indicators.rs` |
 | add a new fuzz target | `fuzz/fuzz_targets/<name>.rs` + register in `fuzz/Cargo.toml` |
 | change CI matrix | `.github/workflows/ci.yml` |
-| change release pipeline | `.github/workflows/release.yml` (irreversible on `v*` tag — test on a throwaway tag first) |
+| change release pipeline | `.github/workflows/release.yml` (irreversible on `v*` tag — test on a throwaway tag first; the publish jobs are independent, so one failing leaves the rest published) |
 
 ## What is **deliberately** not in this repo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.4] - 2026-08-31
+## [1.0.4] - 2026-09-01
 
 ### Added
 
@@ -322,6 +322,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+
+- **`npm publish` was handed a path npm read as a repository.** The wasm publish
+  step passed the packed tarball as a bare relative path
+  (`wasm-pkg/wickra-wasm-<version>.tgz`). npm parses an argument of that shape as
+  the `owner/repo` GitHub shorthand rather than as a file, so it ran
+  `git ls-remote ssh://git@github.com/wasm-pkg/...` and exited with code 128
+  before reaching the registry. A leading `./` marks it as a path; the step now
+  publishes `./$tarball`.
+
+  The step never ran under a tag: the job was split into build and publish in
+  `6293ffce`, after 1.0.3 had shipped, and `release.yml` runs only on `v*`. The
+  publish jobs are independent of one another, so this would have left
+  crates.io, PyPI, npm, NuGet and Maven Central published while the GitHub
+  release -- which needs all of them -- was skipped, taking the C ABI archives
+  with it.
 
 - **A manual run of `release.yml` could publish from a branch.** The workflow
   carries `workflow_dispatch` so a failed publish can be retried without moving


### PR DESCRIPTION
The wasm publish step passed the packed tarball to `npm publish` as a bare
relative path (`wasm-pkg/wickra-wasm-<version>.tgz`). npm parses an argument of
that shape as the `owner/repo` GitHub shorthand rather than as a file, so it ran
`git ls-remote ssh://git@github.com/wasm-pkg/...` and exited with code 128 before
reaching the registry. A leading `./` marks it as a path.

The step has never run under a tag. It was split out of the publish job in
6293ffce, after 1.0.3 shipped, and `release.yml` executes only on `v*` -- so the
bug was written, linted and merged without anything able to catch it.
`wickra-backtest` 0.1.1 hit it first, yesterday, and shows what it costs: the
publish jobs are independent of one another, so crates.io, PyPI, npm, NuGet and
Maven Central published while `wasm-publish` failed, and `github-release` --
which needs every publish job -- was skipped. That release has no C ABI archives
attached, which is why r-universe has been building its R binding into a 404
ever since. None of it can be taken back.

Also dates the 1.0.4 changelog section to the day it will actually ship, and
notes in ARCHITECTURE.md that the publish jobs are independent, since that is
what turns one failing step into a half-published release.