### PR TITLE
ci(release): wait for the tagged commit's CI instead of reading it as failed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,9 @@ jobs:
     name: Nothing publishes before this
     needs: [python-wheels, python-sdist, node-build, c-abi-build, wasm-build]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Generous because this job waits for ci.yml to settle on the tagged commit;
+    # the wait itself is bounded to 45 minutes inside the step.
+    timeout-minutes: 60
     permissions:
       contents: read
       actions: read
@@ -85,12 +87,33 @@ jobs:
           # so this workflow cannot see the tag's health in its own run. Ask what
           # the commit itself was graded, which is the merge commit the tag
           # points at and therefore the state that was actually tested.
-          ci=$(gh api "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${SHA}&per_page=1"                  -q '.workflow_runs[0].conclusion // "none"')
-          echo "ci.yml on ${SHA}: ${ci}"
-          if [ "$ci" != "success" ]; then
-            echo "::error::the tagged commit has no successful ci.yml run (${ci}); refusing to publish"
-            exit 1
-          fi
+          #
+          # A run that is still going carries conclusion `null`, which reads the
+          # same as one that failed -- and a tag pushed straight after its merge
+          # lands while ci.yml is still queued. Refusing there turns "tagged a
+          # minute early" into a failed release that needs a rerun, so wait for
+          # the verdict instead of treating its absence as one. A red conclusion
+          # still ends this immediately: only the undecided case waits.
+          deadline=$(( $(date +%s) + 45 * 60 ))
+          while :; do
+            ci_state=$(gh api "repos/${REPO}/actions/workflows/ci.yml/runs?head_sha=${SHA}&per_page=1"                  -q '(.workflow_runs[0] // {}) | "\(.status // "missing") \(.conclusion // "null")"')
+            ci_status=${ci_state%% *}
+            ci=${ci_state##* }
+            if [ "$ci" = "success" ]; then
+              break
+            fi
+            if [ "$ci" != "null" ]; then
+              echo "::error::ci.yml on ${SHA} is ${ci}; refusing to publish"
+              exit 1
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::ci.yml on ${SHA} did not finish within 45 minutes (${ci_status}); refusing to publish"
+              exit 1
+            fi
+            echo "ci.yml on ${SHA}: ${ci_status} -- waiting"
+            sleep 30
+          done
+          echo "ci.yml on ${SHA}: success"
 
           # And nothing else that did run may have failed. Listing required
           # workflows by name would go stale -- codspeed.yml is path-filtered and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The publish gate refused a tag whose CI had not finished yet.** It asked the
+  API for `conclusion` on the tagged commit's `ci.yml` run and required
+  `success`. A run still in progress reports `null` there, which the check read
+  the same way it read a failure -- so a tag pushed shortly after its merge, with
+  CI still queued behind the release run's own build jobs, was refused for having
+  "no successful ci.yml run". Nothing was published, which is the gate working as
+  designed, but the verdict was wrong: v1.0.4 hit this, the commit went green 32
+  minutes later, and a rerun published it without a single change.
+
+  The step now waits for that run to settle, bounded to 45 minutes, and reports
+  what it is waiting on. A conclusion other than `success` still fails
+  immediately, so a genuinely broken commit is rejected as fast as before -- only
+  the undecided case waits. `timeout-minutes` on the job moves from 10 to 60 to
+  outlive that wait.
+
+
 ## [1.0.4] - 2026-09-01
 
 ### Added


### PR DESCRIPTION
The publish gate asks the API for `conclusion` on the tagged commit's `ci.yml`
run and requires `success`. A run that is still going reports `null` there, and
the check treated that the same as a failure -- so a tag pushed two minutes after
its merge, with CI still queued behind the release run's own build jobs, was
rejected for having "no successful ci.yml run". That is what happened to v1.0.4:
the commit was fine, went green 32 minutes later, and a rerun published it with
no change at all.

Nothing was published in the meantime, so the gate did its job. Its verdict was
still wrong, and the distinction it missed is the one that matters: not decided
yet is not decided against. The step now polls until the run settles, bounded to
45 minutes, and says what it is waiting on. Any conclusion other than `success`
still fails on the spot, so a genuinely broken commit is refused as fast as
before -- only the undecided case waits. `timeout-minutes` on the job moves from
10 to 60 so it outlives the wait it now performs.

This also removes the reason to rush a tag. Tagging early mattered because
r-universe builds the R binding from `main` and resolves its C ABI from the
release matching `DESCRIPTION`, so a bump left untagged puts those builds on a
404; waiting for CI first spent 25 to 55 minutes of that window. The gate now
holds the tag for as long as it needs, and neither constraint has to be timed by
hand.

Written and linted, not run: `release.yml` executes only on a pushed `v*` tag,
so the next release is the first time this path is exercised.