### PR TITLE
A green Maven job should mean the jar is public

### DIFF
--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -162,6 +162,16 @@
             <configuration>
               <publishingServerId>central</publishingServerId>
               <autoPublish>true</autoPublish>
+              <!-- Wait for the deployment to be *published*, not merely
+                   validated. Without this the plugin stops at validation and
+                   prints "to finish publishing visit ...", so the job reports
+                   success while the artifact is not yet on the repository and
+                   anything that fails after validation is invisible here. It
+                   does not change whether the artifact is published;
+                   autoPublish does that. It changes only what a green job means. Note it
+                   waits for the portal's published state, not for the repo1
+                   mirror, which lags separately. -->
+              <waitUntil>published</waitUntil>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
One line in `bindings/java/pom.xml`, plus the reasoning beside it.

## What it changes

`central-publishing-maven-plugin` defaults to waiting only until the deployment
is **validated**. It then prints *"to finish publishing visit …"* and reports
`BUILD SUCCESS` — so the Maven job goes green while the artifact is not yet on
the repository, and anything that fails between validation and publication never
reaches this workflow.

| | before | after |
|---|---|---|
| job turns green when | Central has validated the bundle | Central has published it |
| log reads | `to finish publishing visit …` | `Waiting until Deployment … is published` |
| a failure after validation | invisible here | fails the job |
| cost | none | a few minutes per release |

## What it does not change

**Whether the artifact gets published.** That is `autoPublish`, which is already
set. `wickra-terminal` 0.1.1 reached Maven Central without this line — it just
took a while, and nothing in the run said so.

That is the concrete reason for this change rather than a hypothetical one: when
that release was green and `repo1` still answered 404 half an hour later, the
workflow could not distinguish "on its way" from "waiting for a manual click in
the portal". The answer took a watcher and twenty-five minutes. With this line
the question does not arise.

It also does **not** wait for the `repo1` mirror, which lags separately. A green
job still does not promise the jar is fetchable that second.

## Consistency

`wickra-exchange` has carried this since its first release and is the only
repository in the family whose Maven log reads `Waiting until Deployment … is
published`. This brings the other three into line; `wickra-screener` gets it in
its own 0.1.2 release, which was already open.

No version bump and no release: this takes effect at the next one.
