### PR TITLE
release: bump 1.0.3 -> 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`release.yml` runs in this shape for the first time.** The publish gate, the
+  split between building and publishing the wasm package, the provenance
+  extended to the `.nupkg`, the jar and the C ABI archives, and the npm licence
+  proof were all written after 1.0.3 had shipped. The workflow executes only on
+  a pushed `v*` tag, so none of them had ever run: they were written, linted and
+  merged with nothing able to exercise them. The one bug that survived that gap
+  is in *Fixed* below.
+
 - **A release is all-or-nothing: nothing is published unless everything is
   green.** `cargo-publish` and `wasm-publish` declared no dependencies at all,
   so crates.io could receive a version while the Python wheels were still


### PR DESCRIPTION
The version strings themselves are already on main, set by #444 and verified
there: `scripts/check_version_sync.py` reports all 24 declarations in agreement
on 1.0.4. This is the commit the tag points at, so that a `v1.0.4` tag sits on a
release commit and carries #445 -- the npm path fix -- with it. Tagging #444
directly would ship the release without that fix; tagging #445 would put the tag
on a bugfix commit.

The changelog gains the one thing its 1.0.4 section did not say: `release.yml`
runs in this shape for the first time. The publish gate, the wasm build/publish
split, the provenance extended to the NuGet package, the jar and the C ABI
archives, and the npm licence proof were all written after 1.0.3 shipped, and
the workflow only ever executes on a pushed `v*` tag. None of them had run
before. That is not a footnote for this release -- it is the reason the wasm
publish shipped broken and had to be fixed in #445, and it is worth stating for
anyone reading back why 1.0.4 carries so much release machinery.

No tag is pushed by this.